### PR TITLE
feat(forms): configurable forms system + Incident Report default

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -75,6 +75,7 @@ func (a *App) New() *mux.Router {
 		VDB:    formTemplateVersionDB,
 		CDB:    formCounterDB,
 		UDB:    databases.NewUserDatabase(a.dbHelper),
+		CommDB: databases.NewCommunityDatabase(a.dbHelper),
 		CallDB: databases.NewCallDatabase(a.dbHelper),
 		ARDB:   databases.NewArrestReportDatabase(a.dbHelper),
 		CivDB:  databases.NewCivilianDatabase(a.dbHelper),

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -55,6 +55,29 @@ func (a *App) New() *mux.Router {
 	call := Call{DB: databases.NewCallDatabase(a.dbHelper)}
 	bolo := Bolo{DB: databases.NewBoloDatabase(a.dbHelper)}
 	arrestReport := ArrestReport{DB: databases.NewArrestReportDatabase(a.dbHelper)}
+
+	// Configurable forms (form templates, versions, department toggles, submissions)
+	formTemplateDB := databases.NewFormTemplateDatabase(a.dbHelper)
+	formTemplateVersionDB := databases.NewFormTemplateVersionDatabase(a.dbHelper)
+	departmentFormToggleDB := databases.NewDepartmentFormToggleDatabase(a.dbHelper)
+	formSubmissionDB := databases.NewFormSubmissionDatabase(a.dbHelper)
+	formCounterDB := databases.NewFormCounterDatabase(a.dbHelper)
+	formTemplate := FormTemplate{
+		DB:  formTemplateDB,
+		VDB: formTemplateVersionDB,
+		TDB: departmentFormToggleDB,
+	}
+	departmentFormToggle := DepartmentFormToggle{DB: departmentFormToggleDB}
+	formSubmission := FormSubmission{
+		DB:     formSubmissionDB,
+		TDB:    formTemplateDB,
+		VDB:    formTemplateVersionDB,
+		CDB:    formCounterDB,
+		UDB:    databases.NewUserDatabase(a.dbHelper),
+		CallDB: databases.NewCallDatabase(a.dbHelper),
+		ARDB:   databases.NewArrestReportDatabase(a.dbHelper),
+		CivDB:  databases.NewCivilianDatabase(a.dbHelper),
+	}
 	s := Spotlight{DB: databases.NewSpotlightDatabase(a.dbHelper)}
 	search := Search{UserDB: databases.NewUserDatabase(a.dbHelper), CommDB: databases.NewCommunityDatabase(a.dbHelper)}
 	report := Report{RDB: databases.NewReportDatabase(a.dbHelper)}
@@ -443,6 +466,27 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/warrants/search", api.Middleware(http.HandlerFunc(w.WarrantsSearchHandler))).Methods("GET")
 	apiCreate.Handle("/warrants/pending/community/{community_id}", api.Middleware(http.HandlerFunc(w.PendingWarrantsByCommunityHandler))).Methods("GET")
 	apiV2.Handle("/warrants/community/{community_id}", api.Middleware(http.HandlerFunc(w.WarrantsByCommunityHandlerV2))).Methods("GET")
+
+	// Configurable forms — templates
+	apiCreate.Handle("/form-template", api.Middleware(http.HandlerFunc(formTemplate.CreateFormTemplateHandler))).Methods("POST")
+	apiCreate.Handle("/form-template/{template_id}/versions", api.Middleware(http.HandlerFunc(formTemplate.FormTemplateVersionsHandler))).Methods("GET")
+	apiCreate.Handle("/form-template/{template_id}", api.Middleware(http.HandlerFunc(formTemplate.FormTemplateByIDHandler))).Methods("GET")
+	apiCreate.Handle("/form-template/{template_id}", api.Middleware(http.HandlerFunc(formTemplate.UpdateFormTemplateHandler))).Methods("PUT")
+	apiCreate.Handle("/form-template/community/{community_id}/default/{slug}/hide", api.Middleware(http.HandlerFunc(formTemplate.HideDefaultFormTemplateHandler))).Methods("PUT")
+	apiV2.Handle("/form-templates/community/{community_id}", api.Middleware(http.HandlerFunc(formTemplate.FormTemplatesByCommunityHandlerV2))).Methods("GET")
+	apiV2.Handle("/form-templates/department/{dept_id}", api.Middleware(http.HandlerFunc(formTemplate.FormTemplatesByDepartmentHandlerV2))).Methods("GET")
+
+	// Configurable forms — department toggles
+	apiCreate.Handle("/department/{dept_id}/form-toggle/{slug}", api.Middleware(http.HandlerFunc(departmentFormToggle.SetDepartmentFormToggleHandler))).Methods("PUT")
+
+	// Configurable forms — submissions
+	apiCreate.Handle("/form-submission/draft", api.Middleware(http.HandlerFunc(formSubmission.FormSubmissionDraftHandler))).Methods("POST")
+	apiCreate.Handle("/form-submission/{submission_id}", api.Middleware(http.HandlerFunc(formSubmission.FormSubmissionByIDHandler))).Methods("GET")
+	apiCreate.Handle("/form-submission/{submission_id}", api.Middleware(http.HandlerFunc(formSubmission.UpdateFormSubmissionHandler))).Methods("PUT")
+	apiCreate.Handle("/form-submission/{submission_id}", api.Middleware(http.HandlerFunc(formSubmission.DeleteFormSubmissionHandler))).Methods("DELETE")
+	apiCreate.Handle("/form-submission", api.Middleware(http.HandlerFunc(formSubmission.CreateFormSubmissionHandler))).Methods("POST")
+	apiV2.Handle("/form-submissions/community/{community_id}", api.Middleware(http.HandlerFunc(formSubmission.FormSubmissionsByCommunityHandlerV2))).Methods("GET")
+	apiV2.Handle("/form-submissions/by-link/{link_type}/{link_id}", api.Middleware(http.HandlerFunc(formSubmission.FormSubmissionsByLinkHandlerV2))).Methods("GET")
 
 	// Court case routes
 	apiV2.Handle("/court-cases/{case_id}/assign", api.Middleware(http.HandlerFunc(courtCaseHandler.AssignCourtCaseHandler))).Methods("PUT")

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -78,6 +78,8 @@ func (a *App) New() *mux.Router {
 		CallDB: databases.NewCallDatabase(a.dbHelper),
 		ARDB:   databases.NewArrestReportDatabase(a.dbHelper),
 		CivDB:  databases.NewCivilianDatabase(a.dbHelper),
+		VehDB:  databases.NewVehicleDatabase(a.dbHelper),
+		FirDB:  databases.NewFirearmDatabase(a.dbHelper),
 	}
 	s := Spotlight{DB: databases.NewSpotlightDatabase(a.dbHelper)}
 	search := Search{UserDB: databases.NewUserDatabase(a.dbHelper), CommDB: databases.NewCommunityDatabase(a.dbHelper)}
@@ -571,6 +573,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/arrest-report/{arrest_report_id}", api.Middleware(http.HandlerFunc(arrestReport.DeleteArrestReportHandler))).Methods("DELETE")
 	apiCreate.Handle("/arrest-report", api.Middleware(http.HandlerFunc(arrestReport.CreateArrestReportHandler))).Methods("POST")
 	apiCreate.Handle("/arrest-report/arrestee/{arrestee_id}", api.Middleware(http.HandlerFunc(arrestReport.GetArrestReportsByArresteeIDHandler))).Methods("GET")
+	apiV2.Handle("/arrest-reports/community/{community_id}", api.Middleware(http.HandlerFunc(arrestReport.GetArrestReportsByCommunityHandler))).Methods("GET")
 
 	// Medical Reports routes
 	apiCreate.Handle("/medical-reports", api.Middleware(http.HandlerFunc(medicalReportHandler.GetMedicalReportsHandler))).Methods("GET")

--- a/api/handlers/arrestReport.go
+++ b/api/handlers/arrestReport.go
@@ -149,6 +149,53 @@ func (a ArrestReport) DeleteArrestReportHandler(w http.ResponseWriter, r *http.R
 	w.Write([]byte(`{"message": "Arrest report deleted successfully"}`))
 }
 
+// GetArrestReportsByCommunityHandler returns paginated arrest reports for a
+// community, sorted most-recent-first. Used by the configurable forms picker
+// so officers can start a report from an existing arrest record.
+func (a ArrestReport) GetArrestReportsByCommunityHandler(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["community_id"]
+
+	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil || Limit <= 0 {
+		Limit = 50
+	}
+	Page, err := strconv.Atoi(r.URL.Query().Get("page"))
+	if err != nil || Page < 0 {
+		Page = 0
+	}
+	skip := int64(Page * Limit)
+	limit64 := int64(Limit)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	filter := bson.M{"arrestReport.activeCommunityID": communityID}
+
+	dbResp, err := a.DB.Find(ctx, filter, &options.FindOptions{
+		Limit: &limit64,
+		Skip:  &skip,
+		Sort:  bson.M{"_id": -1},
+	})
+	if err != nil {
+		config.ErrorStatus("failed to get arrest reports", http.StatusInternalServerError, w, err)
+		return
+	}
+	totalCount, err := a.DB.CountDocuments(ctx, filter)
+	if err != nil {
+		totalCount = int64(len(dbResp))
+	}
+	if dbResp == nil {
+		dbResp = []models.ArrestReport{}
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       dbResp,
+		"page":       Page,
+		"limit":      Limit,
+		"totalCount": totalCount,
+	})
+}
+
 // GetArrestReportsByArresteeIDHandler retrieves all Arrest reports that contain the given arresteeID
 func (a ArrestReport) GetArrestReportsByArresteeIDHandler(w http.ResponseWriter, r *http.Request) {
 	arresteeID := mux.Vars(r)["arrestee_id"]

--- a/api/handlers/departmentFormToggle.go
+++ b/api/handlers/departmentFormToggle.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/config"
+	"github.com/linesmerrill/police-cad-api/databases"
+)
+
+// DepartmentFormToggle handles enable/disable of templates per department.
+type DepartmentFormToggle struct {
+	DB databases.DepartmentFormToggleDatabase
+}
+
+// SetDepartmentFormToggleHandler upserts the department's enable/disable
+// state for a given template slug. Body: { communityID, isEnabled }.
+//
+// We only persist a row when the department needs to override the
+// implicit default (everything enabled). When isEnabled=true, the row is
+// removed so the implicit default takes over again.
+func (h DepartmentFormToggle) SetDepartmentFormToggleHandler(w http.ResponseWriter, r *http.Request) {
+	deptID := mux.Vars(r)["dept_id"]
+	slug := mux.Vars(r)["slug"]
+
+	var body struct {
+		CommunityID string `json:"communityID"`
+		IsEnabled   bool   `json:"isEnabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if body.CommunityID == "" {
+		config.ErrorStatus("communityID is required", http.StatusBadRequest, w, fmt.Errorf("missing communityID"))
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	filter := bson.M{
+		"departmentFormToggle.communityID":      body.CommunityID,
+		"departmentFormToggle.departmentId":     deptID,
+		"departmentFormToggle.formTemplateSlug": slug,
+	}
+	update := bson.M{
+		"$set": bson.M{
+			"departmentFormToggle.communityID":      body.CommunityID,
+			"departmentFormToggle.departmentId":     deptID,
+			"departmentFormToggle.formTemplateSlug": slug,
+			"departmentFormToggle.isEnabled":        body.IsEnabled,
+			"departmentFormToggle.updatedAt":        now,
+			"departmentFormToggle.updatedBy":        api.GetAuthenticatedUserIDFromContext(r.Context()),
+		},
+		"$setOnInsert": bson.M{"_id": primitive.NewObjectID()},
+	}
+	upsert := true
+	if err := h.DB.UpdateOne(ctx, filter, update, &options.UpdateOptions{Upsert: &upsert}); err != nil {
+		config.ErrorStatus("failed to update department toggle", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":   "department form toggle updated",
+		"slug":      slug,
+		"isEnabled": body.IsEnabled,
+	})
+}

--- a/api/handlers/featurerequest.go
+++ b/api/handlers/featurerequest.go
@@ -48,6 +48,7 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 	excludeStatus := r.URL.Query().Get("excludeStatus")
 	query := r.URL.Query().Get("q")
 	userID := r.URL.Query().Get("userId")
+	authorID := r.URL.Query().Get("authorId")
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -69,6 +70,11 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 		filter["$or"] = []bson.M{
 			{"title": bson.M{"$regex": escaped, "$options": "i"}},
 			{"description": bson.M{"$regex": escaped, "$options": "i"}},
+		}
+	}
+	if authorID != "" {
+		if authorObjID, err := primitive.ObjectIDFromHex(authorID); err == nil {
+			filter["author"] = authorObjID
 		}
 	}
 

--- a/api/handlers/formSubmission.go
+++ b/api/handlers/formSubmission.go
@@ -26,16 +26,17 @@ import (
 // FormSubmission handles CRUD for filled form instances. It also handles
 // the auto-fill / draft pre-population workflow.
 type FormSubmission struct {
-	DB     databases.FormSubmissionDatabase
-	TDB    databases.FormTemplateDatabase
-	VDB    databases.FormTemplateVersionDatabase
-	CDB    databases.FormCounterDatabase
-	UDB    databases.UserDatabase
-	CallDB databases.CallDatabase
-	ARDB   databases.ArrestReportDatabase
-	CivDB  databases.CivilianDatabase
-	VehDB  databases.VehicleDatabase
-	FirDB  databases.FirearmDatabase
+	DB      databases.FormSubmissionDatabase
+	TDB     databases.FormTemplateDatabase
+	VDB     databases.FormTemplateVersionDatabase
+	CDB     databases.FormCounterDatabase
+	UDB     databases.UserDatabase
+	CommDB  databases.CommunityDatabase
+	CallDB  databases.CallDatabase
+	ARDB    databases.ArrestReportDatabase
+	CivDB   databases.CivilianDatabase
+	VehDB   databases.VehicleDatabase
+	FirDB   databases.FirearmDatabase
 }
 
 // SourceRef is a request-side reference to an existing entity used as an
@@ -122,6 +123,16 @@ func (h FormSubmission) CreateFormSubmissionHandler(w http.ResponseWriter, r *ht
 		status = "submitted"
 	}
 
+	var history []models.FormSubmissionHistoryEntry
+	if status == "submitted" {
+		history = []models.FormSubmissionHistoryEntry{{
+			Action:   "submitted",
+			UserID:   signedBy.UserID,
+			Username: signedBy.Username,
+			At:       now,
+		}}
+	}
+
 	sub := models.FormSubmission{
 		ID: primitive.NewObjectID(),
 		Details: models.FormSubmissionDetails{
@@ -135,6 +146,7 @@ func (h FormSubmission) CreateFormSubmissionHandler(w http.ResponseWriter, r *ht
 			Links:               body.Links,
 			SignedBy:            signedBy,
 			Status:              status,
+			History:             history,
 			CreatedAt:           now,
 			UpdatedAt:           now,
 		},
@@ -177,6 +189,10 @@ func (h FormSubmission) FormSubmissionByIDHandler(w http.ResponseWriter, r *http
 
 // UpdateFormSubmissionHandler patches a submission. Officer-editable
 // fields only — formTemplateVersion and signedBy are NOT updatable.
+//
+// Lock rules: while status="submitted", any change requires the actor
+// to be the original signer or a community admin. Status transitions
+// (submitted ↔ draft) append an entry to the history audit trail.
 func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *http.Request) {
 	subID := mux.Vars(r)["submission_id"]
 	objID, err := primitive.ObjectIDFromHex(subID)
@@ -186,10 +202,11 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 	}
 
 	var body struct {
-		Data         map[string]interface{}      `json:"data,omitempty"`
-		Links        []models.FormSubmissionLink `json:"links,omitempty"`
-		Status       *string                     `json:"status,omitempty"`
-		ReportNumber *string                     `json:"reportNumber,omitempty"`
+		Data         map[string]interface{}          `json:"data,omitempty"`
+		Links        []models.FormSubmissionLink     `json:"links,omitempty"`
+		Status       *string                         `json:"status,omitempty"`
+		ReportNumber *string                         `json:"reportNumber,omitempty"`
+		Actor        *models.FormSubmissionSignature `json:"actor,omitempty"` // server-trusted website fallback when no auth context
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
@@ -199,7 +216,25 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	existing, err := h.DB.FindOne(ctx, bson.M{"_id": objID})
+	if err != nil || existing == nil {
+		config.ErrorStatus("submission not found", http.StatusNotFound, w, err)
+		return
+	}
+
 	now := primitive.NewDateTimeFromTime(time.Now())
+	actor := h.resolveActor(ctx, r, body.Actor, now)
+
+	// Authorization: a submitted report is locked. Any change (data,
+	// links, reopen, etc.) requires the actor to be the original
+	// signer or a community admin.
+	if existing.Details.Status == "submitted" {
+		if !h.canManageSubmission(ctx, actor.UserID, existing.Details) {
+			config.ErrorStatus("only the report's author or a community admin can edit a submitted report", http.StatusForbidden, w, fmt.Errorf("forbidden"))
+			return
+		}
+	}
+
 	set := bson.M{"formSubmission.updatedAt": now}
 	if body.Data != nil {
 		set["formSubmission.data"] = body.Data
@@ -207,19 +242,109 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 	if body.Links != nil {
 		set["formSubmission.links"] = body.Links
 	}
-	if body.Status != nil {
-		set["formSubmission.status"] = *body.Status
-	}
 	if body.ReportNumber != nil {
 		set["formSubmission.reportNumber"] = *body.ReportNumber
 	}
 
-	if err := h.DB.UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": set}); err != nil {
+	var historyEntry *models.FormSubmissionHistoryEntry
+	if body.Status != nil && *body.Status != existing.Details.Status {
+		set["formSubmission.status"] = *body.Status
+		switch *body.Status {
+		case "draft":
+			if existing.Details.Status == "submitted" {
+				historyEntry = &models.FormSubmissionHistoryEntry{
+					Action:   "reopened",
+					UserID:   actor.UserID,
+					Username: actor.Username,
+					At:       now,
+				}
+			}
+		case "submitted":
+			action := "submitted"
+			if len(existing.Details.History) > 0 {
+				action = "resubmitted"
+			}
+			historyEntry = &models.FormSubmissionHistoryEntry{
+				Action:   action,
+				UserID:   actor.UserID,
+				Username: actor.Username,
+				At:       now,
+			}
+		}
+	}
+
+	update := bson.M{"$set": set}
+	if historyEntry != nil {
+		update["$push"] = bson.M{"formSubmission.history": *historyEntry}
+	}
+
+	if err := h.DB.UpdateOne(ctx, bson.M{"_id": objID}, update); err != nil {
 		config.ErrorStatus("failed to update submission", http.StatusInternalServerError, w, err)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{"message": "Submission updated"})
+}
+
+// resolveActor returns the user performing this request. Prefers the
+// auth-context user; falls back to a website-supplied actor block when
+// the API is being proxied by a server-token caller.
+func (h FormSubmission) resolveActor(ctx context.Context, r *http.Request, fallback *models.FormSubmissionSignature, now primitive.DateTime) models.FormSubmissionSignature {
+	if uid := api.GetAuthenticatedUserIDFromContext(r.Context()); uid != "" {
+		return h.lookupSignedBy(ctx, uid, now)
+	}
+	if fallback != nil && fallback.UserID != "" {
+		return models.FormSubmissionSignature{
+			UserID:   fallback.UserID,
+			Username: fallback.Username,
+			SignedAt: now,
+		}
+	}
+	return models.FormSubmissionSignature{SignedAt: now}
+}
+
+// canManageSubmission returns true when the user is the original
+// submitter, the community owner, or holds a role with the
+// "administrator" permission in the submission's community.
+func (h FormSubmission) canManageSubmission(ctx context.Context, userID string, sub models.FormSubmissionDetails) bool {
+	if userID == "" {
+		return false
+	}
+	if sub.SignedBy.UserID != "" && sub.SignedBy.UserID == userID {
+		return true
+	}
+	if sub.CommunityID == "" {
+		return false
+	}
+	commID, err := primitive.ObjectIDFromHex(sub.CommunityID)
+	if err != nil {
+		return false
+	}
+	community, err := h.CommDB.FindOne(ctx, bson.M{"_id": commID})
+	if err != nil || community == nil {
+		return false
+	}
+	if community.Details.OwnerID == userID {
+		return true
+	}
+	for _, role := range community.Details.Roles {
+		inRole := false
+		for _, member := range role.Members {
+			if member == userID {
+				inRole = true
+				break
+			}
+		}
+		if !inRole {
+			continue
+		}
+		for _, perm := range role.Permissions {
+			if perm.Enabled && perm.Name == "administrator" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // DeleteFormSubmissionHandler hard-deletes a submission.

--- a/api/handlers/formSubmission.go
+++ b/api/handlers/formSubmission.go
@@ -34,6 +34,8 @@ type FormSubmission struct {
 	CallDB databases.CallDatabase
 	ARDB   databases.ArrestReportDatabase
 	CivDB  databases.CivilianDatabase
+	VehDB  databases.VehicleDatabase
+	FirDB  databases.FirearmDatabase
 }
 
 // SourceRef is a request-side reference to an existing entity used as an
@@ -520,10 +522,49 @@ func (h FormSubmission) fetchSources(ctx context.Context, sources []SourceRef) m
 				}
 			}
 		case "citation":
-			// Citation source auto-fill from embedded civilian.criminalHistory[]
-			// is deferred to a follow-up — clients pass citation values
-			// directly via `data` overrides for v1.
-			zap.S().Debugw("citation source not yet supported server-side", "id", s.ID)
+			// Citations are embedded in civilian.criminalHistory[]. The
+			// client passes ID=<civilianID>, ChildID=<criminalHistoryID>;
+			// we find the matching item and surface a flattened map plus
+			// a nested "civilian" map for cross-field paths.
+			if s.ChildID == "" {
+				zap.S().Debugw("citation source missing childID", "id", s.ID)
+				continue
+			}
+			civID, err := primitive.ObjectIDFromHex(s.ID)
+			if err != nil {
+				zap.S().Debugw("citation source invalid civilian id", "id", s.ID, "err", err)
+				continue
+			}
+			civ, err := h.CivDB.FindOne(ctx, bson.M{"_id": civID})
+			if err != nil || civ == nil {
+				continue
+			}
+			childID, _ := primitive.ObjectIDFromHex(s.ChildID)
+			var match *models.CriminalHistory
+			for i := range civ.Details.CriminalHistory {
+				if civ.Details.CriminalHistory[i].ID == childID {
+					match = &civ.Details.CriminalHistory[i]
+					break
+				}
+			}
+			if match == nil {
+				continue
+			}
+			cit := toMap(match)
+			cit["civilian"] = toMap(civ.Details)
+			out["citation"] = cit
+		case "vehicle":
+			if oid, err := primitive.ObjectIDFromHex(s.ID); err == nil {
+				if veh, err := h.VehDB.FindOne(ctx, bson.M{"_id": oid}); err == nil && veh != nil {
+					out["vehicle"] = toMap(veh.Details)
+				}
+			}
+		case "firearm":
+			if oid, err := primitive.ObjectIDFromHex(s.ID); err == nil {
+				if firearm, err := h.FirDB.FindOne(ctx, bson.M{"_id": oid}); err == nil && firearm != nil {
+					out["firearm"] = toMap(firearm.Details)
+				}
+			}
 		}
 	}
 	return out

--- a/api/handlers/formSubmission.go
+++ b/api/handlers/formSubmission.go
@@ -206,6 +206,7 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 		Links        []models.FormSubmissionLink     `json:"links,omitempty"`
 		Status       *string                         `json:"status,omitempty"`
 		ReportNumber *string                         `json:"reportNumber,omitempty"`
+		Archived     *bool                           `json:"archived,omitempty"`
 		Actor        *models.FormSubmissionSignature `json:"actor,omitempty"` // server-trusted website fallback when no auth context
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -225,12 +226,12 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 	now := primitive.NewDateTimeFromTime(time.Now())
 	actor := h.resolveActor(ctx, r, body.Actor, now)
 
-	// Authorization: a submitted report is locked. Any change (data,
-	// links, reopen, etc.) requires the actor to be the original
-	// signer or a community admin.
-	if existing.Details.Status == "submitted" {
+	// Authorization: a submitted OR archived report is locked. Any
+	// change (data, links, reopen, archive toggle, etc.) requires the
+	// actor to be the original signer or a community admin.
+	if existing.Details.Status == "submitted" || existing.Details.Archived {
 		if !h.canManageSubmission(ctx, actor.UserID, existing.Details) {
-			config.ErrorStatus("only the report's author or a community admin can edit a submitted report", http.StatusForbidden, w, fmt.Errorf("forbidden"))
+			config.ErrorStatus("only the report's author or a community admin can edit a locked or archived report", http.StatusForbidden, w, fmt.Errorf("forbidden"))
 			return
 		}
 	}
@@ -246,36 +247,58 @@ func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *ht
 		set["formSubmission.reportNumber"] = *body.ReportNumber
 	}
 
-	var historyEntry *models.FormSubmissionHistoryEntry
+	var historyEntries []models.FormSubmissionHistoryEntry
 	if body.Status != nil && *body.Status != existing.Details.Status {
 		set["formSubmission.status"] = *body.Status
 		switch *body.Status {
 		case "draft":
 			if existing.Details.Status == "submitted" {
-				historyEntry = &models.FormSubmissionHistoryEntry{
+				historyEntries = append(historyEntries, models.FormSubmissionHistoryEntry{
 					Action:   "reopened",
 					UserID:   actor.UserID,
 					Username: actor.Username,
 					At:       now,
-				}
+				})
 			}
 		case "submitted":
 			action := "submitted"
 			if len(existing.Details.History) > 0 {
 				action = "resubmitted"
 			}
-			historyEntry = &models.FormSubmissionHistoryEntry{
+			historyEntries = append(historyEntries, models.FormSubmissionHistoryEntry{
 				Action:   action,
 				UserID:   actor.UserID,
 				Username: actor.Username,
 				At:       now,
-			}
+			})
+		}
+	}
+
+	if body.Archived != nil && *body.Archived != existing.Details.Archived {
+		set["formSubmission.archived"] = *body.Archived
+		if *body.Archived {
+			sig := models.FormSubmissionSignature{UserID: actor.UserID, Username: actor.Username, SignedAt: now}
+			set["formSubmission.archivedBy"] = sig
+			historyEntries = append(historyEntries, models.FormSubmissionHistoryEntry{
+				Action:   "archived",
+				UserID:   actor.UserID,
+				Username: actor.Username,
+				At:       now,
+			})
+		} else {
+			set["formSubmission.archivedBy"] = nil
+			historyEntries = append(historyEntries, models.FormSubmissionHistoryEntry{
+				Action:   "unarchived",
+				UserID:   actor.UserID,
+				Username: actor.Username,
+				At:       now,
+			})
 		}
 	}
 
 	update := bson.M{"$set": set}
-	if historyEntry != nil {
-		update["$push"] = bson.M{"formSubmission.history": *historyEntry}
+	if len(historyEntries) > 0 {
+		update["$push"] = bson.M{"formSubmission.history": bson.M{"$each": historyEntries}}
 	}
 
 	if err := h.DB.UpdateOne(ctx, bson.M{"_id": objID}, update); err != nil {

--- a/api/handlers/formSubmission.go
+++ b/api/handlers/formSubmission.go
@@ -1,0 +1,603 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/api/handlers/formdefaults"
+	"github.com/linesmerrill/police-cad-api/config"
+	"github.com/linesmerrill/police-cad-api/databases"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// FormSubmission handles CRUD for filled form instances. It also handles
+// the auto-fill / draft pre-population workflow.
+type FormSubmission struct {
+	DB     databases.FormSubmissionDatabase
+	TDB    databases.FormTemplateDatabase
+	VDB    databases.FormTemplateVersionDatabase
+	CDB    databases.FormCounterDatabase
+	UDB    databases.UserDatabase
+	CallDB databases.CallDatabase
+	ARDB   databases.ArrestReportDatabase
+	CivDB  databases.CivilianDatabase
+}
+
+// SourceRef is a request-side reference to an existing entity used as an
+// auto-fill source when creating or drafting a submission.
+type SourceRef struct {
+	Type    string `json:"type"`              // call, arrestReport, civilian, vehicle, firearm
+	ID      string `json:"id"`
+	ChildID string `json:"childId,omitempty"` // for citations (criminalHistoryID inside civilian)
+}
+
+// CreateFormSubmissionHandler inserts a new submission, snapshotting the
+// current template version, applying auto-fill from sources + auth
+// context, and generating a report number when one wasn't provided.
+//
+// Request body:
+//
+//	{
+//	  "communityID":      "...",
+//	  "departmentId":     "...",
+//	  "formTemplateSlug": "incident-report",
+//	  "data":             { ...overrides keyed by field.id... },
+//	  "links":            [{type, id, childId?, label?}, ...],
+//	  "sources":          [{type, id, childId?}, ...],
+//	  "reportNumber":     "RR-2026-000123"   // optional; auto-generated if blank
+//	  "status":           "draft" | "submitted"
+//	}
+func (h FormSubmission) CreateFormSubmissionHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		CommunityID      string                          `json:"communityID"`
+		DepartmentID     string                          `json:"departmentId"`
+		FormTemplateSlug string                          `json:"formTemplateSlug"`
+		Data             map[string]interface{}          `json:"data"`
+		Links            []models.FormSubmissionLink     `json:"links"`
+		Sources          []SourceRef                     `json:"sources"`
+		ReportNumber     string                          `json:"reportNumber"`
+		Status           string                          `json:"status"`
+		SignedBy         *models.FormSubmissionSignature `json:"signedBy,omitempty"` // server-trusted fallback when auth context is missing (e.g. website proxy)
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if body.CommunityID == "" || body.FormTemplateSlug == "" {
+		config.ErrorStatus("communityID and formTemplateSlug are required", http.StatusBadRequest, w, fmt.Errorf("missing required fields"))
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	tplID, sections, version, err := h.resolveActiveTemplate(ctx, body.CommunityID, body.FormTemplateSlug)
+	if err != nil {
+		config.ErrorStatus("template not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	prefilled := h.buildPrefill(ctx, sections, body.Sources, r)
+
+	// Officer overrides win.
+	for k, v := range body.Data {
+		prefilled[k] = v
+	}
+
+	reportNumber := body.ReportNumber
+	if strings.TrimSpace(reportNumber) == "" {
+		reportNumber = h.nextReportNumber(ctx, body.CommunityID, body.FormTemplateSlug, w, r)
+		if reportNumber == "" {
+			return // error already written
+		}
+	}
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	signedBy := h.lookupSignedBy(ctx, api.GetAuthenticatedUserIDFromContext(r.Context()), now)
+	// Fallback: when no auth-context user (e.g. website server proxying with a
+	// system token), accept body-supplied signedBy.
+	if signedBy.UserID == "" && body.SignedBy != nil && body.SignedBy.UserID != "" {
+		signedBy.UserID = body.SignedBy.UserID
+		signedBy.Username = body.SignedBy.Username
+		signedBy.SignedAt = now
+	}
+
+	status := body.Status
+	if status == "" {
+		status = "submitted"
+	}
+
+	sub := models.FormSubmission{
+		ID: primitive.NewObjectID(),
+		Details: models.FormSubmissionDetails{
+			CommunityID:         body.CommunityID,
+			DepartmentID:        body.DepartmentID,
+			FormTemplateID:      tplID,
+			FormTemplateSlug:    body.FormTemplateSlug,
+			FormTemplateVersion: version,
+			ReportNumber:        reportNumber,
+			Data:                prefilled,
+			Links:               body.Links,
+			SignedBy:            signedBy,
+			Status:              status,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		},
+	}
+
+	if _, err := h.DB.InsertOne(ctx, sub); err != nil {
+		config.ErrorStatus("failed to create submission", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":      "Submission created",
+		"id":           sub.ID.Hex(),
+		"reportNumber": reportNumber,
+		"submission":   sub,
+	})
+}
+
+// FormSubmissionByIDHandler returns a single submission by ID.
+func (h FormSubmission) FormSubmissionByIDHandler(w http.ResponseWriter, r *http.Request) {
+	subID := mux.Vars(r)["submission_id"]
+	objID, err := primitive.ObjectIDFromHex(subID)
+	if err != nil {
+		config.ErrorStatus("invalid submission id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	sub, err := h.DB.FindOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		config.ErrorStatus("submission not found", http.StatusNotFound, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(sub)
+}
+
+// UpdateFormSubmissionHandler patches a submission. Officer-editable
+// fields only — formTemplateVersion and signedBy are NOT updatable.
+func (h FormSubmission) UpdateFormSubmissionHandler(w http.ResponseWriter, r *http.Request) {
+	subID := mux.Vars(r)["submission_id"]
+	objID, err := primitive.ObjectIDFromHex(subID)
+	if err != nil {
+		config.ErrorStatus("invalid submission id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	var body struct {
+		Data         map[string]interface{}      `json:"data,omitempty"`
+		Links        []models.FormSubmissionLink `json:"links,omitempty"`
+		Status       *string                     `json:"status,omitempty"`
+		ReportNumber *string                     `json:"reportNumber,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	set := bson.M{"formSubmission.updatedAt": now}
+	if body.Data != nil {
+		set["formSubmission.data"] = body.Data
+	}
+	if body.Links != nil {
+		set["formSubmission.links"] = body.Links
+	}
+	if body.Status != nil {
+		set["formSubmission.status"] = *body.Status
+	}
+	if body.ReportNumber != nil {
+		set["formSubmission.reportNumber"] = *body.ReportNumber
+	}
+
+	if err := h.DB.UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": set}); err != nil {
+		config.ErrorStatus("failed to update submission", http.StatusInternalServerError, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{"message": "Submission updated"})
+}
+
+// DeleteFormSubmissionHandler hard-deletes a submission.
+func (h FormSubmission) DeleteFormSubmissionHandler(w http.ResponseWriter, r *http.Request) {
+	subID := mux.Vars(r)["submission_id"]
+	objID, err := primitive.ObjectIDFromHex(subID)
+	if err != nil {
+		config.ErrorStatus("invalid submission id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	if err := h.DB.DeleteOne(ctx, bson.M{"_id": objID}); err != nil {
+		config.ErrorStatus("failed to delete submission", http.StatusInternalServerError, w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{"message": "Submission deleted"})
+}
+
+// FormSubmissionDraftHandler returns a non-persisted pre-filled data map
+// based on a template + sources. Used by clients to open the create form
+// pre-filled. Body identical to CreateFormSubmissionHandler minus persistence.
+func (h FormSubmission) FormSubmissionDraftHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		CommunityID      string      `json:"communityID"`
+		FormTemplateSlug string      `json:"formTemplateSlug"`
+		Sources          []SourceRef `json:"sources"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if body.CommunityID == "" || body.FormTemplateSlug == "" {
+		config.ErrorStatus("communityID and formTemplateSlug are required", http.StatusBadRequest, w, fmt.Errorf("missing required fields"))
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	_, sections, version, err := h.resolveActiveTemplate(ctx, body.CommunityID, body.FormTemplateSlug)
+	if err != nil {
+		config.ErrorStatus("template not found", http.StatusNotFound, w, err)
+		return
+	}
+	prefilled := h.buildPrefill(ctx, sections, body.Sources, r)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":                prefilled,
+		"formTemplateSlug":    body.FormTemplateSlug,
+		"formTemplateVersion": version,
+	})
+}
+
+// FormSubmissionsByCommunityHandlerV2 returns paginated submissions for a community.
+func (h FormSubmission) FormSubmissionsByCommunityHandlerV2(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["community_id"]
+	templateSlug := r.URL.Query().Get("templateSlug")
+	departmentID := r.URL.Query().Get("departmentID")
+	officerID := r.URL.Query().Get("officerID")
+	status := r.URL.Query().Get("status")
+
+	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil || Limit <= 0 {
+		Limit = 20
+	}
+	limit64 := int64(Limit)
+	Page := getPage(0, r)
+	skip64 := int64(Page * Limit)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	filter := bson.M{"formSubmission.communityID": communityID}
+	if templateSlug != "" {
+		filter["formSubmission.formTemplateSlug"] = templateSlug
+	}
+	if departmentID != "" {
+		filter["formSubmission.departmentId"] = departmentID
+	}
+	if officerID != "" {
+		filter["formSubmission.signedBy.userID"] = officerID
+	}
+	if status != "" {
+		filter["formSubmission.status"] = status
+	}
+
+	subs, err := h.DB.Find(ctx, filter, &options.FindOptions{
+		Limit: &limit64,
+		Skip:  &skip64,
+		Sort:  bson.M{"_id": -1},
+	})
+	if err != nil {
+		config.ErrorStatus("failed to fetch submissions", http.StatusInternalServerError, w, err)
+		return
+	}
+	totalCount, err := h.DB.CountDocuments(ctx, filter)
+	if err != nil {
+		totalCount = int64(len(subs))
+	}
+	if subs == nil {
+		subs = []models.FormSubmission{}
+	}
+	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       subs,
+		"page":       Page,
+		"limit":      Limit,
+		"totalCount": totalCount,
+		"totalPages": totalPages,
+	})
+}
+
+// FormSubmissionsByLinkHandlerV2 returns submissions linked to a given
+// entity (used by civilian/vehicle/firearm/citation profile pages).
+func (h FormSubmission) FormSubmissionsByLinkHandlerV2(w http.ResponseWriter, r *http.Request) {
+	linkType := mux.Vars(r)["link_type"]
+	linkID := mux.Vars(r)["link_id"]
+
+	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil || Limit <= 0 {
+		Limit = 20
+	}
+	limit64 := int64(Limit)
+	Page := getPage(0, r)
+	skip64 := int64(Page * Limit)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	filter := bson.M{
+		"formSubmission.links": bson.M{
+			"$elemMatch": bson.M{
+				"type": linkType,
+				"id":   linkID,
+			},
+		},
+	}
+
+	subs, err := h.DB.Find(ctx, filter, &options.FindOptions{
+		Limit: &limit64,
+		Skip:  &skip64,
+		Sort:  bson.M{"_id": -1},
+	})
+	if err != nil {
+		config.ErrorStatus("failed to fetch submissions", http.StatusInternalServerError, w, err)
+		return
+	}
+	totalCount, err := h.DB.CountDocuments(ctx, filter)
+	if err != nil {
+		totalCount = int64(len(subs))
+	}
+	if subs == nil {
+		subs = []models.FormSubmission{}
+	}
+	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       subs,
+		"page":       Page,
+		"limit":      Limit,
+		"totalCount": totalCount,
+		"totalPages": totalPages,
+	})
+}
+
+// --- helpers ---
+
+// resolveActiveTemplate looks up either a stored template by (communityID,
+// slug) or a built-in default. Returns the template ID (empty for
+// defaults), its current sections, and its current version number.
+func (h FormSubmission) resolveActiveTemplate(ctx context.Context, communityID, slug string) (string, []models.FormSection, int32, error) {
+	tpl, err := h.TDB.FindOne(ctx, bson.M{
+		"formTemplate.communityID": communityID,
+		"formTemplate.slug":        slug,
+		"formTemplate.isHidden":    bson.M{"$ne": true},
+	})
+	if err == nil && tpl != nil {
+		v, vErr := h.VDB.FindOne(ctx, bson.M{
+			"formTemplateVersion.formTemplateID": tpl.ID.Hex(),
+			"formTemplateVersion.version":        tpl.Details.CurrentVersion,
+		})
+		if vErr != nil {
+			return "", nil, 0, vErr
+		}
+		return tpl.ID.Hex(), v.Details.Sections, tpl.Details.CurrentVersion, nil
+	}
+
+	// Fall back to built-in defaults.
+	if def, ok := formdefaults.All()[slug]; ok {
+		return "", def.Sections, def.CurrentVersion, nil
+	}
+	return "", nil, 0, fmt.Errorf("template %q not found for community %q", slug, communityID)
+}
+
+// nextReportNumber atomically generates the next sequence and formats it
+// per the template's NumberFormat. On failure it writes an error response
+// and returns "".
+func (h FormSubmission) nextReportNumber(ctx context.Context, communityID, slug string, w http.ResponseWriter, r *http.Request) string {
+	year := time.Now().Year()
+	seq, err := h.CDB.NextSeq(ctx, communityID, slug, year)
+	if err != nil {
+		config.ErrorStatus("failed to allocate report number", http.StatusInternalServerError, w, err)
+		return ""
+	}
+
+	format := "RR-{YYYY}-{NNNNNN}"
+	tpl, err := h.TDB.FindOne(ctx, bson.M{
+		"formTemplate.communityID": communityID,
+		"formTemplate.slug":        slug,
+	})
+	if err == nil && tpl != nil && tpl.Details.NumberFormat != "" {
+		format = tpl.Details.NumberFormat
+	} else if def, ok := formdefaults.All()[slug]; ok && def.NumberFormat != "" {
+		format = def.NumberFormat
+	}
+
+	out := strings.ReplaceAll(format, "{YYYY}", strconv.Itoa(year))
+	out = strings.ReplaceAll(out, "{NNNNNN}", fmt.Sprintf("%06d", seq))
+	return out
+}
+
+// lookupSignedBy resolves the username for the auth-context user ID and
+// returns a stamped signature struct.
+func (h FormSubmission) lookupSignedBy(ctx context.Context, userID string, now primitive.DateTime) models.FormSubmissionSignature {
+	sig := models.FormSubmissionSignature{UserID: userID, SignedAt: now}
+	if userID == "" {
+		return sig
+	}
+	var user models.User
+	if err := h.UDB.FindOne(ctx, bson.M{"_id": userID}).Decode(&user); err == nil {
+		sig.Username = user.Details.Username
+	}
+	return sig
+}
+
+// buildPrefill walks the template's top-level fields and resolves each
+// field's PopulateFrom mappings against the fetched source entities, plus
+// any DefaultExpr (auth/today/now) values. Repeatable section row
+// pre-population is deferred to the client for v1 — only top-level scalar
+// fields populate here.
+func (h FormSubmission) buildPrefill(ctx context.Context, sections []models.FormSection, sources []SourceRef, r *http.Request) map[string]interface{} {
+	prefill := map[string]interface{}{}
+
+	sourceData := h.fetchSources(ctx, sources)
+	authCtx := h.buildAuthContext(ctx, r)
+
+	for _, section := range sections {
+		if section.Repeatable {
+			continue // top-level scalar fields only in v1
+		}
+		for _, field := range section.Fields {
+			if v := resolveDefaultExpr(field.DefaultExpr, authCtx); v != nil {
+				prefill[field.ID] = v
+			}
+			for _, m := range field.PopulateFrom {
+				src, ok := sourceData[m.Source]
+				if !ok {
+					continue
+				}
+				if v := resolveJSONPath(src, m.Path); v != nil {
+					prefill[field.ID] = v
+					break
+				}
+			}
+		}
+	}
+	return prefill
+}
+
+// fetchSources loads each source entity and returns a map keyed by source
+// type. Only the first source of each type is honored in v1 (multiple
+// citations would need v2 array-row expansion).
+func (h FormSubmission) fetchSources(ctx context.Context, sources []SourceRef) map[string]interface{} {
+	out := map[string]interface{}{}
+	for _, s := range sources {
+		if _, alreadySet := out[s.Type]; alreadySet {
+			continue
+		}
+		switch s.Type {
+		case "call":
+			if call, err := h.CallDB.FindOne(ctx, bson.M{"_id": s.ID}); err == nil && call != nil {
+				out["call"] = toMap(call.Details)
+			}
+		case "arrestReport":
+			if oid, err := primitive.ObjectIDFromHex(s.ID); err == nil {
+				if ar, err := h.ARDB.FindOne(ctx, bson.M{"_id": oid}); err == nil && ar != nil {
+					out["arrestReport"] = toMap(ar.Details)
+				}
+			}
+		case "civilian":
+			if oid, err := primitive.ObjectIDFromHex(s.ID); err == nil {
+				if civ, err := h.CivDB.FindOne(ctx, bson.M{"_id": oid}); err == nil && civ != nil {
+					out["civilian"] = toMap(civ.Details)
+				}
+			}
+		case "citation":
+			// Citation source auto-fill from embedded civilian.criminalHistory[]
+			// is deferred to a follow-up — clients pass citation values
+			// directly via `data` overrides for v1.
+			zap.S().Debugw("citation source not yet supported server-side", "id", s.ID)
+		}
+	}
+	return out
+}
+
+// buildAuthContext fetches the authenticated user (if any) and returns a
+// map suitable for DefaultExpr resolution.
+func (h FormSubmission) buildAuthContext(ctx context.Context, r *http.Request) map[string]interface{} {
+	out := map[string]interface{}{}
+	uid := api.GetAuthenticatedUserIDFromContext(r.Context())
+	if uid == "" {
+		return out
+	}
+	var user models.User
+	if err := h.UDB.FindOne(ctx, bson.M{"_id": uid}).Decode(&user); err != nil {
+		return out
+	}
+	out["username"] = user.Details.Username
+	return out
+}
+
+// resolveDefaultExpr returns a value for a built-in default expression.
+//
+// Supported: "today", "now", "auth.username".
+func resolveDefaultExpr(expr string, authCtx map[string]interface{}) interface{} {
+	switch expr {
+	case "":
+		return nil
+	case "today":
+		return time.Now().Format("2006-01-02")
+	case "now":
+		return time.Now().Format(time.RFC3339)
+	case "auth.username":
+		if v, ok := authCtx["username"]; ok {
+			return v
+		}
+	}
+	return nil
+}
+
+// resolveJSONPath walks a dot-separated path through nested maps and
+// returns the leaf value, or nil when missing. Array indices and array
+// member-projection are not yet supported.
+func resolveJSONPath(root interface{}, path string) interface{} {
+	if root == nil || path == "" {
+		return nil
+	}
+	if strings.HasPrefix(path, "@const:") {
+		return strings.TrimPrefix(path, "@const:")
+	}
+	parts := strings.Split(path, ".")
+	cur := root
+	for _, p := range parts {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		v, ok := m[p]
+		if !ok {
+			return nil
+		}
+		cur = v
+	}
+	return cur
+}
+
+// toMap JSON-roundtrips a struct into a map[string]interface{} for path traversal.
+func toMap(v interface{}) map[string]interface{} {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var out map[string]interface{}
+	_ = json.Unmarshal(b, &out)
+	return out
+}
+

--- a/api/handlers/formTemplate.go
+++ b/api/handlers/formTemplate.go
@@ -176,11 +176,24 @@ func (h FormTemplate) UpdateFormTemplateHandler(w http.ResponseWriter, r *http.R
 	}
 
 	now := primitive.NewDateTimeFromTime(time.Now())
-	newVersion := existing.Details.CurrentVersion + 1
+
+	// Only bump the version when sections actually change. Metadata-only
+	// toggles (archive/unarchive, role updates) used to bump too, which
+	// orphaned the version pointer — fetchVersionSections couldn't find
+	// a row at the new number and rendered the template as 0 sections /
+	// 0 fields. Versions are immutable section snapshots; flags don't
+	// create new ones.
+	bumpVersion := body.Sections != nil
+	newVersion := existing.Details.CurrentVersion
+	if bumpVersion {
+		newVersion = existing.Details.CurrentVersion + 1
+	}
 
 	set := bson.M{
-		"formTemplate.currentVersion": newVersion,
-		"formTemplate.updatedAt":      now,
+		"formTemplate.updatedAt": now,
+	}
+	if bumpVersion {
+		set["formTemplate.currentVersion"] = newVersion
 	}
 	if body.Name != nil {
 		set["formTemplate.name"] = *body.Name
@@ -213,7 +226,7 @@ func (h FormTemplate) UpdateFormTemplateHandler(w http.ResponseWriter, r *http.R
 	}
 
 	// Append new version row when sections were provided.
-	if body.Sections != nil {
+	if bumpVersion {
 		version := models.FormTemplateVersion{
 			ID: primitive.NewObjectID(),
 			Details: models.FormTemplateVersionDetails{
@@ -470,10 +483,24 @@ func (h FormTemplate) fetchVersionSections(ctx context.Context, formTemplateID s
 		"formTemplateVersion.formTemplateID": formTemplateID,
 		"formTemplateVersion.version":        version,
 	})
+	if err == nil && v != nil {
+		return v.Details.Sections, nil
+	}
+	// Fallback: an older bug bumped formTemplate.currentVersion on
+	// metadata-only updates (archive/unarchive) without writing a matching
+	// version row. Recover by returning the most recent version that does
+	// exist for this template — better than rendering 0 sections.
+	versions, lerr := h.VDB.Find(ctx,
+		bson.M{"formTemplateVersion.formTemplateID": formTemplateID},
+		options.Find().SetSort(bson.M{"formTemplateVersion.version": -1}).SetLimit(1),
+	)
+	if lerr == nil && len(versions) > 0 {
+		return versions[0].Details.Sections, nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	return v.Details.Sections, nil
+	return nil, lerr
 }
 
 func storedTemplateToView(t models.FormTemplate) models.FormTemplateView {

--- a/api/handlers/formTemplate.go
+++ b/api/handlers/formTemplate.go
@@ -315,12 +315,14 @@ func (h FormTemplate) HideDefaultFormTemplateHandler(w http.ResponseWriter, r *h
 }
 
 // FormTemplatesByCommunityHandlerV2 returns every template available to a
-// community: stored rows merged with built-in defaults, defaults filtered
-// out when the community has marked them hidden. Each row is hydrated with
-// its current version's sections.
+// community: stored rows merged with built-in defaults. Defaults the
+// community has marked hidden are normally filtered out; ?includeHidden=true
+// surfaces them with IsHidden=true so admin UIs can show a Restore action.
+// Each row is hydrated with its current version's sections.
 func (h FormTemplate) FormTemplatesByCommunityHandlerV2(w http.ResponseWriter, r *http.Request) {
 	communityID := mux.Vars(r)["community_id"]
 	includeArchived := r.URL.Query().Get("includeArchived") == "true"
+	includeHidden := r.URL.Query().Get("includeHidden") == "true"
 
 	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
 	if err != nil || Limit <= 0 {
@@ -337,7 +339,7 @@ func (h FormTemplate) FormTemplatesByCommunityHandlerV2(w http.ResponseWriter, r
 		return
 	}
 
-	views := h.mergeTemplatesAndDefaults(ctx, stored, includeArchived)
+	views := h.mergeTemplatesAndDefaults(ctx, stored, includeArchived, includeHidden)
 
 	// Pagination over the merged list.
 	totalCount := int64(len(views))
@@ -382,7 +384,7 @@ func (h FormTemplate) FormTemplatesByDepartmentHandlerV2(w http.ResponseWriter, 
 		config.ErrorStatus("failed to fetch templates", http.StatusInternalServerError, w, err)
 		return
 	}
-	views := h.mergeTemplatesAndDefaults(ctx, stored, false)
+	views := h.mergeTemplatesAndDefaults(ctx, stored, false, false)
 
 	toggles, err := h.TDB.Find(ctx, bson.M{
 		"departmentFormToggle.communityID":  communityID,
@@ -416,9 +418,11 @@ func (h FormTemplate) FormTemplatesByDepartmentHandlerV2(w http.ResponseWriter, 
 // --- helpers ---
 
 // mergeTemplatesAndDefaults combines built-in defaults with stored rows
-// for a community, suppressing defaults that have a hide-marker row, and
-// hydrates each entry with its current version's sections.
-func (h FormTemplate) mergeTemplatesAndDefaults(ctx context.Context, stored []models.FormTemplate, includeArchived bool) []models.FormTemplateView {
+// for a community, suppressing defaults that have a hide-marker row
+// (unless includeHidden is true, in which case hidden defaults are
+// surfaced with IsHidden=true so admin UIs can offer a Restore action).
+// Each custom row is hydrated with its current version's sections.
+func (h FormTemplate) mergeTemplatesAndDefaults(ctx context.Context, stored []models.FormTemplate, includeArchived, includeHidden bool) []models.FormTemplateView {
 	hiddenDefaults := map[string]bool{}
 	customRows := make([]models.FormTemplate, 0, len(stored))
 	for _, t := range stored {
@@ -437,6 +441,14 @@ func (h FormTemplate) mergeTemplatesAndDefaults(ctx context.Context, stored []mo
 	// Built-in defaults first (stable order).
 	for slug, def := range formdefaults.All() {
 		if hiddenDefaults[slug] {
+			if !includeHidden {
+				continue
+			}
+			// Surface the hidden default with IsHidden=true set so admin
+			// UIs can render a Restore action against it.
+			hidden := def
+			hidden.IsHidden = true
+			out = append(out, hidden)
 			continue
 		}
 		out = append(out, def)

--- a/api/handlers/formTemplate.go
+++ b/api/handlers/formTemplate.go
@@ -1,0 +1,494 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/api/handlers/formdefaults"
+	"github.com/linesmerrill/police-cad-api/config"
+	"github.com/linesmerrill/police-cad-api/databases"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// FormTemplate exposes endpoints for managing community-scoped form templates.
+type FormTemplate struct {
+	DB  databases.FormTemplateDatabase
+	VDB databases.FormTemplateVersionDatabase
+	TDB databases.DepartmentFormToggleDatabase
+}
+
+// CreateFormTemplateHandler creates a new community-scoped form template
+// plus its initial version row.
+//
+// Request body: a FormTemplateDetails plus a top-level `sections` field.
+// The sections are stripped off and stored in formTemplateVersions; the
+// metadata-only details land in formTemplates.
+func (h FormTemplate) CreateFormTemplateHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		models.FormTemplateDetails
+		Sections []models.FormSection `json:"sections"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if body.CommunityID == "" {
+		config.ErrorStatus("communityID is required", http.StatusBadRequest, w, fmt.Errorf("missing communityID"))
+		return
+	}
+	if body.Slug == "" {
+		config.ErrorStatus("slug is required", http.StatusBadRequest, w, fmt.Errorf("missing slug"))
+		return
+	}
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	tplID := primitive.NewObjectID()
+
+	tpl := models.FormTemplate{
+		ID: tplID,
+		Details: models.FormTemplateDetails{
+			CommunityID:      body.CommunityID,
+			DepartmentID:     body.DepartmentID,
+			Name:             body.Name,
+			Slug:             body.Slug,
+			Description:      body.Description,
+			Icon:             body.Icon,
+			CurrentVersion:   1,
+			NumberFormat:     defaultIfBlank(body.NumberFormat, "RR-{YYYY}-{NNNNNN}"),
+			VisibleToRoles:   body.VisibleToRoles,
+			EditableByRoles:  body.EditableByRoles,
+			LinkableEntities: body.LinkableEntities,
+			IsHidden:         false,
+			DefaultSlug:      "",
+			IsArchived:       false,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+			CreatedBy:        api.GetAuthenticatedUserIDFromContext(r.Context()),
+		},
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	if _, err := h.DB.InsertOne(ctx, tpl); err != nil {
+		config.ErrorStatus("failed to create form template", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	version := models.FormTemplateVersion{
+		ID: primitive.NewObjectID(),
+		Details: models.FormTemplateVersionDetails{
+			FormTemplateID: tplID.Hex(),
+			CommunityID:    body.CommunityID,
+			Slug:           body.Slug,
+			Version:        1,
+			Sections:       body.Sections,
+			PublishedAt:    now,
+			PublishedBy:    tpl.Details.CreatedBy,
+		},
+	}
+	if _, err := h.VDB.InsertOne(ctx, version); err != nil {
+		config.ErrorStatus("failed to create initial template version", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":      "Form template created",
+		"id":           tplID.Hex(),
+		"version":      1,
+		"formTemplate": tpl,
+	})
+}
+
+// FormTemplateByIDHandler returns a single template hydrated with its current version's sections.
+func (h FormTemplate) FormTemplateByIDHandler(w http.ResponseWriter, r *http.Request) {
+	tplID := mux.Vars(r)["template_id"]
+	objID, err := primitive.ObjectIDFromHex(tplID)
+	if err != nil {
+		config.ErrorStatus("invalid template id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	tpl, err := h.DB.FindOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		config.ErrorStatus("form template not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	view := storedTemplateToView(*tpl)
+	if sections, err := h.fetchVersionSections(ctx, tplID, tpl.Details.CurrentVersion); err == nil {
+		view.Sections = sections
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(view)
+}
+
+// UpdateFormTemplateHandler bumps the template's version and appends a new
+// version row containing the new sections. Immediate publish — every save
+// becomes the new current version.
+func (h FormTemplate) UpdateFormTemplateHandler(w http.ResponseWriter, r *http.Request) {
+	tplID := mux.Vars(r)["template_id"]
+	objID, err := primitive.ObjectIDFromHex(tplID)
+	if err != nil {
+		config.ErrorStatus("invalid template id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	var body struct {
+		Name             *string              `json:"name,omitempty"`
+		Description      *string              `json:"description,omitempty"`
+		Icon             *string              `json:"icon,omitempty"`
+		NumberFormat     *string              `json:"numberFormat,omitempty"`
+		VisibleToRoles   *[]string            `json:"visibleToRoles,omitempty"`
+		EditableByRoles  *[]string            `json:"editableByRoles,omitempty"`
+		LinkableEntities *[]string            `json:"linkableEntities,omitempty"`
+		IsArchived       *bool                `json:"isArchived,omitempty"`
+		Sections         []models.FormSection `json:"sections"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	existing, err := h.DB.FindOne(ctx, bson.M{"_id": objID})
+	if err != nil {
+		config.ErrorStatus("form template not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	newVersion := existing.Details.CurrentVersion + 1
+
+	set := bson.M{
+		"formTemplate.currentVersion": newVersion,
+		"formTemplate.updatedAt":      now,
+	}
+	if body.Name != nil {
+		set["formTemplate.name"] = *body.Name
+	}
+	if body.Description != nil {
+		set["formTemplate.description"] = *body.Description
+	}
+	if body.Icon != nil {
+		set["formTemplate.icon"] = *body.Icon
+	}
+	if body.NumberFormat != nil {
+		set["formTemplate.numberFormat"] = *body.NumberFormat
+	}
+	if body.VisibleToRoles != nil {
+		set["formTemplate.visibleToRoles"] = *body.VisibleToRoles
+	}
+	if body.EditableByRoles != nil {
+		set["formTemplate.editableByRoles"] = *body.EditableByRoles
+	}
+	if body.LinkableEntities != nil {
+		set["formTemplate.linkableEntities"] = *body.LinkableEntities
+	}
+	if body.IsArchived != nil {
+		set["formTemplate.isArchived"] = *body.IsArchived
+	}
+
+	if err := h.DB.UpdateOne(ctx, bson.M{"_id": objID}, bson.M{"$set": set}); err != nil {
+		config.ErrorStatus("failed to update form template", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	// Append new version row when sections were provided.
+	if body.Sections != nil {
+		version := models.FormTemplateVersion{
+			ID: primitive.NewObjectID(),
+			Details: models.FormTemplateVersionDetails{
+				FormTemplateID: tplID,
+				CommunityID:    existing.Details.CommunityID,
+				Slug:           existing.Details.Slug,
+				Version:        newVersion,
+				Sections:       body.Sections,
+				PublishedAt:    now,
+				PublishedBy:    api.GetAuthenticatedUserIDFromContext(r.Context()),
+			},
+		}
+		if _, err := h.VDB.InsertOne(ctx, version); err != nil {
+			config.ErrorStatus("failed to append template version", http.StatusInternalServerError, w, err)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":        "Form template updated",
+		"currentVersion": newVersion,
+	})
+}
+
+// FormTemplateVersionsHandler lists all stored versions for a template (newest first).
+func (h FormTemplate) FormTemplateVersionsHandler(w http.ResponseWriter, r *http.Request) {
+	tplID := mux.Vars(r)["template_id"]
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	versions, err := h.VDB.Find(ctx, bson.M{"formTemplateVersion.formTemplateID": tplID}, options.Find().SetSort(bson.M{"formTemplateVersion.version": -1}))
+	if err != nil {
+		config.ErrorStatus("failed to fetch versions", http.StatusInternalServerError, w, err)
+		return
+	}
+	if versions == nil {
+		versions = []models.FormTemplateVersion{}
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(versions)
+}
+
+// HideDefaultFormTemplateHandler upserts a hide-marker row for a built-in
+// default template in a community, or removes it (un-hide) when ?hidden=false.
+func (h FormTemplate) HideDefaultFormTemplateHandler(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["community_id"]
+	slug := mux.Vars(r)["slug"]
+	if _, ok := formdefaults.All()[slug]; !ok {
+		config.ErrorStatus("unknown default template slug", http.StatusBadRequest, w, fmt.Errorf("slug %q is not a built-in default", slug))
+		return
+	}
+
+	hidden := r.URL.Query().Get("hidden") != "false" // default true
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	filter := bson.M{
+		"formTemplate.communityID": communityID,
+		"formTemplate.defaultSlug": slug,
+	}
+	if !hidden {
+		// Un-hide by deleting the marker row entirely.
+		if err := h.DB.DeleteOne(ctx, filter); err != nil {
+			config.ErrorStatus("failed to remove hide marker", http.StatusInternalServerError, w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"message": "default template restored", "slug": slug, "hidden": false})
+		return
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"formTemplate.communityID": communityID,
+			"formTemplate.slug":        slug,
+			"formTemplate.defaultSlug": slug,
+			"formTemplate.isHidden":    true,
+			"formTemplate.updatedAt":   now,
+		},
+		"$setOnInsert": bson.M{
+			"_id":                     primitive.NewObjectID(),
+			"formTemplate.createdAt":  now,
+			"formTemplate.createdBy":  api.GetAuthenticatedUserIDFromContext(r.Context()),
+		},
+		"$inc": bson.M{"__v": 0},
+	}
+	upsert := true
+	if err := h.DB.UpdateOne(ctx, filter, update, &options.UpdateOptions{Upsert: &upsert}); err != nil {
+		config.ErrorStatus("failed to hide default template", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{"message": "default template hidden", "slug": slug, "hidden": true})
+}
+
+// FormTemplatesByCommunityHandlerV2 returns every template available to a
+// community: stored rows merged with built-in defaults, defaults filtered
+// out when the community has marked them hidden. Each row is hydrated with
+// its current version's sections.
+func (h FormTemplate) FormTemplatesByCommunityHandlerV2(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["community_id"]
+	includeArchived := r.URL.Query().Get("includeArchived") == "true"
+
+	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+	if err != nil || Limit <= 0 {
+		Limit = 50
+	}
+	Page := getPage(0, r)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	stored, err := h.DB.Find(ctx, bson.M{"formTemplate.communityID": communityID})
+	if err != nil {
+		config.ErrorStatus("failed to fetch templates", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	views := h.mergeTemplatesAndDefaults(ctx, stored, includeArchived)
+
+	// Pagination over the merged list.
+	totalCount := int64(len(views))
+	from := Page * Limit
+	to := from + Limit
+	if from > len(views) {
+		from = len(views)
+	}
+	if to > len(views) {
+		to = len(views)
+	}
+	pageSlice := views[from:to]
+
+	totalPages := int(math.Ceil(float64(totalCount) / float64(Limit)))
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       pageSlice,
+		"page":       Page,
+		"limit":      Limit,
+		"totalCount": totalCount,
+		"totalPages": totalPages,
+	})
+}
+
+// FormTemplatesByDepartmentHandlerV2 returns templates a specific
+// department has enabled. Default behavior is "everything is enabled
+// unless explicitly toggled off" — explicit isEnabled=false rows in
+// departmentFormToggles suppress entries.
+func (h FormTemplate) FormTemplatesByDepartmentHandlerV2(w http.ResponseWriter, r *http.Request) {
+	deptID := mux.Vars(r)["dept_id"]
+	communityID := r.URL.Query().Get("communityID")
+	if communityID == "" {
+		config.ErrorStatus("communityID query param is required", http.StatusBadRequest, w, fmt.Errorf("missing communityID"))
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	stored, err := h.DB.Find(ctx, bson.M{"formTemplate.communityID": communityID})
+	if err != nil {
+		config.ErrorStatus("failed to fetch templates", http.StatusInternalServerError, w, err)
+		return
+	}
+	views := h.mergeTemplatesAndDefaults(ctx, stored, false)
+
+	toggles, err := h.TDB.Find(ctx, bson.M{
+		"departmentFormToggle.communityID":  communityID,
+		"departmentFormToggle.departmentId": deptID,
+	})
+	if err != nil {
+		config.ErrorStatus("failed to fetch toggles", http.StatusInternalServerError, w, err)
+		return
+	}
+	disabled := map[string]bool{}
+	for _, t := range toggles {
+		if !t.Details.IsEnabled {
+			disabled[t.Details.FormTemplateSlug] = true
+		}
+	}
+
+	enabled := make([]models.FormTemplateView, 0, len(views))
+	for _, v := range views {
+		if !disabled[v.Slug] {
+			enabled = append(enabled, v)
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       enabled,
+		"totalCount": len(enabled),
+	})
+}
+
+// --- helpers ---
+
+// mergeTemplatesAndDefaults combines built-in defaults with stored rows
+// for a community, suppressing defaults that have a hide-marker row, and
+// hydrates each entry with its current version's sections.
+func (h FormTemplate) mergeTemplatesAndDefaults(ctx context.Context, stored []models.FormTemplate, includeArchived bool) []models.FormTemplateView {
+	hiddenDefaults := map[string]bool{}
+	customRows := make([]models.FormTemplate, 0, len(stored))
+	for _, t := range stored {
+		if t.Details.IsHidden && t.Details.DefaultSlug != "" {
+			hiddenDefaults[t.Details.DefaultSlug] = true
+			continue
+		}
+		if t.Details.IsArchived && !includeArchived {
+			continue
+		}
+		customRows = append(customRows, t)
+	}
+
+	out := make([]models.FormTemplateView, 0, len(formdefaults.All())+len(customRows))
+
+	// Built-in defaults first (stable order).
+	for slug, def := range formdefaults.All() {
+		if hiddenDefaults[slug] {
+			continue
+		}
+		out = append(out, def)
+	}
+
+	// Stored rows, hydrated with their current-version sections.
+	for _, t := range customRows {
+		view := storedTemplateToView(t)
+		if sections, err := h.fetchVersionSections(ctx, t.ID.Hex(), t.Details.CurrentVersion); err == nil {
+			view.Sections = sections
+		}
+		out = append(out, view)
+	}
+	return out
+}
+
+func (h FormTemplate) fetchVersionSections(ctx context.Context, formTemplateID string, version int32) ([]models.FormSection, error) {
+	v, err := h.VDB.FindOne(ctx, bson.M{
+		"formTemplateVersion.formTemplateID": formTemplateID,
+		"formTemplateVersion.version":        version,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.Details.Sections, nil
+}
+
+func storedTemplateToView(t models.FormTemplate) models.FormTemplateView {
+	return models.FormTemplateView{
+		ID:               t.ID.Hex(),
+		CommunityID:      t.Details.CommunityID,
+		DepartmentID:     t.Details.DepartmentID,
+		Name:             t.Details.Name,
+		Slug:             t.Details.Slug,
+		Description:      t.Details.Description,
+		Icon:             t.Details.Icon,
+		CurrentVersion:   t.Details.CurrentVersion,
+		NumberFormat:     t.Details.NumberFormat,
+		VisibleToRoles:   t.Details.VisibleToRoles,
+		EditableByRoles:  t.Details.EditableByRoles,
+		LinkableEntities: t.Details.LinkableEntities,
+		IsDefault:        false,
+		IsHidden:         t.Details.IsHidden,
+		IsArchived:       t.Details.IsArchived,
+		CreatedAt:        t.Details.CreatedAt,
+		UpdatedAt:        t.Details.UpdatedAt,
+	}
+}
+
+func defaultIfBlank(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/api/handlers/formdefaults/incident_report.go
+++ b/api/handlers/formdefaults/incident_report.go
@@ -104,27 +104,40 @@ func incidentReportSections() []models.FormSection {
 			},
 		},
 		{
-			ID: "suspects", Title: "Suspects", Repeatable: true,
+			ID: "suspects", Title: "Suspects", Repeatable: true, BindEntity: "civilian",
 			Fields: []models.FormField{
 				{ID: "name", Type: "text", Label: "Name",
 					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "name"},
 						{Source: "arrestReport", Path: "arrestee.name"},
-						{Source: "citation", Path: "civilian.firstName civilian.lastName"},
 					}},
 				{ID: "dob", Type: "date", Label: "DOB",
 					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "birthday"},
 						{Source: "arrestReport", Path: "arrestee.dob"},
-						{Source: "citation", Path: "civilian.birthday"},
 					}},
-				{ID: "description", Type: "textarea", Label: "Description"},
+				{ID: "address", Type: "text", Label: "Address",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "address"},
+					}},
+				{ID: "description", Type: "textarea", Label: "Description",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "@desc:civilian"},
+					}},
 				{ID: "status", Type: "select", Label: "Status", Options: []string{"At Large", "Detained", "Arrested", "Cited", "Released"}},
 			},
 		},
 		{
-			ID: "victims", Title: "Victims", Repeatable: true,
+			ID: "victims", Title: "Victims", Repeatable: true, BindEntity: "civilian",
 			Fields: []models.FormField{
-				{ID: "name", Type: "text", Label: "Name"},
-				{ID: "dob", Type: "date", Label: "DOB"},
+				{ID: "name", Type: "text", Label: "Name",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "name"},
+					}},
+				{ID: "dob", Type: "date", Label: "DOB",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "bound", Path: "birthday"},
+					}},
 				{ID: "injuryStatus", Type: "select", Label: "Injury Status", Options: []string{"None", "Minor", "Serious", "Critical", "Fatal"}},
 			},
 		},

--- a/api/handlers/formdefaults/incident_report.go
+++ b/api/handlers/formdefaults/incident_report.go
@@ -1,0 +1,198 @@
+// Package formdefaults provides built-in form templates that ship with
+// every community. They are not stored in Mongo; they are merged into a
+// community's template list at read time. A community can suppress a
+// default by inserting a FormTemplate row with IsHidden=true and
+// DefaultSlug=<slug>.
+package formdefaults
+
+import "github.com/linesmerrill/police-cad-api/models"
+
+// IncidentReportSlug is the canonical slug for the built-in Incident
+// Report template. Submissions reference this string in their
+// FormTemplateSlug field.
+const IncidentReportSlug = "incident-report"
+
+// IncidentReport returns the built-in Incident Report template (sections,
+// fields, and auto-fill mappings).
+func IncidentReport() models.FormTemplateView {
+	return models.FormTemplateView{
+		ID:               "default:" + IncidentReportSlug,
+		Slug:             IncidentReportSlug,
+		Name:             "Incident Report",
+		Description:      "Standard incident report — auto-fills from calls, citations, and arrest reports.",
+		Icon:             "file-text",
+		CurrentVersion:   1,
+		NumberFormat:     "RR-{YYYY}-{NNNNNN}",
+		VisibleToRoles:   []string{"police", "dispatch", "fire", "ems", "judicial"},
+		EditableByRoles:  []string{"police", "dispatch", "fire", "ems"},
+		LinkableEntities: []string{"civilian", "vehicle", "firearm", "call", "citation", "arrestReport"},
+		IsDefault:        true,
+		Sections:         incidentReportSections(),
+	}
+}
+
+func incidentReportSections() []models.FormSection {
+	return []models.FormSection{
+		{
+			ID: "incidentInfo", Title: "Incident Info",
+			Fields: []models.FormField{
+				{ID: "incidentNumber", Type: "text", Label: "Incident #", Placeholder: "RR-YYYY-NNNNNN — leave blank to auto-generate"},
+				{ID: "callType", Type: "text", Label: "Call Type", Required: true,
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "title"},
+					}},
+				{ID: "priorityLevel", Type: "select", Label: "Priority Level", Options: []string{"1 - Critical", "2 - High", "3 - Routine", "4 - Low"},
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "classifier[0]"},
+					}},
+				{ID: "status", Type: "select", Label: "Status", Options: []string{"Open", "Active", "Cleared", "Closed"}},
+				{ID: "date", Type: "date", Label: "Date", DefaultExpr: "today",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "createdAt"},
+						{Source: "arrestReport", Path: "incidentDate"},
+					}},
+				{ID: "timeDispatched", Type: "time", Label: "Time Dispatched",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "createdAt"},
+					}},
+				{ID: "timeArrived", Type: "time", Label: "Time Arrived"},
+				{ID: "timeCleared", Type: "time", Label: "Time Cleared",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "updatedAt"},
+					}},
+			},
+		},
+		{
+			ID: "locationDetails", Title: "Location Details",
+			Fields: []models.FormField{
+				{ID: "address", Type: "text", Label: "Address",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "details"},
+						{Source: "arrestReport", Path: "incidentLocation"},
+					}},
+				{ID: "city", Type: "text", Label: "City"},
+				{ID: "zipCode", Type: "text", Label: "Zip Code"},
+				{ID: "premisesType", Type: "select", Label: "Premises Type", Options: []string{"Residence", "Business", "Public Way", "School", "Park", "Vehicle", "Other"}},
+			},
+		},
+		{
+			ID: "unitInformation", Title: "Unit Information",
+			Fields: []models.FormField{
+				{ID: "primaryUnit", Type: "text", Label: "Primary Unit", DefaultExpr: "auth.username"},
+				{ID: "assistingUnits", Type: "multiSelect", Label: "Assisting Units",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "assignedTo"},
+					}},
+				{ID: "supervisorNotified", Type: "checkbox", Label: "Supervisor Notified"},
+				{ID: "reportingOfficer", Type: "text", Label: "Reporting Officer", Required: true, DefaultExpr: "auth.username",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "arrestReport", Path: "officer.name"},
+					}},
+				{ID: "badgeNumber", Type: "text", Label: "Badge #", DefaultExpr: "auth.badgeNumber",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "arrestReport", Path: "officer.badgeNumber"},
+					}},
+			},
+		},
+		{
+			ID: "reportingParty", Title: "Reporting Party",
+			Fields: []models.FormField{
+				{ID: "name", Type: "text", Label: "Name"},
+				{ID: "dob", Type: "date", Label: "DOB"},
+				{ID: "phone", Type: "text", Label: "Phone"},
+				{ID: "address", Type: "text", Label: "Address"},
+			},
+		},
+		{
+			ID: "suspects", Title: "Suspects", Repeatable: true,
+			Fields: []models.FormField{
+				{ID: "name", Type: "text", Label: "Name",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "arrestReport", Path: "arrestee.name"},
+						{Source: "citation", Path: "civilian.firstName civilian.lastName"},
+					}},
+				{ID: "dob", Type: "date", Label: "DOB",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "arrestReport", Path: "arrestee.dob"},
+						{Source: "citation", Path: "civilian.birthday"},
+					}},
+				{ID: "description", Type: "textarea", Label: "Description"},
+				{ID: "status", Type: "select", Label: "Status", Options: []string{"At Large", "Detained", "Arrested", "Cited", "Released"}},
+			},
+		},
+		{
+			ID: "victims", Title: "Victims", Repeatable: true,
+			Fields: []models.FormField{
+				{ID: "name", Type: "text", Label: "Name"},
+				{ID: "dob", Type: "date", Label: "DOB"},
+				{ID: "injuryStatus", Type: "select", Label: "Injury Status", Options: []string{"None", "Minor", "Serious", "Critical", "Fatal"}},
+			},
+		},
+		{
+			ID: "narrative", Title: "Narrative",
+			Fields: []models.FormField{
+				{ID: "narrative", Type: "textarea", Label: "Narrative", Required: true,
+					Placeholder: "On [DATE] at approximately [TIME], Officers with the [DEPARTMENT] were dispatched to [LOCATION] regarding a report of [CALL TYPE].\n\nUpon arrival, Officers contacted [NAME] who stated…\n\nInvestigation revealed…",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "call", Path: "details"},
+						{Source: "arrestReport", Path: "narrative"},
+					}},
+			},
+		},
+		{
+			ID: "charges", Title: "Charges / Violations", Repeatable: true,
+			Fields: []models.FormField{
+				{ID: "charge", Type: "penalCodePicker", Label: "Charge",
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "citation", Path: "fines[].fineType"},
+					}},
+				{ID: "rcwCode", Type: "text", Label: "RCW Code", Placeholder: "e.g. RCW 9A.56.050"},
+				{ID: "disposition", Type: "select", Label: "Disposition", Options: []string{"Arrest", "Citation", "Warning"},
+					PopulateFrom: []models.FormFieldPopulate{
+						{Source: "citation", Path: "type"},
+						{Source: "arrestReport", Path: "@const:Arrest"},
+					}},
+			},
+		},
+		{
+			ID: "evidence", Title: "Evidence / Property", Repeatable: true,
+			Fields: []models.FormField{
+				{ID: "itemNumber", Type: "text", Label: "Item #"},
+				{ID: "description", Type: "textarea", Label: "Description"},
+				{ID: "collectedBy", Type: "userPicker", Label: "Collected By"},
+				{ID: "loggedIntoEvidence", Type: "checkbox", Label: "Logged Into Evidence"},
+			},
+		},
+		{
+			ID: "medicalFire", Title: "Medical / Fire Response",
+			Fields: []models.FormField{
+				{ID: "emsRequested", Type: "checkbox", Label: "EMS Requested"},
+				{ID: "fireDepartment", Type: "text", Label: "Fire Department", Placeholder: "e.g. Clark County Fire District 6"},
+				{ID: "transportedTo", Type: "text", Label: "Transported To", Placeholder: "Hospital name"},
+			},
+		},
+		{
+			ID: "dispatch", Title: "Dispatch Notes",
+			Fields: []models.FormField{
+				{ID: "source", Type: "select", Label: "Source", Options: []string{"911", "Non-Emergency", "Officer Initiated", "Walk-In"}},
+				{ID: "additionalRemarks", Type: "textarea", Label: "Additional Remarks"},
+			},
+		},
+		{
+			ID: "approval", Title: "Approval",
+			Fields: []models.FormField{
+				{ID: "reportingOfficerSignature", Type: "text", Label: "Reporting Officer Signature", DefaultExpr: "auth.username", HelpText: "Auto-signed when submitted."},
+				{ID: "supervisorApproval", Type: "text", Label: "Supervisor Approval", HelpText: "Optional."},
+				{ID: "dateSubmitted", Type: "date", Label: "Date Submitted", DefaultExpr: "today"},
+			},
+		},
+	}
+}
+
+// All returns every built-in default template, keyed by slug. Add new
+// defaults here.
+func All() map[string]models.FormTemplateView {
+	return map[string]models.FormTemplateView{
+		IncidentReportSlug: IncidentReport(),
+	}
+}

--- a/databases/departmentFormToggle.go
+++ b/databases/departmentFormToggle.go
@@ -1,0 +1,43 @@
+package databases
+
+import (
+	"context"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const departmentFormToggleName = "departmentFormToggles"
+
+// DepartmentFormToggleDatabase contains the methods to use with the departmentFormToggles collection
+type DepartmentFormToggleDatabase interface {
+	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.DepartmentFormToggle, error)
+	UpdateOne(context.Context, interface{}, interface{}, ...*options.UpdateOptions) error
+}
+
+type departmentFormToggleDatabase struct {
+	db DatabaseHelper
+}
+
+// NewDepartmentFormToggleDatabase initializes a new instance of the departmentFormToggles database
+func NewDepartmentFormToggleDatabase(db DatabaseHelper) DepartmentFormToggleDatabase {
+	return &departmentFormToggleDatabase{db: db}
+}
+
+func (c *departmentFormToggleDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.DepartmentFormToggle, error) {
+	var out []models.DepartmentFormToggle
+	curr, err := c.db.Collection(departmentFormToggleName).Find(ctx, filter, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer curr.Close(ctx)
+	if err := curr.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *departmentFormToggleDatabase) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error {
+	_, err := c.db.Collection(departmentFormToggleName).UpdateOne(ctx, filter, update, opts...)
+	return err
+}

--- a/databases/formCounter.go
+++ b/databases/formCounter.go
@@ -1,0 +1,58 @@
+package databases
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const formCounterName = "formCounters"
+
+// FormCounterDatabase atomically increments and returns a per-(community, slug, year) sequence
+// used to generate unique form submission report numbers.
+type FormCounterDatabase interface {
+	NextSeq(ctx context.Context, communityID, slug string, year int) (int64, error)
+}
+
+type formCounterDatabase struct {
+	db DatabaseHelper
+}
+
+// NewFormCounterDatabase initializes a new instance of the form counter database
+func NewFormCounterDatabase(db DatabaseHelper) FormCounterDatabase {
+	return &formCounterDatabase{db: db}
+}
+
+// NextSeq atomically increments the (communityID, slug, year) counter and returns the new value.
+// Uses FindOneAndUpdate with $inc + upsert + ReturnDocument=After.
+func (c *formCounterDatabase) NextSeq(ctx context.Context, communityID, slug string, year int) (int64, error) {
+	filter := bson.M{
+		"communityID": communityID,
+		"slug":        slug,
+		"year":        year,
+	}
+	update := bson.M{
+		"$inc": bson.M{"seq": int64(1)},
+		"$setOnInsert": bson.M{
+			"communityID": communityID,
+			"slug":        slug,
+			"year":        year,
+		},
+	}
+	after := options.After
+	opts := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(after)
+
+	res := c.db.Collection(formCounterName).FindOneAndUpdate(ctx, filter, update, opts)
+	if err := res.Err(); err != nil {
+		return 0, err
+	}
+
+	var doc struct {
+		Seq int64 `bson:"seq"`
+	}
+	if err := res.Decode(&doc); err != nil {
+		return 0, err
+	}
+	return doc.Seq, nil
+}

--- a/databases/formSubmission.go
+++ b/databases/formSubmission.go
@@ -1,0 +1,67 @@
+package databases
+
+import (
+	"context"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const formSubmissionName = "formSubmissions"
+
+// FormSubmissionDatabase contains the methods to use with the formSubmissions collection
+type FormSubmissionDatabase interface {
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormSubmission, error)
+	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormSubmission, error)
+	InsertOne(context.Context, interface{}, ...*options.InsertOneOptions) (InsertOneResultHelper, error)
+	DeleteOne(context.Context, interface{}, ...*options.DeleteOptions) error
+	UpdateOne(context.Context, interface{}, interface{}, ...*options.UpdateOptions) error
+	CountDocuments(context.Context, interface{}, ...*options.CountOptions) (int64, error)
+}
+
+type formSubmissionDatabase struct {
+	db DatabaseHelper
+}
+
+// NewFormSubmissionDatabase initializes a new instance of the formSubmissions database
+func NewFormSubmissionDatabase(db DatabaseHelper) FormSubmissionDatabase {
+	return &formSubmissionDatabase{db: db}
+}
+
+func (c *formSubmissionDatabase) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormSubmission, error) {
+	s := &models.FormSubmission{}
+	if err := c.db.Collection(formSubmissionName).FindOne(ctx, filter, opts...).Decode(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (c *formSubmissionDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormSubmission, error) {
+	var out []models.FormSubmission
+	curr, err := c.db.Collection(formSubmissionName).Find(ctx, filter, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer curr.Close(ctx)
+	if err := curr.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *formSubmissionDatabase) InsertOne(ctx context.Context, document interface{}, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error) {
+	return c.db.Collection(formSubmissionName).InsertOne(ctx, document, opts...)
+}
+
+func (c *formSubmissionDatabase) DeleteOne(ctx context.Context, filter interface{}, opts ...*options.DeleteOptions) error {
+	return c.db.Collection(formSubmissionName).DeleteOne(ctx, filter, opts...)
+}
+
+func (c *formSubmissionDatabase) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error {
+	_, err := c.db.Collection(formSubmissionName).UpdateOne(ctx, filter, update, opts...)
+	return err
+}
+
+func (c *formSubmissionDatabase) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	return c.db.Collection(formSubmissionName).CountDocuments(ctx, filter, opts...)
+}

--- a/databases/formTemplate.go
+++ b/databases/formTemplate.go
@@ -1,0 +1,67 @@
+package databases
+
+import (
+	"context"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const formTemplateName = "formTemplates"
+
+// FormTemplateDatabase contains the methods to use with the formTemplates collection
+type FormTemplateDatabase interface {
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormTemplate, error)
+	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormTemplate, error)
+	InsertOne(context.Context, interface{}, ...*options.InsertOneOptions) (InsertOneResultHelper, error)
+	DeleteOne(context.Context, interface{}, ...*options.DeleteOptions) error
+	UpdateOne(context.Context, interface{}, interface{}, ...*options.UpdateOptions) error
+	CountDocuments(context.Context, interface{}, ...*options.CountOptions) (int64, error)
+}
+
+type formTemplateDatabase struct {
+	db DatabaseHelper
+}
+
+// NewFormTemplateDatabase initializes a new instance of the formTemplates database
+func NewFormTemplateDatabase(db DatabaseHelper) FormTemplateDatabase {
+	return &formTemplateDatabase{db: db}
+}
+
+func (c *formTemplateDatabase) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormTemplate, error) {
+	tpl := &models.FormTemplate{}
+	if err := c.db.Collection(formTemplateName).FindOne(ctx, filter, opts...).Decode(&tpl); err != nil {
+		return nil, err
+	}
+	return tpl, nil
+}
+
+func (c *formTemplateDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormTemplate, error) {
+	var out []models.FormTemplate
+	curr, err := c.db.Collection(formTemplateName).Find(ctx, filter, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer curr.Close(ctx)
+	if err := curr.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *formTemplateDatabase) InsertOne(ctx context.Context, document interface{}, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error) {
+	return c.db.Collection(formTemplateName).InsertOne(ctx, document, opts...)
+}
+
+func (c *formTemplateDatabase) DeleteOne(ctx context.Context, filter interface{}, opts ...*options.DeleteOptions) error {
+	return c.db.Collection(formTemplateName).DeleteOne(ctx, filter, opts...)
+}
+
+func (c *formTemplateDatabase) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error {
+	_, err := c.db.Collection(formTemplateName).UpdateOne(ctx, filter, update, opts...)
+	return err
+}
+
+func (c *formTemplateDatabase) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	return c.db.Collection(formTemplateName).CountDocuments(ctx, filter, opts...)
+}

--- a/databases/formTemplateVersion.go
+++ b/databases/formTemplateVersion.go
@@ -1,0 +1,51 @@
+package databases
+
+import (
+	"context"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const formTemplateVersionName = "formTemplateVersions"
+
+// FormTemplateVersionDatabase contains the methods to use with the formTemplateVersions collection
+type FormTemplateVersionDatabase interface {
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormTemplateVersion, error)
+	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormTemplateVersion, error)
+	InsertOne(context.Context, interface{}, ...*options.InsertOneOptions) (InsertOneResultHelper, error)
+}
+
+type formTemplateVersionDatabase struct {
+	db DatabaseHelper
+}
+
+// NewFormTemplateVersionDatabase initializes a new instance of the formTemplateVersions database
+func NewFormTemplateVersionDatabase(db DatabaseHelper) FormTemplateVersionDatabase {
+	return &formTemplateVersionDatabase{db: db}
+}
+
+func (c *formTemplateVersionDatabase) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) (*models.FormTemplateVersion, error) {
+	v := &models.FormTemplateVersion{}
+	if err := c.db.Collection(formTemplateVersionName).FindOne(ctx, filter, opts...).Decode(&v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (c *formTemplateVersionDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) ([]models.FormTemplateVersion, error) {
+	var out []models.FormTemplateVersion
+	curr, err := c.db.Collection(formTemplateVersionName).Find(ctx, filter, opts...)
+	if err != nil {
+		return nil, err
+	}
+	defer curr.Close(ctx)
+	if err := curr.All(ctx, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *formTemplateVersionDatabase) InsertOne(ctx context.Context, document interface{}, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error) {
+	return c.db.Collection(formTemplateVersionName).InsertOne(ctx, document, opts...)
+}

--- a/models/departmentFormToggle.go
+++ b/models/departmentFormToggle.go
@@ -1,0 +1,26 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// DepartmentFormToggle records an explicit enable/disable decision for a
+// form template at the department level.
+//
+// Default behavior when no row exists: every department implicitly has
+// every available template (community + defaults) enabled. Rows are only
+// stored when an admin overrides the implicit default — typically to
+// disable a template for a particular department.
+type DepartmentFormToggle struct {
+	ID      primitive.ObjectID          `json:"_id" bson:"_id"`
+	Details DepartmentFormToggleDetails `json:"departmentFormToggle" bson:"departmentFormToggle"`
+	Version int32                       `json:"__v" bson:"__v"`
+}
+
+// DepartmentFormToggleDetails holds the inner toggle state.
+type DepartmentFormToggleDetails struct {
+	CommunityID      string             `json:"communityID" bson:"communityID"`
+	DepartmentID     string             `json:"departmentId" bson:"departmentId"`
+	FormTemplateSlug string             `json:"formTemplateSlug" bson:"formTemplateSlug"`
+	IsEnabled        bool               `json:"isEnabled" bson:"isEnabled"`
+	UpdatedAt        primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+	UpdatedBy        string             `json:"updatedBy" bson:"updatedBy"`
+}

--- a/models/formCounter.go
+++ b/models/formCounter.go
@@ -1,0 +1,16 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// FormCounter is the per-community-per-template-per-year sequence used to
+// generate report numbers (e.g. RR-2026-000123).
+//
+// One row per (communityID, slug, year). Mongo $inc with upsert keeps it
+// atomic.
+type FormCounter struct {
+	ID          primitive.ObjectID `json:"_id" bson:"_id"`
+	CommunityID string             `json:"communityID" bson:"communityID"`
+	Slug        string             `json:"slug" bson:"slug"`
+	Year        int                `json:"year" bson:"year"`
+	Seq         int64              `json:"seq" bson:"seq"`
+}

--- a/models/formSubmission.go
+++ b/models/formSubmission.go
@@ -27,11 +27,21 @@ type FormSubmissionDetails struct {
 
 	Links []FormSubmissionLink `json:"links" bson:"links"`
 
-	SignedBy FormSubmissionSignature `json:"signedBy" bson:"signedBy"`
-	Status   string                  `json:"status" bson:"status"` // "draft", "submitted"
+	SignedBy FormSubmissionSignature      `json:"signedBy" bson:"signedBy"`
+	Status   string                       `json:"status" bson:"status"` // "draft", "submitted"
+	History  []FormSubmissionHistoryEntry `json:"history,omitempty" bson:"history,omitempty"`
 
 	CreatedAt primitive.DateTime `json:"createdAt" bson:"createdAt"`
 	UpdatedAt primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+}
+
+// FormSubmissionHistoryEntry is one append-only entry in the report's
+// audit trail. Action is one of: "submitted", "reopened", "resubmitted".
+type FormSubmissionHistoryEntry struct {
+	Action   string             `json:"action" bson:"action"`
+	UserID   string             `json:"userID" bson:"userID"`
+	Username string             `json:"username" bson:"username"`
+	At       primitive.DateTime `json:"at" bson:"at"`
 }
 
 // FormSubmissionLink is one cross-link to another entity. ChildID is set

--- a/models/formSubmission.go
+++ b/models/formSubmission.go
@@ -1,0 +1,53 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// FormSubmission is a filled instance of a FormTemplate. Data is stored as
+// a free-form map keyed by field IDs from the snapshotted template version.
+type FormSubmission struct {
+	ID      primitive.ObjectID    `json:"_id" bson:"_id"`
+	Details FormSubmissionDetails `json:"formSubmission" bson:"formSubmission"`
+	Version int32                 `json:"__v" bson:"__v"`
+}
+
+// FormSubmissionDetails holds the inner submission record.
+type FormSubmissionDetails struct {
+	CommunityID  string `json:"communityID" bson:"communityID"`
+	DepartmentID string `json:"departmentId" bson:"departmentId"`
+
+	FormTemplateID      string `json:"formTemplateID,omitempty" bson:"formTemplateID,omitempty"` // empty for default-template submissions
+	FormTemplateSlug    string `json:"formTemplateSlug" bson:"formTemplateSlug"`
+	FormTemplateVersion int32  `json:"formTemplateVersion" bson:"formTemplateVersion"`
+
+	ReportNumber string `json:"reportNumber" bson:"reportNumber"`
+
+	// Data is keyed by field.id from the snapshotted template version.
+	// Repeatable sections store an array of row objects under the section.id key.
+	Data map[string]interface{} `json:"data" bson:"data"`
+
+	Links []FormSubmissionLink `json:"links" bson:"links"`
+
+	SignedBy FormSubmissionSignature `json:"signedBy" bson:"signedBy"`
+	Status   string                  `json:"status" bson:"status"` // "draft", "submitted"
+
+	CreatedAt primitive.DateTime `json:"createdAt" bson:"createdAt"`
+	UpdatedAt primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+}
+
+// FormSubmissionLink is one cross-link to another entity. ChildID is set
+// when the linked entity is embedded in a parent doc — e.g. citations live
+// inside a civilian's criminalHistory array, so Type="citation" sets
+// ID=<civilianID> and ChildID=<criminalHistoryID>.
+type FormSubmissionLink struct {
+	Type    string `json:"type" bson:"type"`
+	ID      string `json:"id" bson:"id"`
+	ChildID string `json:"childId,omitempty" bson:"childId,omitempty"`
+	Label   string `json:"label,omitempty" bson:"label,omitempty"`
+}
+
+// FormSubmissionSignature is server-stamped from the auth context on submit.
+type FormSubmissionSignature struct {
+	UserID   string             `json:"userID" bson:"userID"`
+	Username string             `json:"username" bson:"username"`
+	SignedAt primitive.DateTime `json:"signedAt" bson:"signedAt"`
+}

--- a/models/formSubmission.go
+++ b/models/formSubmission.go
@@ -31,6 +31,12 @@ type FormSubmissionDetails struct {
 	Status   string                       `json:"status" bson:"status"` // "draft", "submitted"
 	History  []FormSubmissionHistoryEntry `json:"history,omitempty" bson:"history,omitempty"`
 
+	// Archived is orthogonal to Status. An archived report is locked
+	// from edits regardless of draft/submitted state. Unarchiving
+	// returns it to whatever Status it had before.
+	Archived   bool                     `json:"archived,omitempty" bson:"archived,omitempty"`
+	ArchivedBy *FormSubmissionSignature `json:"archivedBy,omitempty" bson:"archivedBy,omitempty"`
+
 	CreatedAt primitive.DateTime `json:"createdAt" bson:"createdAt"`
 	UpdatedAt primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
 }

--- a/models/formTemplate.go
+++ b/models/formTemplate.go
@@ -1,0 +1,71 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// FormTemplate is the top-level metadata for a community-scoped form
+// definition. The actual section/field schema lives in FormTemplateVersion
+// rows; FormTemplate.CurrentVersion points at the latest.
+//
+// Defaults (e.g. the built-in Incident Report) are NOT stored as rows in
+// this collection — they are virtual, defined in code under
+// api/handlers/formdefaults. A community can hide a default by inserting a
+// row with IsHidden=true and DefaultSlug=<slug>.
+type FormTemplate struct {
+	ID      primitive.ObjectID  `json:"_id" bson:"_id"`
+	Details FormTemplateDetails `json:"formTemplate" bson:"formTemplate"`
+	Version int32               `json:"__v" bson:"__v"`
+}
+
+// FormTemplateDetails holds the inner template metadata.
+type FormTemplateDetails struct {
+	CommunityID  string `json:"communityID" bson:"communityID"`
+	DepartmentID string `json:"departmentId,omitempty" bson:"departmentId,omitempty"` // optional scope; empty = community-wide
+
+	Name        string `json:"name" bson:"name"`
+	Slug        string `json:"slug" bson:"slug"` // unique within a community
+	Description string `json:"description" bson:"description"`
+	Icon        string `json:"icon" bson:"icon"`
+
+	CurrentVersion int32 `json:"currentVersion" bson:"currentVersion"`
+
+	// Default-template hide override. When IsHidden=true and DefaultSlug
+	// is set, this row exists solely to suppress the named default for
+	// this community.
+	IsHidden    bool   `json:"isHidden" bson:"isHidden"`
+	DefaultSlug string `json:"defaultSlug,omitempty" bson:"defaultSlug,omitempty"`
+	IsArchived  bool   `json:"isArchived" bson:"isArchived"`
+
+	NumberFormat      string   `json:"numberFormat" bson:"numberFormat"` // tokens: {YYYY}, {NNNNNN}, custom prefix
+	VisibleToRoles    []string `json:"visibleToRoles" bson:"visibleToRoles"`
+	EditableByRoles   []string `json:"editableByRoles" bson:"editableByRoles"`
+	LinkableEntities  []string `json:"linkableEntities" bson:"linkableEntities"` // civilian, vehicle, firearm, call, citation, arrestReport, warrant, bolo
+
+	CreatedAt primitive.DateTime `json:"createdAt" bson:"createdAt"`
+	UpdatedAt primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+	CreatedBy string             `json:"createdBy" bson:"createdBy"`
+}
+
+// FormTemplateView is the merged representation returned to clients —
+// either a stored FormTemplateDetails row or a virtual default. The
+// IsDefault flag tells the UI whether this row is built-in (and therefore
+// can only be hidden, not edited or deleted).
+type FormTemplateView struct {
+	ID               string             `json:"_id"`
+	CommunityID      string             `json:"communityID"`
+	DepartmentID     string             `json:"departmentId,omitempty"`
+	Name             string             `json:"name"`
+	Slug             string             `json:"slug"`
+	Description      string             `json:"description"`
+	Icon             string             `json:"icon"`
+	CurrentVersion   int32              `json:"currentVersion"`
+	NumberFormat     string             `json:"numberFormat"`
+	VisibleToRoles   []string           `json:"visibleToRoles"`
+	EditableByRoles  []string           `json:"editableByRoles"`
+	LinkableEntities []string           `json:"linkableEntities"`
+	IsDefault        bool               `json:"isDefault"`
+	IsHidden         bool               `json:"isHidden"`
+	IsArchived       bool               `json:"isArchived"`
+	Sections         []FormSection      `json:"sections"`
+	CreatedAt        primitive.DateTime `json:"createdAt,omitempty"`
+	UpdatedAt        primitive.DateTime `json:"updatedAt,omitempty"`
+}

--- a/models/formTemplateVersion.go
+++ b/models/formTemplateVersion.go
@@ -1,0 +1,61 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// FormTemplateVersion is an immutable snapshot of a template's section/field
+// schema. A new row is appended every time a template is saved.
+type FormTemplateVersion struct {
+	ID      primitive.ObjectID         `json:"_id" bson:"_id"`
+	Details FormTemplateVersionDetails `json:"formTemplateVersion" bson:"formTemplateVersion"`
+	Version int32                      `json:"__v" bson:"__v"`
+}
+
+// FormTemplateVersionDetails holds the inner snapshot.
+type FormTemplateVersionDetails struct {
+	FormTemplateID string `json:"formTemplateID" bson:"formTemplateID"` // ObjectID hex; empty for default-template snapshots that aren't stored
+	CommunityID    string `json:"communityID" bson:"communityID"`
+	Slug           string `json:"slug" bson:"slug"`
+	Version        int32  `json:"version" bson:"version"`
+
+	Sections []FormSection `json:"sections" bson:"sections"`
+
+	PublishedAt primitive.DateTime `json:"publishedAt" bson:"publishedAt"`
+	PublishedBy string             `json:"publishedBy" bson:"publishedBy"`
+}
+
+// FormSection is one section in a template (e.g. "Incident Info"). When
+// Repeatable is true, the section produces an array of row objects in the
+// submission data instead of a single object.
+type FormSection struct {
+	ID         string      `json:"id" bson:"id"`
+	Title      string      `json:"title" bson:"title"`
+	Repeatable bool        `json:"repeatable" bson:"repeatable"`
+	MinRows    int         `json:"minRows,omitempty" bson:"minRows,omitempty"`
+	MaxRows    int         `json:"maxRows,omitempty" bson:"maxRows,omitempty"`
+	Fields     []FormField `json:"fields" bson:"fields"`
+}
+
+// FormField is a single input within a section.
+//
+// Type drives the renderer on web/mobile. PopulateFrom drives auto-fill
+// when the submission is created with sources= context (e.g. "from this
+// call, pull callType into this field").
+type FormField struct {
+	ID          string   `json:"id" bson:"id"`
+	Type        string   `json:"type" bson:"type"` // text, textarea, number, date, time, datetime, select, multiSelect, checkbox, radio, penalCodePicker, userPicker, departmentPicker
+	Label       string   `json:"label" bson:"label"`
+	Placeholder string   `json:"placeholder,omitempty" bson:"placeholder,omitempty"`
+	HelpText    string   `json:"helpText,omitempty" bson:"helpText,omitempty"`
+	Required    bool     `json:"required,omitempty" bson:"required,omitempty"`
+	Options     []string `json:"options,omitempty" bson:"options,omitempty"` // for select/radio/multiSelect
+	DefaultExpr string   `json:"defaultExpr,omitempty" bson:"defaultExpr,omitempty"` // "now", "today", "auth.username", "auth.badgeNumber", "auth.departmentName"
+
+	PopulateFrom []FormFieldPopulate `json:"populateFrom,omitempty" bson:"populateFrom,omitempty"`
+}
+
+// FormFieldPopulate maps a field to a path on a source entity. First match
+// wins when multiple sources are provided.
+type FormFieldPopulate struct {
+	Source string `json:"source" bson:"source"` // call, citation, arrestReport, warrant, bolo, civilian, vehicle, firearm
+	Path   string `json:"path" bson:"path"`     // dotted JSON path on the source entity (or special tokens like "criminalHistory.fines[].fineType")
+}

--- a/models/formTemplateVersion.go
+++ b/models/formTemplateVersion.go
@@ -26,10 +26,18 @@ type FormTemplateVersionDetails struct {
 // FormSection is one section in a template (e.g. "Incident Info"). When
 // Repeatable is true, the section produces an array of row objects in the
 // submission data instead of a single object.
+//
+// BindEntity, when set on a repeatable section, anchors each row to a real
+// entity (civilian | vehicle | firearm). The renderer adds a per-row "Link
+// <entity>" control that fetches the entity and auto-fills any field whose
+// PopulateFrom mapping has Source="bound". The picked entity ID is also
+// added to the submission's Links array so future "all reports involving X"
+// queries can use a single index lookup.
 type FormSection struct {
 	ID         string      `json:"id" bson:"id"`
 	Title      string      `json:"title" bson:"title"`
 	Repeatable bool        `json:"repeatable" bson:"repeatable"`
+	BindEntity string      `json:"bindEntity,omitempty" bson:"bindEntity,omitempty"` // "" | civilian | vehicle | firearm
 	MinRows    int         `json:"minRows,omitempty" bson:"minRows,omitempty"`
 	MaxRows    int         `json:"maxRows,omitempty" bson:"maxRows,omitempty"`
 	Fields     []FormField `json:"fields" bson:"fields"`
@@ -55,7 +63,13 @@ type FormField struct {
 
 // FormFieldPopulate maps a field to a path on a source entity. First match
 // wins when multiple sources are provided.
+//
+// Source="bound" is special: it resolves against the entity linked to the
+// field's row (only valid inside a repeatable section whose BindEntity is
+// set). The renderer applies bound paths client-side after the user picks
+// an entity for that row, and never sends "bound" sources to the
+// server-side prefill resolver.
 type FormFieldPopulate struct {
-	Source string `json:"source" bson:"source"` // call, citation, arrestReport, warrant, bolo, civilian, vehicle, firearm
+	Source string `json:"source" bson:"source"` // call, citation, arrestReport, warrant, bolo, civilian, vehicle, firearm, bound
 	Path   string `json:"path" bson:"path"`     // dotted JSON path on the source entity (or special tokens like "criminalHistory.fines[].fineType")
 }

--- a/scripts/create_indexes_configurable_forms.js
+++ b/scripts/create_indexes_configurable_forms.js
@@ -1,0 +1,142 @@
+// MongoDB Index Creation Script — Configurable Forms System
+//
+// Run this in MongoDB Atlas → your cluster → "Browse Collections" → "Shell" tab,
+// OR via mongosh:
+//   mongosh "YOUR_CONNECTION_STRING" < create_indexes_configurable_forms.js
+//
+// Idempotent — safe to run multiple times.
+
+function createIndexSafe(collection, key, options) {
+  const indexes = collection.getIndexes();
+  const keyStr = JSON.stringify(key);
+  const exists = indexes.some(idx => JSON.stringify(idx.key) === keyStr);
+  if (exists) {
+    const existingIdx = indexes.find(idx => JSON.stringify(idx.key) === keyStr);
+    print(`⚠️  Index already exists: ${existingIdx.name} (skipping ${options.name || 'unnamed'})`);
+    return;
+  }
+  try {
+    collection.createIndex(key, options);
+    print(`✓ Created index: ${options.name || 'unnamed'}`);
+  } catch (e) {
+    if (e.code === 85 || e.message.includes("already exists") || e.message.includes("IndexOptionsConflict")) {
+      print(`⚠️  Index already exists (different name): ${options.name || 'unnamed'} - skipping`);
+    } else if (e.code === 11000 || e.message.includes("duplicate key")) {
+      print(`⚠️  Cannot create unique index ${options.name || 'unnamed'}: duplicate keys found.`);
+      print(`   Clean up duplicates first or drop the unique constraint.`);
+    } else {
+      print(`❌ Error creating index ${options.name || 'unnamed'}: ${e.message}`);
+    }
+  }
+}
+
+print("=== Configurable Forms — Index Creation ===");
+
+// formTemplates: lookup by community + slug must be unique so a community
+// can't have two templates with the same slug.
+createIndexSafe(
+  db.formTemplates,
+  { "formTemplate.communityID": 1, "formTemplate.slug": 1 },
+  {
+    name: "formTemplate_community_slug_unique",
+    unique: true,
+    background: true,
+  }
+);
+
+// formTemplateVersions: most reads are by (formTemplateID, version) for
+// hydrating a template at its current version.
+createIndexSafe(
+  db.formTemplateVersions,
+  { "formTemplateVersion.formTemplateID": 1, "formTemplateVersion.version": -1 },
+  {
+    name: "formTemplateVersion_template_version_idx",
+    background: true,
+  }
+);
+
+// departmentFormToggles: lookup by community + department + slug must be
+// unique so the upsert path stays atomic.
+createIndexSafe(
+  db.departmentFormToggles,
+  {
+    "departmentFormToggle.communityID": 1,
+    "departmentFormToggle.departmentId": 1,
+    "departmentFormToggle.formTemplateSlug": 1,
+  },
+  {
+    name: "departmentFormToggle_unique",
+    unique: true,
+    background: true,
+  }
+);
+
+// formSubmissions: report number must be unique within a community.
+createIndexSafe(
+  db.formSubmissions,
+  { "formSubmission.communityID": 1, "formSubmission.reportNumber": 1 },
+  {
+    name: "formSubmission_community_reportNumber_unique",
+    unique: true,
+    background: true,
+  }
+);
+
+// formSubmissions: paginated list-by-community filtered by template slug.
+createIndexSafe(
+  db.formSubmissions,
+  {
+    "formSubmission.communityID": 1,
+    "formSubmission.formTemplateSlug": 1,
+    "formSubmission.createdAt": -1,
+  },
+  {
+    name: "formSubmission_community_slug_createdAt_idx",
+    background: true,
+  }
+);
+
+// formSubmissions: department-scoped list.
+createIndexSafe(
+  db.formSubmissions,
+  { "formSubmission.communityID": 1, "formSubmission.departmentId": 1, "formSubmission.createdAt": -1 },
+  {
+    name: "formSubmission_community_department_createdAt_idx",
+    background: true,
+  }
+);
+
+// formSubmissions: lookup-by-link is the index that makes
+// civilian/vehicle/firearm/citation profile pages fast.
+createIndexSafe(
+  db.formSubmissions,
+  { "formSubmission.links.type": 1, "formSubmission.links.id": 1 },
+  {
+    name: "formSubmission_links_type_id_idx",
+    background: true,
+  }
+);
+
+// formSubmissions: officer-scoped list.
+createIndexSafe(
+  db.formSubmissions,
+  { "formSubmission.signedBy.userID": 1, "formSubmission.createdAt": -1 },
+  {
+    name: "formSubmission_signedBy_user_createdAt_idx",
+    background: true,
+  }
+);
+
+// formCounters: atomic FindOneAndUpdate filter — must be unique to avoid
+// counter races across replicas.
+createIndexSafe(
+  db.formCounters,
+  { "communityID": 1, "slug": 1, "year": 1 },
+  {
+    name: "formCounter_unique",
+    unique: true,
+    background: true,
+  }
+);
+
+print("=== Done. Run check_indexes.js to verify, or db.<collection>.getIndexes() ===");

--- a/scripts/create_indexes_configurable_forms.js
+++ b/scripts/create_indexes_configurable_forms.js
@@ -7,8 +7,20 @@
 // Idempotent — safe to run multiple times.
 
 function createIndexSafe(collection, key, options) {
-  const indexes = collection.getIndexes();
   const keyStr = JSON.stringify(key);
+  // getIndexes() throws "ns does not exist" on collections that haven't
+  // been created yet. Treat that as "no indexes exist" and proceed —
+  // createIndex will create the collection.
+  let indexes = [];
+  try {
+    indexes = collection.getIndexes();
+  } catch (e) {
+    if (!(e.code === 26 || e.codeName === "NamespaceNotFound" || (e.message || "").includes("ns does not exist"))) {
+      print(`❌ Could not read existing indexes for ${collection.getName()}: ${e.message}`);
+      return;
+    }
+    // Otherwise: collection doesn't exist yet — fall through and create.
+  }
   const exists = indexes.some(idx => JSON.stringify(idx.key) === keyStr);
   if (exists) {
     const existingIdx = indexes.find(idx => JSON.stringify(idx.key) === keyStr);
@@ -17,7 +29,7 @@ function createIndexSafe(collection, key, options) {
   }
   try {
     collection.createIndex(key, options);
-    print(`✓ Created index: ${options.name || 'unnamed'}`);
+    print(`✓ Created index: ${options.name || 'unnamed'} on ${collection.getName()}`);
   } catch (e) {
     if (e.code === 85 || e.message.includes("already exists") || e.message.includes("IndexOptionsConflict")) {
       print(`⚠️  Index already exists (different name): ${options.name || 'unnamed'} - skipping`);


### PR DESCRIPTION
## Summary
- Adds a community-scoped form-template engine so admins can ship custom report types without code changes. Defaults are code-defined (Incident Report shipped) and merged virtually into community lists at read time; a community can hide a default by inserting a marker row.
- Submissions snapshot the template version on create so historical reports keep rendering correctly after admins edit a template.
- Auto-fill: each field declares ``populateFrom`` mappings; the ``POST /api/v1/form-submission/draft`` endpoint resolves them against fetched source entities (call/arrestReport in v1) and returns a prefilled data map for the website's "Start from" panel.

## What's new

**5 new collections**
- ``formTemplates`` — community-scoped template metadata
- ``formTemplateVersions`` — immutable section/field snapshots, appended on every save
- ``departmentFormToggles`` — per-department enable/disable overrides (implicit-enabled when no row exists)
- ``formSubmissions`` — filled instances; ``links[]`` array enables civilian/vehicle/firearm/citation/call/arrestReport/warrant/bolo cross-linking
- ``formCounters`` — atomic per-(community, slug, year) sequence used to generate ``RR-YYYY-NNNNNN`` report numbers

**16 new routes** across ``/api/v1`` and ``/api/v2``: template CRUD, version history, default-hide override, paginated community/department template lists, submission CRUD, draft prefill, paginated submission list, by-link lookup for entity profile pages.

**Default Incident Report template** matches the spec the customer provided — 12 sections (Incident Info, Location Details, Unit Information, Reporting Party, Suspects, Victims, Narrative, Charges/Violations, Evidence/Property, Medical/Fire Response, Dispatch Notes, Approval) with auto-fill mappings for Call and Arrest Report sources plus ``DefaultExpr`` auth-context fills (officer name, badge, today, now).

## Known v1 limitations (deferred follow-ups)
- **Mongo indexes are NOT auto-created.** Add via Atlas before going live: ``formSubmissions {communityID, reportNumber}`` unique, ``formTemplates {communityID, slug}`` unique, ``departmentFormToggles {communityID, departmentID, formTemplateSlug}`` unique, ``formSubmissions {links.type, links.id}``.
- Citation source auto-fill from embedded ``civilian.criminalHistory[]`` is stubbed — clients pass values through ``data`` overrides for now.
- Repeatable section row pre-population (e.g. arrestee → suspects[0]) is deferred — clients prefill these client-side.
- Mock files for the new database interfaces aren't generated.

## Test plan
- [ ] ``go build ./...`` passes (verified locally, exit 0)
- [ ] ``go vet`` passes on new files (verified locally, no new warnings)
- [ ] Smoke against police-cad-dev: list defaults via ``GET /api/v2/form-templates/community/{id}`` returns the Incident Report template
- [ ] Create a submission via ``POST /api/v1/form-submission`` with ``communityID`` + ``formTemplateSlug=incident-report``; verify ``reportNumber`` is auto-generated and unique within the community
- [ ] Save the same payload twice; verify the counter increments (no duplicate report numbers)
- [ ] Hide the default via ``PUT /api/v1/form-template/community/{id}/default/incident-report/hide``; verify it disappears from the v2 list
- [ ] Restore via the same endpoint with ``?hidden=false``
- [ ] Edit a stored template; verify ``currentVersion`` bumps and a new ``formTemplateVersions`` row is appended
- [ ] Pull a draft via ``POST /api/v1/form-submission/draft`` with ``sources: [{type:"call", id:"..."}]``; verify ``data`` contains prefilled top-level fields (callType, address, etc.)
- [ ] After deploy: add the four Mongo indexes listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)