### PR TITLE
fix: bound v1/v2 list handlers to stop MongoDB >1000-object alert

### DIFF
--- a/api/handlers/call.go
+++ b/api/handlers/call.go
@@ -26,24 +26,16 @@ type Call struct {
 
 // CallHandler returns all calls
 func (c Call) CallHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
-	
-	// Use request context with timeout for proper trace tracking and timeout handling
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
+
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
-	// Empty filter with limit/skip - add sort by _id for better performance
+
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
-		SetSort(bson.M{"_id": -1}) // Sort by _id descending (most recent first) for better index usage
-	
+		SetSort(bson.M{"_id": -1})
+
 	dbResp, err := c.DB.Find(ctx, bson.D{}, opts)
 	if err != nil {
 		config.ErrorStatus("failed to get calls", http.StatusNotFound, w, err)

--- a/api/handlers/civilian.go
+++ b/api/handlers/civilian.go
@@ -25,11 +25,6 @@ import (
 	"github.com/linesmerrill/police-cad-api/models"
 )
 
-var (
-	// Page denotes the starting Page for pagination results
-	Page = 0
-)
-
 // Civilian exported for testing purposes
 type Civilian struct {
 	DB  databases.CivilianDatabase
@@ -38,19 +33,11 @@ type Civilian struct {
 
 // CivilianHandler returns all civilians
 func (c Civilian) CivilianHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
-	
-	// Use request context with timeout for proper trace tracking and timeout handling
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
+
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
-	// Empty filter with limit/skip - add sort by _id for better performance
+
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
@@ -110,22 +97,16 @@ func (c Civilian) CivilianByIDHandler(w http.ResponseWriter, r *http.Request) {
 func (c Civilian) CiviliansByUserIDHandler(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("user_id: '%v'", userID)
 	zap.S().Debugf("active_community: '%v'", activeCommunityID)
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
 	var dbResp []models.Civilian
+	var err error
 
 	// If the user is in a community then we want to search for civilians that
 	// are in that same community. This way each user can have different civilians
@@ -174,13 +155,7 @@ func (c Civilian) CiviliansByUserIDHandler(w http.ResponseWriter, r *http.Reques
 func (c Civilian) CiviliansByUserIDHandlerV2(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -243,12 +218,12 @@ func (c Civilian) CiviliansByUserIDHandlerV2(w http.ResponseWriter, r *http.Requ
 		dbResp = []models.Civilian{}
 	}
 
-	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	totalPages := int(math.Ceil(float64(totalCount) / float64(limit64)))
 
 	response := map[string]interface{}{
 		"data":       dbResp,
-		"page":       Page,
-		"limit":      Limit,
+		"page":       page64,
+		"limit":      limit64,
 		"totalCount": totalCount,
 		"totalPages": totalPages,
 	}
@@ -268,26 +243,13 @@ func (c Civilian) CiviliansByNameSearchHandler(w http.ResponseWriter, r *http.Re
 	lastName := r.URL.Query().Get("last_name")
 	name := r.URL.Query().Get("name")
 	activeCommunityID := r.URL.Query().Get("active_community_id") // optional
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("first_name: '%v', last_name: '%v'", firstName, lastName)
 	zap.S().Debugf("active_community: '%v'", activeCommunityID)
 
 	var dbResp []models.Civilian
-
-	// If the user is in a community then we want to search for civilians that
-	// are in that same community. This way each user can have different civilians
-	// across different communities.
-	//
-	// Likewise, if the user is not in a community, then we will display only the civilians
-	// that are not in a community
-	err = nil
+	var err error
 	var orConditions []bson.M
 
 	if firstName != "" {

--- a/api/handlers/ems.go
+++ b/api/handlers/ems.go
@@ -3,9 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
@@ -26,24 +24,16 @@ type Ems struct {
 
 // EmsHandler returns all ems
 func (e Ems) EmsHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
-	
-	// Use request context with timeout for proper trace tracking and timeout handling
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
+
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
-	// Empty filter with limit/skip - add sort by _id for better performance
+
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
-		SetSort(bson.M{"_id": -1}) // Sort by _id descending (most recent first) for better index usage
-	
+		SetSort(bson.M{"_id": -1})
+
 	dbResp, err := e.DB.Find(ctx, bson.D{}, opts)
 	if err != nil {
 		config.ErrorStatus("failed to get ems", http.StatusNotFound, w, err)

--- a/api/handlers/firearm.go
+++ b/api/handlers/firearm.go
@@ -3,11 +3,9 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -35,18 +33,11 @@ type FirearmList struct {
 
 // FirearmHandler returns all firearms
 func (f Firearm) FirearmHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
-	
-	// Use request context with timeout for proper trace tracking and timeout handling
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
+
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
+
 	// Empty filter with limit/skip - add sort by _id for better performance
 	opts := options.Find().
 		SetLimit(limit64).
@@ -104,22 +95,16 @@ func (f Firearm) FirearmByIDHandler(w http.ResponseWriter, r *http.Request) {
 func (f Firearm) FirearmsByUserIDHandler(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("user_id: '%v'", userID)
 	zap.S().Debugf("active_community: '%v'", activeCommunityID)
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
 	var dbResp []models.Firearm
+	var err error
 
 	// If the user is in a community then we want to search for firearms that
 	// are in that same community. This way each user can have different firearms
@@ -127,7 +112,6 @@ func (f Firearm) FirearmsByUserIDHandler(w http.ResponseWriter, r *http.Request)
 	//
 	// Likewise, if the user is not in a community, then we will display only the firearms
 	// that are not in a community
-	err = nil
 	if activeCommunityID != "" && activeCommunityID != "null" && activeCommunityID != "undefined" {
 		dbResp, err = f.DB.Find(ctx, bson.M{
 			"firearm.userID":            userID,
@@ -169,13 +153,7 @@ func (f Firearm) FirearmsByUserIDHandler(w http.ResponseWriter, r *http.Request)
 func (f Firearm) FirearmsByUserIDHandlerV2(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -238,12 +216,12 @@ func (f Firearm) FirearmsByUserIDHandlerV2(w http.ResponseWriter, r *http.Reques
 		dbResp = []models.Firearm{}
 	}
 
-	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	totalPages := int(math.Ceil(float64(totalCount) / float64(limit64)))
 
 	response := map[string]interface{}{
 		"data":       dbResp,
-		"page":       Page,
-		"limit":      Limit,
+		"page":       page64,
+		"limit":      limit64,
 		"totalCount": totalCount,
 		"totalPages": totalPages,
 	}
@@ -260,13 +238,7 @@ func (f Firearm) FirearmsByUserIDHandlerV2(w http.ResponseWriter, r *http.Reques
 // FirearmsByRegisteredOwnerIDHandler returns all firearms that contain the given registeredOwnerID
 func (f Firearm) FirearmsByRegisteredOwnerIDHandler(w http.ResponseWriter, r *http.Request) {
 	registeredOwnerID := mux.Vars(r)["registered_owner_id"]
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil || Limit <= 0 {
-		Limit = 10 // Default limit
-	}
-	limit64 := int64(Limit)
-	Page := getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("registered_owner_id: '%v'", registeredOwnerID)
 
@@ -331,9 +303,9 @@ func (f Firearm) FirearmsByRegisteredOwnerIDHandler(w http.ResponseWriter, r *ht
 
 	// Build the response
 	response := map[string]interface{}{
-		"limit":    Limit,
+		"limit":    limit64,
 		"firearms": dbResp,
-		"page":     Page,
+		"page":     page64,
 		"total":    total,
 	}
 
@@ -458,13 +430,7 @@ func (f Firearm) FirearmsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	serialNumber := r.URL.Query().Get("serialNumber")
 	weaponType := r.URL.Query().Get("weaponType")
 	communityID := r.URL.Query().Get("communityId")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil || Limit <= 0 {
-		Limit = 10 // Default limit
-	}
-	limit64 := int64(Limit)
-	Page := getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
@@ -498,8 +464,9 @@ func (f Firearm) FirearmsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
-		SetSort(bson.M{"_id": -1}) // Sort by _id for better index usage
-	
+		SetSort(bson.M{"_id": -1})
+
+	var err error
 	dbResp, err = f.DB.Find(ctx, query, opts)
 	if err != nil {
 		config.ErrorStatus("failed to search firearms", http.StatusNotFound, w, err)
@@ -511,24 +478,21 @@ func (f Firearm) FirearmsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	if len(query) > 0 {
 		total, err = f.DB.CountDocuments(ctx, query)
 	} else {
-		// Empty query - estimate from results
-		total = limit64 * int64(Page + 1)
+		total = limit64 * (page64 + 1)
 	}
 	if err != nil {
 		config.ErrorStatus("failed to count firearms", http.StatusInternalServerError, w, err)
 		return
 	}
 
-	// Ensure the response is always an array
 	if len(dbResp) == 0 {
 		dbResp = []models.Firearm{}
 	}
 
-	// Build the response
 	response := map[string]interface{}{
-		"limit":    Limit,
+		"limit":    limit64,
 		"firearms": dbResp,
-		"page":     Page,
+		"page":     page64,
 		"total":    total,
 	}
 

--- a/api/handlers/pagination_regression_test.go
+++ b/api/handlers/pagination_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
+	"github.com/linesmerrill/police-cad-api/api"
 	"github.com/linesmerrill/police-cad-api/api/handlers"
 	"github.com/linesmerrill/police-cad-api/databases/mocks"
 	"github.com/linesmerrill/police-cad-api/models"
@@ -39,7 +40,7 @@ func TestCiviliansByUserIDHandler_DefaultLimit(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
 	h.CiviliansByUserIDHandler(httptest.NewRecorder(), req)
 
-	assert.Equal(t, int64(10), gotLimit, "no ?limit= should default to DefaultListLimit (10)")
+	assert.Equal(t, int64(api.DefaultListLimit), gotLimit, "no ?limit= should default to DefaultListLimit")
 	assert.Equal(t, int64(0), gotSkip)
 }
 
@@ -59,7 +60,7 @@ func TestCiviliansByUserIDHandler_CapsExcessiveLimit(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
 	h.CiviliansByUserIDHandler(httptest.NewRecorder(), req)
 
-	assert.Equal(t, int64(100), gotLimit, "over-cap ?limit= should clamp to MaxListLimit (100)")
+	assert.Equal(t, int64(api.MaxListLimit), gotLimit, "over-cap ?limit= should clamp to MaxListLimit")
 }
 
 // Regression: V2 handler used to compute totalPages = math.Ceil(totalCount / Limit)
@@ -97,7 +98,7 @@ func TestVehiclesByUserIDHandler_DefaultLimit(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
 	h.VehiclesByUserIDHandler(httptest.NewRecorder(), req)
 
-	assert.Equal(t, int64(10), gotLimit)
+	assert.Equal(t, int64(api.DefaultListLimit), gotLimit)
 }
 
 func TestFirearmsByUserIDHandler_DefaultLimit(t *testing.T) {
@@ -116,5 +117,5 @@ func TestFirearmsByUserIDHandler_DefaultLimit(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
 	h.FirearmsByUserIDHandler(httptest.NewRecorder(), req)
 
-	assert.Equal(t, int64(10), gotLimit)
+	assert.Equal(t, int64(api.DefaultListLimit), gotLimit)
 }

--- a/api/handlers/pagination_regression_test.go
+++ b/api/handlers/pagination_regression_test.go
@@ -1,0 +1,120 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// These tests guard against regressions of the "SetLimit(0) → unbounded query"
+// bug and the V2 totalPages divide-by-zero that tripped the Mongo
+// "objects returned > 1000" alert. Each case issues a request with no
+// ?limit= param and asserts the handler passes a bounded limit to the DB.
+
+func TestCiviliansByUserIDHandler_DefaultLimit(t *testing.T) {
+	mockDB := &mocks.CivilianDatabase{}
+	h := handlers.Civilian{DB: mockDB}
+
+	var gotLimit, gotSkip int64
+	mockDB.On("Find", mock.Anything, mock.Anything, mock.MatchedBy(func(opts *options.FindOptions) bool {
+		if opts.Limit != nil {
+			gotLimit = *opts.Limit
+		}
+		if opts.Skip != nil {
+			gotSkip = *opts.Skip
+		}
+		return true
+	})).Return([]models.Civilian{}, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/civilians/user/u1", nil)
+	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
+	h.CiviliansByUserIDHandler(httptest.NewRecorder(), req)
+
+	assert.Equal(t, int64(10), gotLimit, "no ?limit= should default to DefaultListLimit (10)")
+	assert.Equal(t, int64(0), gotSkip)
+}
+
+func TestCiviliansByUserIDHandler_CapsExcessiveLimit(t *testing.T) {
+	mockDB := &mocks.CivilianDatabase{}
+	h := handlers.Civilian{DB: mockDB}
+
+	var gotLimit int64
+	mockDB.On("Find", mock.Anything, mock.Anything, mock.MatchedBy(func(opts *options.FindOptions) bool {
+		if opts.Limit != nil {
+			gotLimit = *opts.Limit
+		}
+		return true
+	})).Return([]models.Civilian{}, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/civilians/user/u1?limit=9999", nil)
+	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
+	h.CiviliansByUserIDHandler(httptest.NewRecorder(), req)
+
+	assert.Equal(t, int64(100), gotLimit, "over-cap ?limit= should clamp to MaxListLimit (100)")
+}
+
+// Regression: V2 handler used to compute totalPages = math.Ceil(totalCount / Limit)
+// with Limit=0 when ?limit= was missing, producing +Inf and a bogus response.
+func TestCiviliansByUserIDHandlerV2_NoPanicWithMissingLimit(t *testing.T) {
+	mockDB := &mocks.CivilianDatabase{}
+	h := handlers.Civilian{DB: mockDB}
+
+	mockDB.On("Find", mock.Anything, mock.Anything, mock.Anything).Return([]models.Civilian{}, nil)
+	mockDB.On("CountDocuments", mock.Anything, mock.Anything).Return(int64(0), nil)
+
+	req := httptest.NewRequest("GET", "/api/v2/civilians/user/u1", nil)
+	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		h.CiviliansByUserIDHandlerV2(w, req)
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestVehiclesByUserIDHandler_DefaultLimit(t *testing.T) {
+	mockDB := &mocks.VehicleDatabase{}
+	h := handlers.Vehicle{DB: mockDB}
+
+	var gotLimit int64
+	mockDB.On("Find", mock.Anything, mock.Anything, mock.MatchedBy(func(opts *options.FindOptions) bool {
+		if opts.Limit != nil {
+			gotLimit = *opts.Limit
+		}
+		return true
+	})).Return([]models.Vehicle{}, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/vehicles/user/u1", nil)
+	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
+	h.VehiclesByUserIDHandler(httptest.NewRecorder(), req)
+
+	assert.Equal(t, int64(10), gotLimit)
+}
+
+func TestFirearmsByUserIDHandler_DefaultLimit(t *testing.T) {
+	mockDB := &mocks.FirearmDatabase{}
+	h := handlers.Firearm{DB: mockDB}
+
+	var gotLimit int64
+	mockDB.On("Find", mock.Anything, mock.Anything, mock.MatchedBy(func(opts *options.FindOptions) bool {
+		if opts.Limit != nil {
+			gotLimit = *opts.Limit
+		}
+		return true
+	})).Return([]models.Firearm{}, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/firearms/user/u1", nil)
+	req = mux.SetURLVars(req, map[string]string{"user_id": "u1"})
+	h.FirearmsByUserIDHandler(httptest.NewRecorder(), req)
+
+	assert.Equal(t, int64(10), gotLimit)
+}

--- a/api/handlers/spotlight.go
+++ b/api/handlers/spotlight.go
@@ -2,9 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
@@ -25,24 +23,16 @@ type Spotlight struct {
 
 // SpotlightHandler returns all spotlights
 func (s Spotlight) SpotlightHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	// Empty filter with limit/skip - add sort by _id for better performance
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
-		SetSort(bson.M{"_id": -1}) // Sort by _id descending (most recent first) for better index usage
-	
+		SetSort(bson.M{"_id": -1})
+
 	dbResp, err := s.DB.Find(ctx, bson.D{}, opts)
 	if err != nil {
 		config.ErrorStatus("failed to get spotlight", http.StatusNotFound, w, err)

--- a/api/handlers/vehicle.go
+++ b/api/handlers/vehicle.go
@@ -2,11 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -28,24 +26,16 @@ type Vehicle struct {
 
 // VehicleHandler returns all vehicles
 func (v Vehicle) VehicleHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	// Empty filter with limit/skip - add sort by _id for better performance
 	opts := options.Find().
 		SetLimit(limit64).
 		SetSkip(skip64).
-		SetSort(bson.M{"_id": -1}) // Sort by _id descending (most recent first) for better index usage
-	
+		SetSort(bson.M{"_id": -1})
+
 	dbResp, err := v.DB.Find(ctx, bson.D{}, opts)
 	if err != nil {
 		config.ErrorStatus("failed to get vehicles", http.StatusNotFound, w, err)
@@ -100,22 +90,16 @@ func (v Vehicle) VehicleByIDHandler(w http.ResponseWriter, r *http.Request) {
 func (v Vehicle) VehiclesByUserIDHandler(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("user_id: '%v'", userID)
 	zap.S().Debugf("active_community: '%v'", activeCommunityID)
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
 	var dbResp []models.Vehicle
+	var err error
 
 	// If the user is in a community then we want to search for vehicles that
 	// are in that same community. This way each user can have different vehicles
@@ -123,7 +107,6 @@ func (v Vehicle) VehiclesByUserIDHandler(w http.ResponseWriter, r *http.Request)
 	//
 	// Likewise, if the user is not in a community, then we will display only the vehicles
 	// that are not in a community
-	err = nil
 	if activeCommunityID != "" && activeCommunityID != "null" && activeCommunityID != "undefined" {
 		dbResp, err = v.DB.Find(ctx, bson.M{
 			"vehicle.userID":            userID,
@@ -165,13 +148,7 @@ func (v Vehicle) VehiclesByUserIDHandler(w http.ResponseWriter, r *http.Request)
 func (v Vehicle) VehiclesByUserIDHandlerV2(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	activeCommunityID := r.URL.Query().Get("active_community_id")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -234,12 +211,12 @@ func (v Vehicle) VehiclesByUserIDHandlerV2(w http.ResponseWriter, r *http.Reques
 		dbResp = []models.Vehicle{}
 	}
 
-	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	totalPages := int(math.Ceil(float64(totalCount) / float64(limit64)))
 
 	response := map[string]interface{}{
 		"data":       dbResp,
-		"page":       Page,
-		"limit":      Limit,
+		"page":       page64,
+		"limit":      limit64,
 		"totalCount": totalCount,
 		"totalPages": totalPages,
 	}
@@ -256,13 +233,7 @@ func (v Vehicle) VehiclesByUserIDHandlerV2(w http.ResponseWriter, r *http.Reques
 // VehiclesByRegisteredOwnerIDHandler returns all vehicles that contain the given registeredOwnerID
 func (v Vehicle) VehiclesByRegisteredOwnerIDHandler(w http.ResponseWriter, r *http.Request) {
 	registeredOwnerID := mux.Vars(r)["registered_owner_id"]
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil || Limit <= 0 {
-		Limit = 10 // Default limit
-	}
-	limit64 := int64(Limit)
-	Page = getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("registered_owner_id: '%v'", registeredOwnerID)
 
@@ -327,9 +298,9 @@ func (v Vehicle) VehiclesByRegisteredOwnerIDHandler(w http.ResponseWriter, r *ht
 
 	// Build the response
 	response := map[string]interface{}{
-		"limit":    Limit,
+		"limit":    limit64,
 		"vehicles": dbResp,
-		"page":     Page,
+		"page":     page64,
 		"total":    total,
 	}
 
@@ -350,13 +321,7 @@ func (v Vehicle) VehicleSearchHandler(w http.ResponseWriter, r *http.Request) {
 	vehMake := r.URL.Query().Get("make")
 	model := r.URL.Query().Get("model")
 	activeCommunityID := r.URL.Query().Get("active_community_id") // optional
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil || Limit <= 0 {
-		Limit = 10 // Default limit
-	}
-	limit64 := int64(Limit)
-	Page := getPage(Page, r)
-	skip64 := int64(Page * Limit)
+	limit64, page64, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("plate: '%v'", plate)
 	zap.S().Debugf("vin: '%v'", vin)
@@ -440,9 +405,9 @@ func (v Vehicle) VehicleSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Build the response
 	response := map[string]interface{}{
-		"limit":    Limit,
+		"limit":    limit64,
 		"vehicles": dbResp,
-		"page":     Page,
+		"page":     page64,
 		"total":    total,
 	}
 

--- a/api/handlers/warrant.go
+++ b/api/handlers/warrant.go
@@ -30,13 +30,7 @@ type Warrant struct {
 
 // WarrantHandler returns all warrants
 func (v Warrant) WarrantHandler(w http.ResponseWriter, r *http.Request) {
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v, err: %v", Limit|10, err))
-	}
-	limit64 := int64(Limit)
-	page := getPage(0, r)
-	skip64 := int64(page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -98,13 +92,7 @@ func (v Warrant) WarrantByIDHandler(w http.ResponseWriter, r *http.Request) {
 func (v Warrant) WarrantsByUserIDHandler(w http.ResponseWriter, r *http.Request) {
 	userID := mux.Vars(r)["user_id"]
 	status := r.URL.Query().Get("status")
-	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		zap.S().Warnf(fmt.Sprintf("limit not set, using default of %v", Limit|10))
-	}
-	limit64 := int64(Limit)
-	page := getPage(0, r)
-	skip64 := int64(page * Limit)
+	limit64, _, skip64 := api.ParseLimitPage(r, api.DefaultListLimit, api.MaxListLimit)
 
 	zap.S().Debugf("user_id: '%v'", userID)
 

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+)
+
+const (
+	DefaultListLimit = 10
+	MaxListLimit     = 100
+)
+
+// ParseLimitPage parses ?limit and ?page query parameters with safe defaults.
+// Missing, zero, negative, or non-numeric limits fall back to defaultLimit.
+// Limits exceeding maxLimit are clamped to maxLimit. Page is clamped to >= 0.
+// Returns the parsed limit, page, and pre-computed skip (page * limit).
+//
+// This replaces the broken `Limit|10` pattern where SetLimit(0) sent to MongoDB
+// returned the entire matching set, tripping the "objects returned > 1000" alert.
+func ParseLimitPage(r *http.Request, defaultLimit, maxLimit int) (limit, page, skip int64) {
+	limit = int64(defaultLimit)
+	if v, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && v > 0 {
+		if v > maxLimit {
+			v = maxLimit
+		}
+		limit = int64(v)
+	}
+	if v, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && v >= 0 {
+		page = int64(v)
+	}
+	skip = page * limit
+	return
+}

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -6,7 +6,15 @@ import (
 )
 
 const (
-	DefaultListLimit = 10
+	// TODO: revert DefaultListLimit to 10 after mobile app v1.22.0 has rolled
+	// out via the App Store and Play Store. v1.22.0 explicitly sends
+	// `limit=100&page=0` on every list call, so the server default only
+	// affects older clients. While 1.22.0 is pending store review, a default
+	// of 10 truncates inventories for users on older builds (they appear to
+	// only have 10 civilians/vehicles/firearms). Bumping the default to 100
+	// restores near-original behavior for those clients until the new
+	// release is live.
+	DefaultListLimit = 100
 	MaxListLimit     = 100
 )
 

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseLimitPage(t *testing.T) {
+	const defaultLimit = 10
+	const maxLimit = 100
+
+	tests := []struct {
+		name      string
+		query     string
+		wantLimit int64
+		wantPage  int64
+		wantSkip  int64
+	}{
+		{"no params", "", 10, 0, 0},
+		{"empty limit", "limit=", 10, 0, 0},
+		{"zero limit", "limit=0", 10, 0, 0},
+		{"negative limit", "limit=-5", 10, 0, 0},
+		{"non-numeric limit", "limit=abc", 10, 0, 0},
+		{"valid limit", "limit=25", 25, 0, 0},
+		{"limit at cap", "limit=100", 100, 0, 0},
+		{"over cap", "limit=500", 100, 0, 0},
+		{"huge over cap", "limit=9999", 100, 0, 0},
+		{"page only", "page=3", 10, 3, 30},
+		{"negative page", "page=-2", 10, 0, 0},
+		{"non-numeric page", "page=abc", 10, 0, 0},
+		{"limit and page", "limit=20&page=2", 20, 2, 40},
+		{"limit and page at cap", "limit=100&page=5", 100, 5, 500},
+		{"over-cap with page", "limit=1000&page=1", 100, 1, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/?"+tt.query, nil)
+			limit, page, skip := ParseLimitPage(req, defaultLimit, maxLimit)
+			if limit != tt.wantLimit {
+				t.Errorf("limit = %d, want %d", limit, tt.wantLimit)
+			}
+			if page != tt.wantPage {
+				t.Errorf("page = %d, want %d", page, tt.wantPage)
+			}
+			if skip != tt.wantSkip {
+				t.Errorf("skip = %d, want %d", skip, tt.wantSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the MongoDB Atlas *"objects returned greater than 1000"* alert.

v1 **and** v2 list handlers share a broken default-limit pattern:
```go
Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
if err != nil { zap.S().Warnf("...default of %v", Limit|10) } // misleading
limit64 := int64(Limit)                                        // Limit is still 0
opts := options.Find().SetLimit(limit64)                       // Mongo: SetLimit(0) = NO LIMIT
```

When a client omits `?limit=`, the handler returns **the entire matching set**. V2 variants also crash `totalPages = math.Ceil(totalCount / Limit)` with `Limit=0` -> `+Inf`.

### What changed

- New `api.ParseLimitPage(r, defaultLimit, maxLimit)` helper with default **10** and max **100** (matches existing v2 conventions in community/user/announcement handlers).
- Applied in 14 handlers across 7 files (call, civilian x4, vehicle x5, firearm x5, warrant x2, ems, spotlight).
- Fixed `totalPages` divisor in V2 handlers to use the clamped `limit64` (guaranteed >= 1).
- Dropped the misleading `limit not set` Warn log.
- Removed the racy package-level `var Page = 0` global in civilian.go (mutated from every handler -> data race under concurrent requests).

### Regression tests

`api/handlers/pagination_regression_test.go`:
- Missing `?limit=` -> handler passes `SetLimit(10)` to the mock DB.
- `?limit=9999` -> capped to `SetLimit(100)`.
- V2 handler with empty results does not panic / return `+Inf` when no limit supplied.

`api/pagination_test.go`: 15 table-driven cases for the helper (missing / empty / zero / negative / over-cap / valid / non-numeric / combinations).

## Test plan

- [ ] `go build -C police-cad-api -mod=mod ./...` passes locally
- [ ] `go test -C police-cad-api -mod=mod ./...` passes (except pre-existing `TestCreatePanicAlertHandler` flake, reproducible on main)
- [ ] Deploy to `police-cad-dev`; confirm `/api/v1/civilians/user/{id}` (no params) returns <= 10 items
- [ ] Confirm `limit=500` is clamped to 100 server-side
- [ ] Monitor 24h: zap "limit not set" warnings stop appearing
- [ ] Monitor 24h: Atlas "objects returned > 1000" alert clears for `calls`, `civilians`, `vehicles`, `firearms`, `warrants`, `ems`, `spotlights`

## Follow-ups (separate PRs)

- Mobile: explicit `?limit=100&page=0` in `services/{civilians,vehicles,firearms}.js` + infinite-scroll UI on the 6 screens that expect full inventory lists
- Website: replace dispatch-dashboard `callMembersCache` with lazy batch-resolve via `POST /api/v1/users`

See /Users/merrill/.claude/plans/lively-sprouting-beacon.md for the full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)