### PR TITLE
feat: add Dockerfile for E2E test environment

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,12 @@
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /police-cad-api .
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /police-cad-api /usr/local/bin/police-cad-api
+EXPOSE 8081
+CMD ["police-cad-api"]


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.test` — a lightweight multi-stage Go build used by police-cad's `docker-compose.test.yml`
- Spins up an isolated API instance pointed at a test MongoDB container
- Required by Linesmerrill/police-cad#886 (Playwright E2E testing infrastructure)

## Test plan
- [ ] `docker build -f Dockerfile.test .` completes successfully
- [ ] Container starts and serves `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)