### PR TITLE
fix: track arrests in department metrics

### DIFF
--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -645,14 +645,13 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 		return relevant[metricType]
 	}
 
-	// Citations, Warnings, Arrests — from civilians collection
+	// Citations, Warnings — from civilians collection
 	for _, entry := range []struct {
 		metricType   string
 		crimHistType string
 	}{
 		{"citations_issued", "Citation"},
 		{"warnings_issued", "Warning"},
-		{"arrests_made", "Arrest"},
 	} {
 		if !needMetric(entry.metricType) {
 			continue
@@ -672,6 +671,22 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 			return nil, err
 		}
 		metrics[entry.metricType] = count
+	}
+
+	// Arrests Made — from arrestreports collection
+	if needMetric("arrests_made") {
+		count, err := c.runCountPipeline(ctx, "arrestreports", bson.A{
+			bson.M{"$match": bson.M{
+				"arrestReport.activeCommunityID": communityID,
+				"arrestReport.officerID":         userID,
+				"arrestReport.departmentId":      departmentID,
+			}},
+			bson.M{"$count": "total"},
+		})
+		if err != nil {
+			return nil, err
+		}
+		metrics["arrests_made"] = count
 	}
 
 	// Calls Created

--- a/models/arrestreport.go
+++ b/models/arrestreport.go
@@ -22,6 +22,9 @@ type ArrestReportDetails struct {
 	IncidentLocation string             `json:"incidentLocation" bson:"incidentLocation"`
 	Arrestee         Arrestee           `json:"arrestee" bson:"arrestee"`
 	Officer          Officer            `json:"officer" bson:"officer"`
+	OfficerID        string             `json:"officerID" bson:"officerID"`
+	ActiveCommunityID string            `json:"activeCommunityID" bson:"activeCommunityID"`
+	DepartmentID     string             `json:"departmentId" bson:"departmentId"`
 	Charges          string             `json:"charges" bson:"charges"`
 	Narrative        string             `json:"narrative" bson:"narrative"`
 	Witnesses        string             `json:"witnesses" bson:"witnesses"`


### PR DESCRIPTION
## Summary
- Add `officerID`, `activeCommunityID`, and `departmentId` fields to the arrest report model so arrests can be linked to officers/departments
- Fix `arrests_made` metric to query the `arrestreports` collection instead of `civilians.criminalHistory` (which never contained arrest entries)

## Test plan
- [ ] Create an arrest report and verify the new fields are persisted in MongoDB
- [ ] Check department metrics and confirm `arrests_made` now increments for new arrests
- [ ] Verify existing metrics (citations, warnings, calls, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)