### PR TITLE
feat: custom sound support for panic and signal 100 alerts

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -6240,6 +6240,19 @@ func (c Community) CreatePanicAlertHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Resolve custom panic sound URL (if community has one configured)
+	var panicSoundUrl string
+	if comm, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID}); cErr == nil {
+		if key := comm.Details.DefaultPanicSound; key != "" {
+			for _, s := range comm.Details.CustomToneSounds {
+				if s.Key == key {
+					panicSoundUrl = s.URL
+					break
+				}
+			}
+		}
+	}
+
 	// Broadcast panic alert created event to all connected users
 	panicData := map[string]interface{}{
 		"alertId":        alertID,
@@ -6250,6 +6263,9 @@ func (c Community) CreatePanicAlertHandler(w http.ResponseWriter, r *http.Reques
 		"communityId":    communityID,
 		"triggeredAt":    panicAlert.TriggeredAt,
 		"action":         "created",
+	}
+	if panicSoundUrl != "" {
+		panicData["panicSoundUrl"] = panicSoundUrl
 	}
 
 	zap.S().Infof("PANIC ALERT CREATED - About to broadcast socket events for alertId: %s, userId: %s", alertID, request.UserID)
@@ -7322,6 +7338,19 @@ func (c Community) ActivateSignal100Handler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Resolve custom signal 100 sound URL (if community has one configured)
+	var signal100SoundUrl string
+	if comm, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID}); cErr == nil {
+		if key := comm.Details.DefaultSignal100Sound; key != "" {
+			for _, s := range comm.Details.CustomToneSounds {
+				if s.Key == key {
+					signal100SoundUrl = s.URL
+					break
+				}
+			}
+		}
+	}
+
 	// Broadcast via WebSocket
 	broadcastData := map[string]interface{}{
 		"type":                  "signal_100",
@@ -7333,6 +7362,9 @@ func (c Community) ActivateSignal100Handler(w http.ResponseWriter, r *http.Reque
 		"activatedByDepartment": request.DepartmentName,
 		"activatedAt":           now,
 	}
+	if signal100SoundUrl != "" {
+		broadcastData["signal100SoundUrl"] = signal100SoundUrl
+	}
 	broadcastPanicAlertEvent("signal_100_activated", broadcastData)
 
 	zap.S().Infof("SIGNAL 100 ACTIVATED - community: %s, by: %s (%s)", communityID, request.Username, request.CallSign)
@@ -7341,13 +7373,17 @@ func (c Community) ActivateSignal100Handler(w http.ResponseWriter, r *http.Reque
 	go c.sendSignal100PushNotifications(cID, communityID, request.UserID, request.Username, request.CallSign, "activated")
 
 	// Notify Node.js server to broadcast via Socket.IO (for web dashboard updates from mobile)
-	go c.notifyNodeServerPanic("signal_100_activated", map[string]interface{}{
+	nodeData := map[string]interface{}{
 		"communityId":    communityID,
 		"userId":         request.UserID,
 		"username":       request.Username,
 		"callSign":       request.CallSign,
 		"departmentType": request.DepartmentName,
-	})
+	}
+	if signal100SoundUrl != "" {
+		nodeData["signal100SoundUrl"] = signal100SoundUrl
+	}
+	go c.notifyNodeServerPanic("signal_100_activated", nodeData)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(signal100)

--- a/api/handlers/tone_sounds.go
+++ b/api/handlers/tone_sounds.go
@@ -42,9 +42,11 @@ func (c Community) GetToneSoundsHandler(w http.ResponseWriter, r *http.Request) 
 		"success":  true,
 		"sounds":   sounds,
 		"defaults": map[string]string{
-			"leo": community.Details.DefaultToneLeo,
-			"fd":  community.Details.DefaultToneFd,
-			"ems": community.Details.DefaultToneEms,
+			"leo":       community.Details.DefaultToneLeo,
+			"fd":        community.Details.DefaultToneFd,
+			"ems":       community.Details.DefaultToneEms,
+			"panic":     community.Details.DefaultPanicSound,
+			"signal100": community.Details.DefaultSignal100Sound,
 		},
 	})
 }
@@ -191,6 +193,12 @@ func (c Community) DeleteToneSoundHandler(w http.ResponseWriter, r *http.Request
 		if community.Details.DefaultToneEms == soundKey {
 			unsetFields["community.defaultToneEms"] = ""
 		}
+		if community.Details.DefaultPanicSound == soundKey {
+			unsetFields["community.defaultPanicSound"] = ""
+		}
+		if community.Details.DefaultSignal100Sound == soundKey {
+			unsetFields["community.defaultSignal100Sound"] = ""
+		}
 	}
 	if len(unsetFields) > 0 {
 		_ = c.DB.UpdateOne(context.Background(), bson.M{"_id": cID}, bson.M{"$unset": unsetFields})
@@ -246,8 +254,12 @@ func (c Community) SetToneDefaultHandler(w http.ResponseWriter, r *http.Request)
 		field = "community.defaultToneFd"
 	case "ems":
 		field = "community.defaultToneEms"
+	case "panic":
+		field = "community.defaultPanicSound"
+	case "signal100":
+		field = "community.defaultSignal100Sound"
 	default:
-		config.ErrorStatus("template must be 'leo', 'fd', or 'ems'", http.StatusBadRequest, w, fmt.Errorf("invalid template: %s", request.Template))
+		config.ErrorStatus("template must be 'leo', 'fd', 'ems', 'panic', or 'signal100'", http.StatusBadRequest, w, fmt.Errorf("invalid template: %s", request.Template))
 		return
 	}
 

--- a/models/community.go
+++ b/models/community.go
@@ -60,6 +60,8 @@ type CommunityDetails struct {
 	DefaultToneLeo          string                `json:"defaultToneLeo,omitempty" bson:"defaultToneLeo,omitempty"`
 	DefaultToneFd           string                `json:"defaultToneFd,omitempty" bson:"defaultToneFd,omitempty"`
 	DefaultToneEms          string                `json:"defaultToneEms,omitempty" bson:"defaultToneEms,omitempty"`
+	DefaultPanicSound       string                `json:"defaultPanicSound,omitempty" bson:"defaultPanicSound,omitempty"`
+	DefaultSignal100Sound   string                `json:"defaultSignal100Sound,omitempty" bson:"defaultSignal100Sound,omitempty"`
 	WarrantApprovalMode        string              `json:"warrantApprovalMode" bson:"warrantApprovalMode"`               // "auto-approve", "random", "require-judge"
 	WarrantRandomApprovalRate  int                 `json:"warrantRandomApprovalRate" bson:"warrantRandomApprovalRate"`   // 0-100 percentage, default 70
 	MostWantedEnabled       bool                   `json:"mostWantedEnabled" bson:"mostWantedEnabled"`


### PR DESCRIPTION
## Summary
- Add `defaultPanicSound` and `defaultSignal100Sound` fields to the community model
- Extend tone sounds handlers to support panic/signal100 as template types (get, set, delete)
- Resolve custom sound URLs when broadcasting panic and signal 100 events
- Pass sound URLs through the Node.js webhook for Socket.IO relay

## Test plan
- [ ] Set a custom sound as panic default via `PUT /tone-defaults` with `template: "panic"`
- [ ] Trigger a panic alert — verify `panicSoundUrl` appears in broadcast data
- [ ] Set a custom sound as signal 100 default
- [ ] Activate signal 100 — verify `signal100SoundUrl` appears in broadcast data
- [ ] Delete a custom sound that's set as panic/signal100 default — verify it gets cleared
- [ ] Verify existing tone dispatch flow still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)