### PR TITLE
fix: populate reasonCounts/entries in admin beta-feedback endpoint

### DIFF
--- a/api/handlers/betafeedback.go
+++ b/api/handlers/betafeedback.go
@@ -128,17 +128,22 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 		config.ErrorStatus("failed to aggregate beta feedback", http.StatusInternalServerError, w, err)
 		return
 	}
-	reasonCounts := map[string]int64{}
-	for cur.Next(ctx) {
-		var row struct {
-			ID    string `bson:"_id"`
-			Count int64  `bson:"count"`
-		}
-		if err := cur.Decode(&row); err == nil {
-			reasonCounts[row.ID] = row.Count
-		}
+	// Custom MongoCursor wrapper: Decode() calls All() under the hood, so we
+	// decode into a slice in one shot rather than iterating with Next/Decode.
+	var rows []struct {
+		ID    string `bson:"_id"`
+		Count int64  `bson:"count"`
+	}
+	if err := cur.All(ctx, &rows); err != nil {
+		_ = cur.Close(ctx)
+		config.ErrorStatus("failed to decode beta feedback aggregation", http.StatusInternalServerError, w, err)
+		return
 	}
 	_ = cur.Close(ctx)
+	reasonCounts := map[string]int64{}
+	for _, row := range rows {
+		reasonCounts[row.ID] = row.Count
+	}
 
 	findOpts := options.Find().
 		SetSort(bson.D{{Key: "createdAt", Value: -1}}).
@@ -152,11 +157,9 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 	defer cursor.Close(ctx)
 
 	entries := []models.BetaFeedback{}
-	for cursor.Next(ctx) {
-		var doc models.BetaFeedback
-		if err := cursor.Decode(&doc); err == nil {
-			entries = append(entries, doc)
-		}
+	if err := cursor.All(ctx, &entries); err != nil {
+		config.ErrorStatus("failed to decode beta feedback", http.StatusInternalServerError, w, err)
+		return
 	}
 
 	resp := map[string]interface{}{


### PR DESCRIPTION
## Summary

- Admin console "Beta Opt-Out Feedback" panel showed `totalCount: 5` but every reason chip rendered `0` and the recent-comments list was empty. Live API response was `{"data":[],"reasonCounts":{},"totalCount":5}` despite valid docs in MongoDB.
- Root cause: the repo's custom `MongoCursor` wrapper redefines `Decode(v)` as `All(ctx, v)` (decodes the entire cursor into a slice). The handler used the standard idiom `for cur.Next(ctx) { cur.Decode(&row) }`, so each call tried to decode the whole cursor into a single struct, errored, and the error was silently ignored — leaving `reasonCounts` and `entries` empty. `community.go:7291` already has a comment warning about this exact footgun.
- Fix: replace both Next/Decode loops in `ListBetaFeedbackHandler` with `cursor.All(ctx, &slice)` bulk-decode.

## Test plan

- [ ] `go build ./api/handlers/...` (passes locally)
- [ ] Hit `GET /api/v1/admin/beta-feedback?flag=betaCommandDispatch&limit=100` against dev and verify `reasonCounts` is populated (e.g. `{"missing_features":3,"preferred_old":1,"look_and_feel":1}`) and `data` contains the 5 entries
- [ ] Open admin console → Beta Opt-Out Feedback section → confirm distribution chips render non-zero counts and percentages
- [ ] Switch tabs between Command Dashboard and Command Bridge and confirm both populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)