### PR TITLE
fix: admin verify email fails for ObjectID users

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -905,17 +905,31 @@ func (h Admin) AdminVerifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter := bson.M{"_id": userID}
 	update := bson.M{
 		"$set":   bson.M{"user.emailVerified": true},
 		"$unset": bson.M{"user.emailVerificationToken": "", "user.emailVerificationExpires": ""},
 	}
 
+	// Try string ID first
+	filter := bson.M{"_id": userID}
 	result, err := h.UDB.UpdateOne(r.Context(), filter, update)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to verify email"})
 		return
+	}
+
+	// If string ID didn't match, try ObjectID
+	if result.MatchedCount == 0 {
+		if oid, oidErr := primitive.ObjectIDFromHex(userID); oidErr == nil {
+			filter = bson.M{"_id": oid}
+			result, err = h.UDB.UpdateOne(r.Context(), filter, update)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to verify email"})
+				return
+			}
+		}
 	}
 
 	if result.MatchedCount == 0 {


### PR DESCRIPTION
## Summary
- Admin console "Verify Email" button on pending users was returning "failed to verify email" because the handler only matched `_id` as a string
- Most users have ObjectID `_id` values (Mongoose default), so the string filter never matched
- Added the same ObjectID fallback pattern already used by `AdminUserDetailsHandler` and other admin handlers

## Test plan
- [ ] Search for pending unverified users in admin console
- [ ] Click "Verify Email" on a user — should succeed instead of erroring
- [ ] Confirm the user disappears from the pending list after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)