### PR TITLE
fix(community): self-healing membersCount + drift prevention on ban/join

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -210,6 +210,31 @@ func (c Community) CommunityHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Self-healing: overwrite the denormalized MembersCount with a live count
+	// from the users collection. Protects against historical drift (e.g. bans
+	// that did not decrement the stored field). Uses the same filter as
+	// CommunityMembersHandler so both endpoints agree. Backed by the
+	// {user.communities.communityId, user.communities.status} compound index
+	// (scripts/create_indexes.js).
+	memberFilter := bson.M{
+		"$and": []bson.M{
+			{"user.communities": bson.M{"$exists": true}},
+			{"user.communities": bson.M{"$ne": nil}},
+			{"user.communities": bson.M{
+				"$elemMatch": bson.M{
+					"communityId": commID,
+					"status":      "approved",
+				},
+			}},
+		},
+	}
+	if liveCount, countErr := c.UDB.CountDocuments(ctx, memberFilter); countErr == nil {
+		dbResp.Details.MembersCount = int(liveCount)
+	} else {
+		zap.S().Warnw("failed to compute live membersCount; falling back to stored value",
+			"community_id", commID, "error", countErr)
+	}
+
 	b, err := json.Marshal(dbResp)
 	if err != nil {
 		config.ErrorStatus("failed to marshal response", http.StatusInternalServerError, w, err)
@@ -1901,9 +1926,15 @@ func (c Community) JoinCommunityHandler(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Step 5: Increment membersCount if new entry
+	// Step 5: Increment membersCount in two cases:
+	//   1. New entry (not on banList).
+	//   2. Existing entry transitioned from a non-approved, non-banned status
+	//      to "approved" via the update at Step 3 above.
 	isNewEntry := existingCommunity == nil && !contains(community.Details.BanList, req.UserID)
-	if isNewEntry {
+	becameApproved := existingCommunity != nil &&
+		existingCommunity.Status != "approved" &&
+		existingCommunity.Status != "banned"
+	if isNewEntry || becameApproved {
 		if err := c.DB.UpdateOne(
 			ctx,
 			bson.M{"_id": communityObjID},

--- a/api/handlers/community_members_count_test.go
+++ b/api/handlers/community_members_count_test.go
@@ -1,0 +1,419 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// approvedMembersFilter is the filter shape used by both CommunityHandler
+// (self-healing read) and CommunityMembersHandler. The tests assert against
+// this exact shape so any future drift between the two endpoints fails fast.
+func approvedMembersFilter(communityID string) bson.M {
+	return bson.M{
+		"$and": []bson.M{
+			{"user.communities": bson.M{"$exists": true}},
+			{"user.communities": bson.M{"$ne": nil}},
+			{"user.communities": bson.M{
+				"$elemMatch": bson.M{
+					"communityId": communityID,
+					"status":      "approved",
+				},
+			}},
+		},
+	}
+}
+
+// -----------------------------------------------------------------------------
+// CommunityHandler — self-healing read
+// -----------------------------------------------------------------------------
+
+func TestCommunity_CommunityHandler_UsesLiveCount_OverwritesStored(t *testing.T) {
+	communityID := "507f1f77bcf86cd799439011"
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockUserDB := &mocks.UserDatabase{}
+
+	storedCommunity := &models.Community{
+		ID: communityObjectID,
+		Details: models.CommunityDetails{
+			Name:         "Test Community",
+			MembersCount: 85, // stale, drifted
+		},
+	}
+	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+		Return(storedCommunity, nil)
+	mockUserDB.On("CountDocuments", mock.Anything, approvedMembersFilter(communityID)).
+		Return(int64(35), nil)
+
+	c := handlers.Community{
+		DB:  mockCommunityDB,
+		UDB: mockUserDB,
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/community/"+communityID, nil)
+	req = mux.SetURLVars(req, map[string]string{"community_id": communityID})
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var response models.Community
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, 35, response.Details.MembersCount,
+		"response should reflect the live count, not the stored value")
+
+	mockCommunityDB.AssertExpectations(t)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestCommunity_CommunityHandler_CountFails_FallsBackToStored(t *testing.T) {
+	communityID := "507f1f77bcf86cd799439011"
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockUserDB := &mocks.UserDatabase{}
+
+	storedCommunity := &models.Community{
+		ID: communityObjectID,
+		Details: models.CommunityDetails{
+			Name:         "Test Community",
+			MembersCount: 42,
+		},
+	}
+	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+		Return(storedCommunity, nil)
+	mockUserDB.On("CountDocuments", mock.Anything, approvedMembersFilter(communityID)).
+		Return(int64(0), errors.New("transient mongo error"))
+
+	c := handlers.Community{
+		DB:  mockCommunityDB,
+		UDB: mockUserDB,
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/community/"+communityID, nil)
+	req = mux.SetURLVars(req, map[string]string{"community_id": communityID})
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"count failure should NOT fail the request — it must fall back to stored")
+
+	var response models.Community
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, 42, response.Details.MembersCount,
+		"on count failure, response should preserve the stored value")
+
+	mockCommunityDB.AssertExpectations(t)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestCommunity_CommunityHandler_CommunityNotFound_ReturnsNotFound(t *testing.T) {
+	communityID := "507f1f77bcf86cd799439011"
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockUserDB := &mocks.UserDatabase{}
+
+	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+		Return((*models.Community)(nil), mongo.ErrNoDocuments)
+
+	c := handlers.Community{
+		DB:  mockCommunityDB,
+		UDB: mockUserDB,
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/community/"+communityID, nil)
+	req = mux.SetURLVars(req, map[string]string{"community_id": communityID})
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	mockCommunityDB.AssertExpectations(t)
+	mockUserDB.AssertNotCalled(t, "CountDocuments", mock.Anything, mock.Anything)
+}
+
+func TestCommunity_CommunityHandler_InvalidObjectID_ReturnsBadRequest(t *testing.T) {
+	communityID := "not-a-valid-object-id"
+
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockUserDB := &mocks.UserDatabase{}
+
+	c := handlers.Community{
+		DB:  mockCommunityDB,
+		UDB: mockUserDB,
+	}
+
+	req, _ := http.NewRequest("GET", "/api/v1/community/"+communityID, nil)
+	req = mux.SetURLVars(req, map[string]string{"community_id": communityID})
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockCommunityDB.AssertNotCalled(t, "FindOne", mock.Anything, mock.Anything)
+	mockUserDB.AssertNotCalled(t, "CountDocuments", mock.Anything, mock.Anything)
+}
+
+// -----------------------------------------------------------------------------
+// BanUserFromCommunityHandler — conditional decrement on prior approved status
+// -----------------------------------------------------------------------------
+
+// banUserRequest builds the wire request for BanUserFromCommunityHandler.
+func banUserRequest(t *testing.T, userID, communityID string) *http.Request {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"communityId": communityID})
+	req, err := http.NewRequest("POST", "/api/v1/user/"+userID+"/ban-community", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return mux.SetURLVars(req, map[string]string{"userId": userID})
+}
+
+// stubUserFindOne wires up u.DB.FindOne to decode into the supplied user model.
+func stubUserFindOne(mockUserDB *mocks.UserDatabase, userObjectID primitive.ObjectID, userDoc *models.User) *mocks.SingleResultHelper {
+	mockResult := &mocks.SingleResultHelper{}
+	mockResult.On("Decode", mock.Anything).Run(func(args mock.Arguments) {
+		userPtr := args.Get(0).(*models.User)
+		*userPtr = *userDoc
+	}).Return(nil)
+	mockUserDB.On("FindOne", mock.Anything, bson.M{"_id": userObjectID}).Return(mockResult)
+	return mockResult
+}
+
+func TestUser_BanUserFromCommunityHandler_PriorStatusApproved_DecrementsCount(t *testing.T) {
+	userID := "507f1f77bcf86cd799439011"
+	communityID := "507f1f77bcf86cd799439012"
+	userObjectID, _ := primitive.ObjectIDFromHex(userID)
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockUserDB := &mocks.UserDatabase{}
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockAuditLogDB := &mocks.AuditLogDatabase{}
+
+	stubUserFindOne(mockUserDB, userObjectID, &models.User{
+		ID: userID,
+		Details: models.UserDetails{
+			Communities: []models.UserCommunity{
+				{ID: "uc1", CommunityID: communityID, Status: "approved"},
+			},
+		},
+	})
+
+	mockUserDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": userObjectID, "user.communities.communityId": communityID},
+		bson.M{"$set": bson.M{"user.communities.$.status": "banned"}},
+	).Return(&mongo.UpdateResult{MatchedCount: 1, ModifiedCount: 1}, nil)
+
+	mockCommunityDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$addToSet": bson.M{"community.banList": userID}},
+	).Return(nil)
+
+	mockCommunityDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$inc": bson.M{"community.membersCount": -1}},
+	).Return(nil)
+
+	mockAuditLogDB.On("InsertOne", mock.Anything, mock.Anything).Return(&mocks.InsertOneResultHelper{}, nil)
+
+	u := handlers.User{
+		DB:   mockUserDB,
+		CDB:  mockCommunityDB,
+		ALDB: mockAuditLogDB,
+	}
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(u.BanUserFromCommunityHandler).ServeHTTP(rr, banUserRequest(t, userID, communityID))
+	time.Sleep(50 * time.Millisecond) // let logAudit goroutine complete
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "User banned from community successfully")
+	mockUserDB.AssertExpectations(t)
+	mockCommunityDB.AssertExpectations(t)
+}
+
+func TestUser_BanUserFromCommunityHandler_PriorStatusPending_DoesNotDecrement(t *testing.T) {
+	userID := "507f1f77bcf86cd799439011"
+	communityID := "507f1f77bcf86cd799439012"
+	userObjectID, _ := primitive.ObjectIDFromHex(userID)
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockUserDB := &mocks.UserDatabase{}
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockAuditLogDB := &mocks.AuditLogDatabase{}
+
+	stubUserFindOne(mockUserDB, userObjectID, &models.User{
+		ID: userID,
+		Details: models.UserDetails{
+			Communities: []models.UserCommunity{
+				{ID: "uc1", CommunityID: communityID, Status: "pending"},
+			},
+		},
+	})
+
+	mockUserDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": userObjectID, "user.communities.communityId": communityID},
+		bson.M{"$set": bson.M{"user.communities.$.status": "banned"}},
+	).Return(&mongo.UpdateResult{MatchedCount: 1, ModifiedCount: 1}, nil)
+
+	mockCommunityDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$addToSet": bson.M{"community.banList": userID}},
+	).Return(nil)
+
+	mockAuditLogDB.On("InsertOne", mock.Anything, mock.Anything).Return(&mocks.InsertOneResultHelper{}, nil)
+
+	u := handlers.User{
+		DB:   mockUserDB,
+		CDB:  mockCommunityDB,
+		ALDB: mockAuditLogDB,
+	}
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(u.BanUserFromCommunityHandler).ServeHTTP(rr, banUserRequest(t, userID, communityID))
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockCommunityDB.AssertNotCalled(t, "UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$inc": bson.M{"community.membersCount": -1}},
+	)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestUser_BanUserFromCommunityHandler_UserNotMember_ReturnsBadRequest(t *testing.T) {
+	userID := "507f1f77bcf86cd799439011"
+	communityID := "507f1f77bcf86cd799439012"
+	otherCommunityID := "507f1f77bcf86cd7994390aa"
+	userObjectID, _ := primitive.ObjectIDFromHex(userID)
+
+	mockUserDB := &mocks.UserDatabase{}
+	mockCommunityDB := &mocks.CommunityDatabase{}
+
+	stubUserFindOne(mockUserDB, userObjectID, &models.User{
+		ID: userID,
+		Details: models.UserDetails{
+			Communities: []models.UserCommunity{
+				{ID: "uc1", CommunityID: otherCommunityID, Status: "approved"},
+			},
+		},
+	})
+
+	u := handlers.User{
+		DB:  mockUserDB,
+		CDB: mockCommunityDB,
+	}
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(u.BanUserFromCommunityHandler).ServeHTTP(rr, banUserRequest(t, userID, communityID))
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "user is not a member of this community")
+	mockUserDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+	mockCommunityDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUser_BanUserFromCommunityHandler_AlreadyBanned_IsIdempotent(t *testing.T) {
+	userID := "507f1f77bcf86cd799439011"
+	communityID := "507f1f77bcf86cd799439012"
+	userObjectID, _ := primitive.ObjectIDFromHex(userID)
+
+	mockUserDB := &mocks.UserDatabase{}
+	mockCommunityDB := &mocks.CommunityDatabase{}
+
+	stubUserFindOne(mockUserDB, userObjectID, &models.User{
+		ID: userID,
+		Details: models.UserDetails{
+			Communities: []models.UserCommunity{
+				{ID: "uc1", CommunityID: communityID, Status: "banned"},
+			},
+		},
+	})
+
+	u := handlers.User{
+		DB:  mockUserDB,
+		CDB: mockCommunityDB,
+	}
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(u.BanUserFromCommunityHandler).ServeHTTP(rr, banUserRequest(t, userID, communityID))
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "User already banned from community")
+	mockUserDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+	mockCommunityDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUser_BanUserFromCommunityHandler_DecrementFailureIsNonFatal(t *testing.T) {
+	userID := "507f1f77bcf86cd799439011"
+	communityID := "507f1f77bcf86cd799439012"
+	userObjectID, _ := primitive.ObjectIDFromHex(userID)
+	communityObjectID, _ := primitive.ObjectIDFromHex(communityID)
+
+	mockUserDB := &mocks.UserDatabase{}
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockAuditLogDB := &mocks.AuditLogDatabase{}
+
+	stubUserFindOne(mockUserDB, userObjectID, &models.User{
+		ID: userID,
+		Details: models.UserDetails{
+			Communities: []models.UserCommunity{
+				{ID: "uc1", CommunityID: communityID, Status: "approved"},
+			},
+		},
+	})
+
+	mockUserDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": userObjectID, "user.communities.communityId": communityID},
+		bson.M{"$set": bson.M{"user.communities.$.status": "banned"}},
+	).Return(&mongo.UpdateResult{MatchedCount: 1, ModifiedCount: 1}, nil)
+
+	mockCommunityDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$addToSet": bson.M{"community.banList": userID}},
+	).Return(nil)
+
+	mockCommunityDB.On("UpdateOne", mock.Anything,
+		bson.M{"_id": communityObjectID},
+		bson.M{"$inc": bson.M{"community.membersCount": -1}},
+	).Return(errors.New("transient mongo error"))
+
+	mockAuditLogDB.On("InsertOne", mock.Anything, mock.Anything).Return(&mocks.InsertOneResultHelper{}, nil)
+
+	u := handlers.User{
+		DB:   mockUserDB,
+		CDB:  mockCommunityDB,
+		ALDB: mockAuditLogDB,
+	}
+
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(u.BanUserFromCommunityHandler).ServeHTTP(rr, banUserRequest(t, userID, communityID))
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Equal(t, http.StatusOK, rr.Code,
+		"decrement failure must be non-fatal — the ban itself succeeded")
+	assert.Contains(t, rr.Body.String(), "User banned from community successfully")
+	mockUserDB.AssertExpectations(t)
+	mockCommunityDB.AssertExpectations(t)
+}

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -2277,6 +2277,32 @@ func (u User) BanUserFromCommunityHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	// Fetch user to determine prior community status — we only decrement
+	// membersCount if this user was previously "approved" (counted).
+	var bannedUser models.User
+	if err := u.DB.FindOne(ctx, bson.M{"_id": uID}).Decode(&bannedUser); err != nil {
+		config.ErrorStatus("failed to fetch user", http.StatusInternalServerError, w, err)
+		return
+	}
+	priorStatus := ""
+	for _, uc := range bannedUser.Details.Communities {
+		if uc.CommunityID == requestBody.CommunityID {
+			priorStatus = uc.Status
+			break
+		}
+	}
+	if priorStatus == "" {
+		config.ErrorStatus("user is not a member of this community", http.StatusBadRequest, w,
+			fmt.Errorf("community %s is not associated with user %s", requestBody.CommunityID, userID))
+		return
+	}
+	if priorStatus == "banned" {
+		// Idempotent: already banned.
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "User already banned from community"}`))
+		return
+	}
+
 	// Update the user's community status to "banned"
 	userFilter := bson.M{
 		"_id":                          uID,
@@ -2304,6 +2330,19 @@ func (u User) BanUserFromCommunityHandler(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		config.ErrorStatus("failed to update community ban list", http.StatusInternalServerError, w, err)
 		return
+	}
+
+	// Only decrement membersCount if the user was previously approved (counted).
+	// Non-fatal: CommunityHandler's self-healing read will correct any transient
+	// drift on the next GET. Don't block a security-critical action on a
+	// denormalized-field update failure.
+	if priorStatus == "approved" {
+		if err := u.CDB.UpdateOne(ctx, communityFilter, bson.M{
+			"$inc": bson.M{"community.membersCount": -1},
+		}); err != nil {
+			zap.S().Warnw("failed to decrement membersCount on ban",
+				"community_id", requestBody.CommunityID, "user_id", userID, "error", err)
+		}
 	}
 
 	// Audit log — member banned


### PR DESCRIPTION
## Summary

Fixes a bug where the mobile app community home screen displayed an incorrect `membersCount` (e.g. **85**) while the members list screen correctly showed the actual count (e.g. **35**) for the same community. The fix is backend-only — no mobile push required.

### Root cause

`community.membersCount` is a denormalized stored field. Two paths mutate user community status without keeping it in sync:

1. **`BanUserFromCommunityHandler`** ([api/handlers/user.go](api/handlers/user.go)) sets `user.communities.$.status` to `"banned"` but never decrements `community.membersCount`. Each ban of a previously-approved user inflates the stored count by 1 — the dominant source of the 85-vs-35 drift.
2. **`JoinCommunityHandler`** ([api/handlers/community.go](api/handlers/community.go)) only increments for brand-new user entries; pending users transitioning to approved via invite code were silently uncounted.

### Changes

- **`CommunityHandler`** — overwrites the stored `MembersCount` with a live `CountDocuments` against the same filter as `CommunityMembersHandler`, so both endpoints always agree. This **immediately fixes the user-visible bug for all communities** with no DB migration. Falls back to the stored value on count failure (logged) so the home-screen GET never fails. Backed by the existing `{user.communities.communityId, user.communities.status}` compound index.
- **`BanUserFromCommunityHandler`** — read-then-update pattern: fetches the user first, decrements `membersCount` only when prior status was `"approved"`, returns 400 if user has no entry for the community, and is idempotent for already-banned users. The decrement is non-fatal (warn-only) — the self-healing read is the safety net.
- **`JoinCommunityHandler`** — increments `membersCount` for both brand-new entries and pending→approved transitions.
- **New tests** in `api/handlers/community_members_count_test.go` cover four `CommunityHandler` paths and five `BanUserFromCommunityHandler` branches. `JoinCommunityHandler` is not unit-tested here because `IDB.FindOneAndUpdate` returns a concrete `*mongo.SingleResult` (would require interface refactor or integration test).

### Why hybrid (self-healing read + write-side fix)?

The self-healing read alone would be enough to fix the user-visible bug, but the stored field is also used by leaderboard/sort/admin paths ([api/handlers/community.go](api/handlers/community.go) ranking queries, [api/handlers/admin.go](api/handlers/admin.go) admin views) that we don't want to keep drifting. Fixing both write paths keeps the stored field accurate going forward; the self-healing read also masks any future drift sources we might miss.

## Test plan

- [x] `go build -mod=mod ./...` — clean
- [x] All 9 new tests pass: 4 `CommunityHandler` (live count overwrite, count-failure fallback, not-found, invalid ID) and 5 `BanUserFromCommunityHandler` (approved→decrements, pending→does not decrement, not-a-member→400, already-banned→idempotent, decrement-failure→non-fatal)
- [x] All other handler tests still pass (the pre-existing `TestCreatePanicAlertHandler` failure is unrelated and reproduces on `main`)
- [ ] Production verification: open the affected community on mobile — home-screen count should match the members list (e.g. 35)
- [ ] Drift prevention check: ban a test user from a test community, refetch — `membersCount` should drop by 1 in both stored and live values

## Out of scope (tech debt to follow up)

- `RemoveCommunityFromUserHandler` unconditionally decrements even when prior status was pending/declined — masked by the self-healing read; ship a separate fix
- `UnbanUserFromCommunityHandler` uses `context.Background()` instead of the request context — pre-existing
- One-shot recompute migration to fix drifted leaderboards — defer until/if leaderboard accuracy is reported as a problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)