### PR TITLE
fix: prevent race conditions that silently remove community members

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -358,40 +358,14 @@ func (c Community) CreateCommunityHandler(w http.ResponseWriter, r *http.Request
 		Status:      "approved",
 	}
 
-	// Ensure the user's communities array is initialized
+	// Atomically ensure the user's communities array is initialized (no-op if already an array).
+	// Using a conditional filter avoids overwriting concurrent modifications.
 	filter := bson.M{"_id": uID}
+	_, _ = c.UDB.UpdateOne(ctx, bson.M{"_id": uID, "user.communities": nil}, bson.M{"$set": bson.M{"user.communities": bson.A{}}})
 
-	user := models.User{}
-	err = c.UDB.FindOne(ctx, filter).Decode(&user)
-	if err != nil {
-		config.ErrorStatus("failed to retrieve user's communities", http.StatusInternalServerError, w, err)
-		return
-	}
-
-	// Initialize null fields
-	if user.Details.Communities == nil {
-		user.Details.Communities = []models.UserCommunity{}
-	}
-	if user.Details.Friends == nil {
-		user.Details.Friends = []models.Friend{}
-	}
-	if user.Details.Notifications == nil {
-		user.Details.Notifications = []models.Notification{}
-	}
-
-	// Update the user's communities array
+	// Atomically append the new community — $addToSet ensures no duplicates.
 	update := bson.M{
-		"$set": bson.M{"user.communities": user.Details.Communities}, // Ensure communities is an array
-	}
-	_, err = c.UDB.UpdateOne(ctx, filter, update)
-	if err != nil {
-		config.ErrorStatus("failed to update user's communities", http.StatusInternalServerError, w, err)
-		return
-	}
-
-	// Add the new community to the user's communities array
-	update = bson.M{
-		"$addToSet": bson.M{"user.communities": newUserCommunity}, // $addToSet ensures no duplicates
+		"$addToSet": bson.M{"user.communities": newUserCommunity},
 	}
 	_, err = c.UDB.UpdateOne(ctx, filter, update)
 	if err != nil {
@@ -1898,19 +1872,13 @@ func (c Community) JoinCommunityHandler(w http.ResponseWriter, r *http.Request) 
 				"status":      "approved",
 			}
 
-			// Check if user.communities is null and handle accordingly
-			if user.Details.Communities == nil {
-				// If communities is null, set it to an array with the new entry
-				update = bson.M{
-					"$set": bson.M{"user.communities": bson.A{newCommunityEntry}},
-				}
-			} else {
-				// If communities already exists as an array, push to it
-				update = bson.M{
-					"$push": bson.M{"user.communities": newCommunityEntry},
-				}
-			}
+			// Atomically ensure communities array is initialized (no-op if already an array).
+			_, _ = c.UDB.UpdateOne(ctx, bson.M{"_id": userObjID, "user.communities": nil}, bson.M{"$set": bson.M{"user.communities": bson.A{}}})
 
+			// Atomically append the new community entry.
+			update = bson.M{
+				"$push": bson.M{"user.communities": newCommunityEntry},
+			}
 			_, err = c.UDB.UpdateOne(
 				ctx,
 				bson.M{"_id": userObjID},
@@ -2914,6 +2882,10 @@ func (c Community) RemoveUserFromDepartmentHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
+	// Audit log for department member removal
+	actorID := resolveActorFromRequest(r)
+	logAudit(c.ALDB, cID, "department.member_removed", "department", actorID, resolveActorName(c.UDB, actorID), requestBody.UserID, resolveActorName(c.UDB, requestBody.UserID), map[string]interface{}{"departmentId": departmentID})
+
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"message": "User removed from department successfully"}`))
 }
@@ -3089,6 +3061,14 @@ func (c Community) UpdateDepartmentJoinRequestHandler(w http.ResponseWriter, r *
 		config.ErrorStatus("failed to update department join request", http.StatusInternalServerError, w, err)
 		return
 	}
+
+	// Audit log for department join request decision
+	actorID := resolveActorFromRequest(r)
+	auditAction := "department.member_approved"
+	if requestBody.Status == "declined" {
+		auditAction = "department.member_declined"
+	}
+	logAudit(c.ALDB, cID, auditAction, "department", actorID, resolveActorName(c.UDB, actorID), requestBody.UserID, resolveActorName(c.UDB, requestBody.UserID), map[string]interface{}{"departmentId": departmentID})
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"message": "Department join request updated successfully"}`))

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -2014,25 +2014,15 @@ func (u User) AddCommunityToUserHandler(w http.ResponseWriter, r *http.Request) 
 		newCommunity.Status = requestBody.Status
 	}
 
-	// Handle communities array based on its length
-	if user.Details.Communities == nil || len(user.Details.Communities) == 0 {
-		// Initialize communities array and insert the first record
-		update := bson.M{
-			"$set": bson.M{"user.communities": []models.UserCommunity{newCommunity}},
-		}
-		_, err = u.DB.UpdateOne(ctx, filter, update)
-		if err != nil {
-			config.ErrorStatus("failed to initialize communities", http.StatusInternalServerError, w, fmt.Errorf("failed to initialize communities: %w", err))
-			return
-		}
-	} else {
-		// Insert the new community into the existing array
-		update := bson.M{"$push": bson.M{"user.communities": newCommunity}}
-		_, err = u.DB.UpdateOne(ctx, filter, update)
-		if err != nil {
-			config.ErrorStatus("failed to add community", http.StatusInternalServerError, w, fmt.Errorf("failed to add community: %w", err))
-			return
-		}
+	// Atomically ensure communities array is initialized (no-op if already an array).
+	_, _ = u.DB.UpdateOne(ctx, bson.M{"_id": uID, "user.communities": nil}, bson.M{"$set": bson.M{"user.communities": bson.A{}}})
+
+	// Atomically append the new community.
+	update := bson.M{"$push": bson.M{"user.communities": newCommunity}}
+	_, err = u.DB.UpdateOne(ctx, filter, update)
+	if err != nil {
+		config.ErrorStatus("failed to add community", http.StatusInternalServerError, w, fmt.Errorf("failed to add community: %w", err))
+		return
 	}
 
 	// Increment the membersCount in the community document
@@ -2041,6 +2031,12 @@ func (u User) AddCommunityToUserHandler(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		config.ErrorStatus("failed to increment community membersCount", http.StatusInternalServerError, w, fmt.Errorf("failed to increment community membersCount: %w", err))
 		return
+	}
+
+	// Audit log: member added directly (e.g. via migration or admin action)
+	if newCommunity.Status == "approved" {
+		actorID := resolveActorFromRequest(r)
+		logAudit(u.ALDB, cID, "member.approved", "member", actorID, resolveActorName(u.DB, actorID), userID, resolveActorName(u.DB, userID), nil)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -2096,6 +2092,10 @@ func (u User) PendingCommunityRequestHandler(w http.ResponseWriter, r *http.Requ
 			// If already pending, return error
 			config.ErrorStatus("community request already exists", http.StatusConflict, w, fmt.Errorf("community request already exists"))
 			return
+		case "approved":
+			// Already an approved member — do not reset to pending
+			config.ErrorStatus("user is already an approved member of this community", http.StatusConflict, w, fmt.Errorf("user %s already approved for community %s", userID, requestBody.CommunityID))
+			return
 		case "declined":
 			// If declined, update to pending
 			filter := bson.M{"_id": uID, "user.communities.communityId": requestBody.CommunityID}
@@ -2112,16 +2112,9 @@ func (u User) PendingCommunityRequestHandler(w http.ResponseWriter, r *http.Requ
 			// If blocked, silently process but don't change status (just return success)
 			// No database update needed
 		default:
-			// For any other status, treat as new request and update to pending
-			filter := bson.M{"_id": uID, "user.communities.communityId": requestBody.CommunityID}
-			update := bson.M{
-				"$set": bson.M{"user.communities.$.status": "pending"},
-			}
-			_, err = u.DB.UpdateOne(ctx, filter, update)
-			if err != nil {
-				config.ErrorStatus("failed to update community request status", http.StatusInternalServerError, w, err)
-				return
-			}
+			// For any other unexpected status, return error rather than silently resetting
+			config.ErrorStatus("unexpected community membership status", http.StatusConflict, w, fmt.Errorf("user %s has unexpected status %q for community %s", userID, existingCommunity.Status, requestBody.CommunityID))
+			return
 		}
 	} else {
 		// No existing request found, add a new pending request
@@ -2131,25 +2124,15 @@ func (u User) PendingCommunityRequestHandler(w http.ResponseWriter, r *http.Requ
 			Status:      "pending",
 		}
 
-		if user.Details.Communities == nil || len(user.Details.Communities) == 0 {
-			// Initialize communities array
-			update := bson.M{
-				"$set": bson.M{"user.communities": []models.UserCommunity{pendingRequest}},
-			}
-			_, err = u.DB.UpdateOne(ctx, bson.M{"_id": uID}, update)
-			if err != nil {
-				config.ErrorStatus("failed to initialize user's communities", http.StatusInternalServerError, w, err)
-				return
-			}
-		} else {
-			// Add to existing communities array
-			filter := bson.M{"_id": uID}
-			update := bson.M{"$push": bson.M{"user.communities": pendingRequest}}
-			_, err = u.DB.UpdateOne(ctx, filter, update)
-			if err != nil {
-				config.ErrorStatus("failed to add community request", http.StatusInternalServerError, w, err)
-				return
-			}
+		// Atomically ensure communities array is initialized (no-op if already an array).
+		_, _ = u.DB.UpdateOne(ctx, bson.M{"_id": uID, "user.communities": nil}, bson.M{"$set": bson.M{"user.communities": bson.A{}}})
+
+		// Atomically append the pending request.
+		update := bson.M{"$push": bson.M{"user.communities": pendingRequest}}
+		_, err = u.DB.UpdateOne(ctx, bson.M{"_id": uID}, update)
+		if err != nil {
+			config.ErrorStatus("failed to add community request", http.StatusInternalServerError, w, err)
+			return
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **Race condition fixes**: Replace dangerous fetch-then-`$set` patterns with atomic conditional-init + `$push`/`$addToSet` in `CreateCommunityHandler`, `JoinCommunityHandler`, and `AddCommunityToUserHandler`. The old pattern overwrote the entire `user.communities` array with stale in-memory data, silently dropping concurrent changes — likely the root cause of members "randomly losing access."
- **Status reset bug**: Fix `PendingCommunityRequestHandler` `default` case that reset "approved" status to "pending" — an approved member who triggered this endpoint would lose access.
- **Missing audit logs**: Add audit logging for department member approval/decline and department member removal.

## Related PRs
- Linesmerrill/police-cad — frontend: pass approver userId + audit labels
- Linesmerrill/police-cad-app — mobile: pass approver userId + audit labels

## Test plan
- [x] Go build passes
- [x] All related tests pass (pre-existing `TestCreatePanicAlertHandler` failure is unrelated)
- [ ] Create a community as a user with existing communities → verify all communities preserved
- [ ] Approve a member from dd-notifications → audit log shows approver name
- [ ] Try sending a pending request for a community you're already approved in → should get 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)