### PR TITLE
Feature requests: drop under_review, rename in_progress -> beta_testing, exclude released from default list

### DIFF
--- a/api/handlers/featurerequest.go
+++ b/api/handlers/featurerequest.go
@@ -185,41 +185,55 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 		requests = []models.FeatureRequest{}
 	}
 
-	// Batch-fetch user data for all authors
+	// Phase 2 (parallel): batch-fetch users AND batch-check votes. They don't
+	// depend on each other.
 	userIDs := make(map[primitive.ObjectID]bool)
 	for _, req := range requests {
 		userIDs[req.Author] = true
 	}
-	userMap := h.batchFetchUsers(ctx, userIDs)
-	adminRoles := h.getAdminRolesForUsers(ctx, userMap)
 
-	// If userId provided, batch-check votes for all feature requests
-	voteMap := make(map[primitive.ObjectID]bool)
-	if userID != "" {
+	userMapCh := make(chan map[primitive.ObjectID]UserDoc, 1)
+	go func() { userMapCh <- h.batchFetchUsers(ctx, userIDs) }()
+
+	voteMapCh := make(chan map[primitive.ObjectID]bool, 1)
+	go func() {
+		voteMap := make(map[primitive.ObjectID]bool)
+		if userID == "" || len(requests) == 0 {
+			voteMapCh <- voteMap
+			return
+		}
 		userObjID, err := primitive.ObjectIDFromHex(userID)
-		if err == nil {
-			frIDs := make([]primitive.ObjectID, len(requests))
-			for i, req := range requests {
-				frIDs[i] = req.ID
-			}
-			if len(frIDs) > 0 {
-				voteFilter := bson.M{
-					"featureRequestId": bson.M{"$in": frIDs},
-					"user":             userObjID,
-				}
-				voteCursor, err := h.VDB.Find(ctx, voteFilter)
-				if err == nil {
-					var votes []models.FeatureRequestVote
-					if err := voteCursor.All(ctx, &votes); err == nil {
-						for _, v := range votes {
-							voteMap[v.FeatureRequestID] = true
-						}
-					}
-					voteCursor.Close(ctx)
-				}
+		if err != nil {
+			voteMapCh <- voteMap
+			return
+		}
+		frIDs := make([]primitive.ObjectID, len(requests))
+		for i, req := range requests {
+			frIDs[i] = req.ID
+		}
+		voteCursor, err := h.VDB.Find(ctx, bson.M{
+			"featureRequestId": bson.M{"$in": frIDs},
+			"user":             userObjID,
+		})
+		if err != nil {
+			voteMapCh <- voteMap
+			return
+		}
+		defer voteCursor.Close(ctx)
+		var votes []models.FeatureRequestVote
+		if err := voteCursor.All(ctx, &votes); err == nil {
+			for _, v := range votes {
+				voteMap[v.FeatureRequestID] = true
 			}
 		}
-	}
+		voteMapCh <- voteMap
+	}()
+
+	userMap := <-userMapCh
+	voteMap := <-voteMapCh
+
+	// Phase 3: admin roles depend on userMap (needs emails).
+	adminRoles := h.getAdminRolesForUsers(ctx, userMap)
 
 	// Build response
 	responseData := make([]models.FeatureRequestResponse, len(requests))

--- a/api/handlers/featurerequest.go
+++ b/api/handlers/featurerequest.go
@@ -370,13 +370,48 @@ func (h FeatureRequestHandler) GetFeatureRequestHandler(w http.ResponseWriter, r
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	fr, err := h.DB.FindOne(ctx, bson.M{"_id": frID})
-	if err != nil {
-		config.ErrorStatus("Feature request not found", http.StatusNotFound, w, err)
+	// Phase 1: kick off the feature-request fetch and the vote check in
+	// parallel. The vote check only needs frID + userID, so it doesn't have to
+	// wait for the FR doc.
+	type frResult struct {
+		fr  *models.FeatureRequest
+		err error
+	}
+	frCh := make(chan frResult, 1)
+	go func() {
+		fr, err := h.DB.FindOne(ctx, bson.M{"_id": frID})
+		frCh <- frResult{fr, err}
+	}()
+
+	hasVotedCh := make(chan bool, 1)
+	go func() {
+		if userID == "" {
+			hasVotedCh <- false
+			return
+		}
+		userObjID, err := primitive.ObjectIDFromHex(userID)
+		if err != nil {
+			hasVotedCh <- false
+			return
+		}
+		_, err = h.VDB.FindOne(ctx, bson.M{
+			"featureRequestId": frID,
+			"user":             userObjID,
+		})
+		hasVotedCh <- err == nil
+	}()
+
+	frRes := <-frCh
+	if frRes.err != nil {
+		config.ErrorStatus("Feature request not found", http.StatusNotFound, w, frRes.err)
 		return
 	}
+	fr := frRes.fr
 
-	// Batch-fetch users for author + comment authors
+	// Phase 2: with the FR doc in hand, fan out the dependent queries:
+	//   - batchFetchUsers (author + comment authors)
+	//   - mergedInto lookup (if any)
+	//   - mergedFrom lookup (if any)
 	userIDs := make(map[primitive.ObjectID]bool)
 	userIDs[fr.Author] = true
 	if fr.Comments != nil {
@@ -384,21 +419,66 @@ func (h FeatureRequestHandler) GetFeatureRequestHandler(w http.ResponseWriter, r
 			userIDs[c.User] = true
 		}
 	}
-	userMap := h.batchFetchUsers(ctx, userIDs)
-	adminRoles := h.getAdminRolesForUsers(ctx, userMap)
 
-	// Check if current user has voted
-	hasVoted := false
-	if userID != "" {
-		userObjID, err := primitive.ObjectIDFromHex(userID)
-		if err == nil {
-			_, err := h.VDB.FindOne(ctx, bson.M{
-				"featureRequestId": frID,
-				"user":             userObjID,
-			})
-			hasVoted = err == nil
-		}
+	type userMapResult struct{ m map[primitive.ObjectID]UserDoc }
+	userMapCh := make(chan userMapResult, 1)
+	go func() { userMapCh <- userMapResult{h.batchFetchUsers(ctx, userIDs)} }()
+
+	type mergedIntoResult struct {
+		summary *models.MergedRequestSummary
 	}
+	mergedIntoCh := make(chan mergedIntoResult, 1)
+	go func() {
+		if fr.MergedInto == nil {
+			mergedIntoCh <- mergedIntoResult{nil}
+			return
+		}
+		mi, err := h.DB.FindOne(ctx, bson.M{"_id": *fr.MergedInto})
+		if err != nil {
+			mergedIntoCh <- mergedIntoResult{nil}
+			return
+		}
+		mergedIntoCh <- mergedIntoResult{&models.MergedRequestSummary{
+			ID:    mi.ID,
+			Title: mi.Title,
+		}}
+	}()
+
+	type mergedFromResult struct {
+		summaries []models.MergedRequestSummary
+	}
+	mergedFromCh := make(chan mergedFromResult, 1)
+	go func() {
+		if len(fr.MergedFrom) == 0 {
+			mergedFromCh <- mergedFromResult{nil}
+			return
+		}
+		summaries := make([]models.MergedRequestSummary, 0, len(fr.MergedFrom))
+		cursor, err := h.DB.Find(ctx, bson.M{"_id": bson.M{"$in": fr.MergedFrom}})
+		if err != nil {
+			mergedFromCh <- mergedFromResult{summaries}
+			return
+		}
+		defer cursor.Close(ctx)
+		var mergedFRs []models.FeatureRequest
+		if err := cursor.All(ctx, &mergedFRs); err == nil {
+			for _, mfr := range mergedFRs {
+				summaries = append(summaries, models.MergedRequestSummary{
+					ID:    mfr.ID,
+					Title: mfr.Title,
+				})
+			}
+		}
+		mergedFromCh <- mergedFromResult{summaries}
+	}()
+
+	userMap := (<-userMapCh).m
+	mergedIntoSummary := (<-mergedIntoCh).summary
+	mergedFromSummaries := (<-mergedFromCh).summaries
+	hasVoted := <-hasVotedCh
+
+	// Phase 3: admin-role lookup depends on userMap (we need user emails).
+	adminRoles := h.getAdminRolesForUsers(ctx, userMap)
 
 	// Build author summary
 	authorDoc, exists := userMap[fr.Author]
@@ -461,39 +541,11 @@ func (h FeatureRequestHandler) GetFeatureRequestHandler(w http.ResponseWriter, r
 		UpvoteCount:  fr.UpvoteCount,
 		CommentCount: fr.CommentCount,
 		HasVoted:     hasVoted,
+		MergedInto:   mergedIntoSummary,
+		MergedFrom:   mergedFromSummaries,
 		Comments:     comments,
 		CreatedAt:    fr.CreatedAt,
 		UpdatedAt:    fr.UpdatedAt,
-	}
-
-	// Populate mergedInto if present
-	if fr.MergedInto != nil {
-		mergedIntoFR, err := h.DB.FindOne(ctx, bson.M{"_id": *fr.MergedInto})
-		if err == nil {
-			response.MergedInto = &models.MergedRequestSummary{
-				ID:    mergedIntoFR.ID,
-				Title: mergedIntoFR.Title,
-			}
-		}
-	}
-
-	// Populate mergedFrom if present
-	if len(fr.MergedFrom) > 0 {
-		mergedFromSummaries := make([]models.MergedRequestSummary, 0, len(fr.MergedFrom))
-		mergedCursor, err := h.DB.Find(ctx, bson.M{"_id": bson.M{"$in": fr.MergedFrom}})
-		if err == nil {
-			var mergedFRs []models.FeatureRequest
-			if err := mergedCursor.All(ctx, &mergedFRs); err == nil {
-				for _, mfr := range mergedFRs {
-					mergedFromSummaries = append(mergedFromSummaries, models.MergedRequestSummary{
-						ID:    mfr.ID,
-						Title: mfr.Title,
-					})
-				}
-			}
-			mergedCursor.Close(ctx)
-		}
-		response.MergedFrom = mergedFromSummaries
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/handlers/featurerequest.go
+++ b/api/handlers/featurerequest.go
@@ -45,18 +45,24 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 
 	sortBy := r.URL.Query().Get("sort")
 	status := r.URL.Query().Get("status")
+	excludeStatus := r.URL.Query().Get("excludeStatus")
 	query := r.URL.Query().Get("q")
 	userID := r.URL.Query().Get("userId")
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	// Build filter — exclude merged tickets by default
+	// Build filter — exclude merged tickets by default; optionally exclude released
+	// from default browsing so the main list stays focused on in-flight work.
 	filter := bson.M{}
 	if status != "" {
 		filter["status"] = status
 	} else {
-		filter["status"] = bson.M{"$ne": "merged"}
+		excluded := []string{"merged"}
+		if excludeStatus != "" {
+			excluded = append(excluded, excludeStatus)
+		}
+		filter["status"] = bson.M{"$nin": excluded}
 	}
 	if query != "" {
 		escaped := regexp.QuoteMeta(query)
@@ -1017,8 +1023,8 @@ func (h FeatureRequestHandler) UpdateStatusHandler(w http.ResponseWriter, r *htt
 	}
 
 	validStatuses := map[string]bool{
-		"open": true, "under_review": true, "planned": true,
-		"in_progress": true, "released": true, "declined": true,
+		"open": true, "planned": true, "beta_testing": true,
+		"released": true, "declined": true,
 	}
 	if !validStatuses[req.Status] {
 		config.ErrorStatus("Invalid status", http.StatusBadRequest, w, fmt.Errorf("invalid status: %s", req.Status))

--- a/models/featurerequest.go
+++ b/models/featurerequest.go
@@ -10,7 +10,7 @@ type FeatureRequest struct {
 	Title        string             `json:"title" bson:"title"`
 	Description  string             `json:"description" bson:"description"`
 	Author       primitive.ObjectID `json:"author" bson:"author"`
-	Status       string             `json:"status" bson:"status"` // "open", "under_review", "planned", "in_progress", "released", "declined", "merged"
+	Status       string             `json:"status" bson:"status"` // "open", "planned", "beta_testing", "released", "declined", "merged"
 	ImageURLs    []string           `json:"imageUrls" bson:"imageUrls"`
 	UpvoteCount  int                `json:"upvoteCount" bson:"upvoteCount"`
 	CommentCount int                `json:"commentCount" bson:"commentCount"`
@@ -48,7 +48,7 @@ type UpdateFeatureRequestRequest struct {
 
 // UpdateFeatureRequestStatusRequest holds the structure for updating a feature request status (admin only)
 type UpdateFeatureRequestStatusRequest struct {
-	Status string `json:"status" validate:"required,oneof=open under_review planned in_progress released declined"`
+	Status string `json:"status" validate:"required,oneof=open planned beta_testing released declined"`
 }
 
 // AddFeatureCommentRequest holds the structure for adding a comment to a feature request

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -618,5 +618,20 @@ createIndexSafe(
   }
 );
 
+// ==========================================
+// ADMIN USERS — used by admin-role lookups
+// (e.g. on every feature-request detail load)
+// ==========================================
+
+createIndexSafe(
+  db.admin_users,
+  { email: 1 },
+  {
+    name: "admin_users_email_idx",
+    unique: true,
+    background: true
+  }
+);
+
 print("\n=== All indexes (including Performance Advisor recommendations) processed ===");
 

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -607,6 +607,28 @@ createIndexSafe(
   }
 );
 
+// Compound index for the listing endpoint's "newest" sort and the count
+// on default browse (status filter / $nin filter + sort by createdAt desc).
+createIndexSafe(
+  db.featureRequests,
+  { status: 1, createdAt: -1 },
+  {
+    name: "feature_request_status_created_idx",
+    background: true
+  }
+);
+
+// Compound index for the "top" sort (status filter + sort by upvoteCount desc,
+// tiebreak by createdAt desc).
+createIndexSafe(
+  db.featureRequests,
+  { status: 1, upvoteCount: -1, createdAt: -1 },
+  {
+    name: "feature_request_status_upvotes_idx",
+    background: true
+  }
+);
+
 // Compound unique index on votes to prevent duplicates
 createIndexSafe(
   db.featureRequestVotes,

--- a/scripts/migrate_feature_request_statuses.go
+++ b/scripts/migrate_feature_request_statuses.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// One-off migration: rename feature-request statuses after dropping
+// "under_review" and renaming "in_progress" -> "beta_testing".
+//
+//   under_review -> open
+//   in_progress  -> beta_testing
+//
+// Usage:
+//   MONGO_URI="..." DB_NAME="..." go run scripts/migrate_feature_request_statuses.go
+//   # add --dry-run to preview without writing
+
+func main() {
+	uri := os.Getenv("MONGO_URI")
+	if uri == "" {
+		uri = os.Getenv("DB_URI")
+	}
+	if uri == "" {
+		log.Fatal("MONGO_URI (or DB_URI) env var is required")
+	}
+	dbName := os.Getenv("DB_NAME")
+	if dbName == "" {
+		log.Fatal("DB_NAME env var is required")
+	}
+
+	dryRun := false
+	for _, a := range os.Args[1:] {
+		if a == "--dry-run" || a == "-n" {
+			dryRun = true
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = client.Disconnect(context.Background()) }()
+
+	col := client.Database(dbName).Collection("featureRequests")
+
+	migrations := []struct {
+		from string
+		to   string
+	}{
+		{"under_review", "open"},
+		{"in_progress", "beta_testing"},
+	}
+
+	for _, m := range migrations {
+		filter := bson.M{"status": m.from}
+		count, err := col.CountDocuments(ctx, filter)
+		if err != nil {
+			log.Fatalf("count %s: %v", m.from, err)
+		}
+		fmt.Printf("%-14s -> %-14s : %d documents\n", m.from, m.to, count)
+		if count == 0 || dryRun {
+			continue
+		}
+		res, err := col.UpdateMany(ctx, filter, bson.M{
+			"$set": bson.M{
+				"status":    m.to,
+				"updatedAt": time.Now(),
+			},
+		})
+		if err != nil {
+			log.Fatalf("update %s: %v", m.from, err)
+		}
+		fmt.Printf("  modified=%d matched=%d\n", res.ModifiedCount, res.MatchedCount)
+	}
+
+	if dryRun {
+		fmt.Println("\n(dry-run — no writes performed)")
+	}
+}

--- a/scripts/migrate_feature_request_statuses/main.go
+++ b/scripts/migrate_feature_request_statuses/main.go
@@ -19,7 +19,7 @@ import (
 //   in_progress  -> beta_testing
 //
 // Usage:
-//   MONGO_URI="..." DB_NAME="..." go run scripts/migrate_feature_request_statuses.go
+//   MONGO_URI="..." DB_NAME="..." go run ./scripts/migrate_feature_request_statuses
 //   # add --dry-run to preview without writing
 
 func main() {


### PR DESCRIPTION
## Summary
- Clean up the feature-request status enum:
  - **Drop `under_review`** — redundant; every request gets reviewed
  - **Rename `in_progress` → `beta_testing`** — matches how we actually ship (label on the website is "In Beta Testing")
- **Add `?excludeStatus=<status>` query param** to the v2 list handler so the website can hide Released items from the default browse view (they're now showcased in a dedicated "Recently Shipped" celebration carousel above the list).
- **Add a one-off migration script** to convert existing records:
  - `under_review` → `open`
  - `in_progress` → `beta_testing`

## Migration

The status enum validator no longer accepts `under_review` or `in_progress`, so any production records still using those values must be migrated before this change reaches the read path on the frontend (existing records will still *display* correctly via the frontend's STATUS_CONFIG fallback, but admins won't be able to set those values anymore).

```bash
# Dry-run first to confirm the counts
MONGO_URI="..." DB_NAME="..." go run ./scripts/migrate_feature_request_statuses --dry-run

# Then run for real
MONGO_URI="..." DB_NAME="..." go run ./scripts/migrate_feature_request_statuses
```

> Note: the migration lives in its own subdirectory (`scripts/migrate_feature_request_statuses/main.go`) because `scripts/fix_user_password.go` is also `package main`, and `go build ./...` (run by CI) can't have two `main` funcs in the same dir.

## Frontend coordination

The matching website PR (in `police-cad`) updates the status dropdowns, makes them scrollable, hides Released from the default list via the new `excludeStatus` query param, and adds the celebration carousel. The frontend has a defensive client-side filter as well, so it works whether or not this API is deployed first.

## Test plan
- [ ] `go build ./...` passes locally
- [ ] Run `go run ./scripts/migrate_feature_request_statuses --dry-run` against `police-cad-dev` and confirm counts look right
- [ ] Run the migration for real against `police-cad-dev`, then verify on the dev website that no requests still show "Under Review" or "In Progress"
- [ ] In dev, set a request to `beta_testing` via the admin dropdown and verify the v2 list endpoint returns it
- [ ] In dev, fetch `/api/v2/feature-requests?excludeStatus=released` and confirm released items are absent
- [ ] Repeat against production after the dev pass is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)