### PR TITLE
feat(beta-feedback): resolve + soft-delete admin actions

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -425,6 +425,8 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/beta-dashboard-metrics/daily", http.HandlerFunc(userPrefs.GetBetaDashboardMetricsDailyHandler)).Methods("GET")
 	apiCreate.Handle("/beta-feedback", http.HandlerFunc(betaFeedback.CreateBetaFeedbackHandler)).Methods("POST")
 	apiCreate.Handle("/admin/beta-feedback", http.HandlerFunc(betaFeedback.ListBetaFeedbackHandler)).Methods("GET")
+	apiCreate.Handle("/admin/beta-feedback/{id}", http.HandlerFunc(betaFeedback.ResolveBetaFeedbackHandler)).Methods("PATCH")
+	apiCreate.Handle("/admin/beta-feedback/{id}", http.HandlerFunc(betaFeedback.DeleteBetaFeedbackHandler)).Methods("DELETE")
 
 	// Civilian approval routes (must come before parameterized routes)
 	apiCreate.Handle("/civilian/approval", api.Middleware(http.HandlerFunc(civ.CivilianApprovalHandler))).Methods("POST")

--- a/api/handlers/betafeedback.go
+++ b/api/handlers/betafeedback.go
@@ -177,12 +177,16 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	// Sibling counts so the UI can show "Open (N) · Resolved (M)"
-	// without firing a second request.
+	// without firing a second request. Only entries with a non-empty
+	// free-form `feedback` are counted — those are the ones the admin
+	// can actually triage. The reason-distribution chips above still
+	// reflect the full opt-out volume.
 	statusBaseFilter := bson.M{
 		"$or": []bson.M{
 			{"deletedAt": bson.M{"$exists": false}},
 			{"deletedAt": nil},
 		},
+		"feedback": bson.M{"$exists": true, "$ne": ""},
 	}
 	if flag, ok := filter["flag"]; ok {
 		statusBaseFilter["flag"] = flag
@@ -210,6 +214,18 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 		config.ErrorStatus("failed to count resolved beta feedback", http.StatusInternalServerError, w, err)
 		return
 	}
+	// Total commentable entries in the current status window — used for
+	// the "X comments" label on the panel. Excludes empty-feedback rows.
+	commentFilter := bson.M{}
+	for k, v := range filter {
+		commentFilter[k] = v
+	}
+	commentFilter["feedback"] = bson.M{"$exists": true, "$ne": ""}
+	commentCount, err := b.DB.CountDocuments(ctx, commentFilter)
+	if err != nil {
+		config.ErrorStatus("failed to count beta feedback comments", http.StatusInternalServerError, w, err)
+		return
+	}
 
 	findOpts := options.Find().
 		SetSort(bson.D{{Key: "createdAt", Value: -1}}).
@@ -231,6 +247,7 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 	resp := map[string]interface{}{
 		"data":          entries,
 		"totalCount":    total,
+		"commentCount":  commentCount,
 		"page":          page,
 		"limit":         limit,
 		"reasonCounts":  reasonCounts,

--- a/api/handlers/betafeedback.go
+++ b/api/handlers/betafeedback.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/linesmerrill/police-cad-api/config"
 	"github.com/linesmerrill/police-cad-api/databases"
 	"github.com/linesmerrill/police-cad-api/models"
@@ -84,16 +85,46 @@ func (b BetaFeedback) CreateBetaFeedbackHandler(w http.ResponseWriter, r *http.R
 }
 
 // ListBetaFeedbackHandler returns feedback entries for the admin console.
-// Supports `flag`, `limit`, and `page` query params. Sorted newest first.
+// Supports `flag`, `status` (open|resolved|all), `limit`, and `page`
+// query params. Sorted newest first. Soft-deleted entries are always
+// excluded.
 func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	filter := bson.M{}
+	// Always exclude soft-deleted entries from the admin list.
+	filter := bson.M{
+		"$or": []bson.M{
+			{"deletedAt": bson.M{"$exists": false}},
+			{"deletedAt": nil},
+		},
+	}
 	if flag := q.Get("flag"); flag != "" {
 		if !validFlags[flag] {
 			config.ErrorStatus("unknown flag", http.StatusBadRequest, w, nil)
 			return
 		}
 		filter["flag"] = flag
+	}
+
+	// Status: open (default) hides resolved entries; resolved shows
+	// only resolved; all shows both. Counts are always computed against
+	// the same status window so the distribution chips reflect the list.
+	status := q.Get("status")
+	if status == "" {
+		status = "open"
+	}
+	switch status {
+	case "open":
+		filter["$and"] = []bson.M{{"$or": []bson.M{
+			{"resolvedAt": bson.M{"$exists": false}},
+			{"resolvedAt": nil},
+		}}}
+	case "resolved":
+		filter["resolvedAt"] = bson.M{"$ne": nil}
+	case "all":
+		// no extra filter
+	default:
+		config.ErrorStatus("unknown status", http.StatusBadRequest, w, nil)
+		return
 	}
 
 	limit := int64(50)
@@ -145,6 +176,41 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 		reasonCounts[row.ID] = row.Count
 	}
 
+	// Sibling counts so the UI can show "Open (N) · Resolved (M)"
+	// without firing a second request.
+	statusBaseFilter := bson.M{
+		"$or": []bson.M{
+			{"deletedAt": bson.M{"$exists": false}},
+			{"deletedAt": nil},
+		},
+	}
+	if flag, ok := filter["flag"]; ok {
+		statusBaseFilter["flag"] = flag
+	}
+	openFilter := bson.M{}
+	for k, v := range statusBaseFilter {
+		openFilter[k] = v
+	}
+	openFilter["$and"] = []bson.M{{"$or": []bson.M{
+		{"resolvedAt": bson.M{"$exists": false}},
+		{"resolvedAt": nil},
+	}}}
+	openCount, err := b.DB.CountDocuments(ctx, openFilter)
+	if err != nil {
+		config.ErrorStatus("failed to count open beta feedback", http.StatusInternalServerError, w, err)
+		return
+	}
+	resolvedFilter := bson.M{}
+	for k, v := range statusBaseFilter {
+		resolvedFilter[k] = v
+	}
+	resolvedFilter["resolvedAt"] = bson.M{"$ne": nil}
+	resolvedCount, err := b.DB.CountDocuments(ctx, resolvedFilter)
+	if err != nil {
+		config.ErrorStatus("failed to count resolved beta feedback", http.StatusInternalServerError, w, err)
+		return
+	}
+
 	findOpts := options.Find().
 		SetSort(bson.D{{Key: "createdAt", Value: -1}}).
 		SetSkip(skip).
@@ -163,12 +229,87 @@ func (b BetaFeedback) ListBetaFeedbackHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	resp := map[string]interface{}{
-		"data":         entries,
-		"totalCount":   total,
-		"page":         page,
-		"limit":        limit,
-		"reasonCounts": reasonCounts,
+		"data":          entries,
+		"totalCount":    total,
+		"page":          page,
+		"limit":         limit,
+		"reasonCounts":  reasonCounts,
+		"openCount":     openCount,
+		"resolvedCount": resolvedCount,
+		"status":        status,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// resolveBody is the PATCH body for ResolveBetaFeedbackHandler. Setting
+// resolved=false reopens an entry; resolved=true marks it completed.
+type resolveBody struct {
+	Resolved   bool   `json:"resolved"`
+	ResolvedBy string `json:"resolvedBy"`
+}
+
+// ResolveBetaFeedbackHandler toggles the resolved state of an entry.
+// PATCH /api/v1/admin/beta-feedback/{id}
+func (b BetaFeedback) ResolveBetaFeedbackHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		config.ErrorStatus("invalid id", http.StatusBadRequest, w, err)
+		return
+	}
+	var req resolveBody
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("failed to decode request", http.StatusBadRequest, w, err)
+		return
+	}
+	if len(req.ResolvedBy) > 200 {
+		req.ResolvedBy = req.ResolvedBy[:200]
+	}
+
+	var update bson.M
+	if req.Resolved {
+		now := primitive.NewDateTimeFromTime(time.Now())
+		update = bson.M{"$set": bson.M{
+			"resolvedAt": now,
+			"resolvedBy": req.ResolvedBy,
+		}}
+	} else {
+		update = bson.M{"$unset": bson.M{
+			"resolvedAt": "",
+			"resolvedBy": "",
+		}}
+	}
+	if err := b.DB.UpdateOne(context.Background(), bson.M{"_id": objID}, update); err != nil {
+		config.ErrorStatus("failed to update beta feedback", http.StatusInternalServerError, w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true, "resolved": req.Resolved})
+}
+
+// DeleteBetaFeedbackHandler soft-deletes (default) or restores an entry.
+// DELETE /api/v1/admin/beta-feedback/{id}              -> soft-delete
+// DELETE /api/v1/admin/beta-feedback/{id}?undo=true    -> restore
+func (b BetaFeedback) DeleteBetaFeedbackHandler(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	objID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		config.ErrorStatus("invalid id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	var update bson.M
+	if r.URL.Query().Get("undo") == "true" {
+		update = bson.M{"$unset": bson.M{"deletedAt": ""}}
+	} else {
+		now := primitive.NewDateTimeFromTime(time.Now())
+		update = bson.M{"$set": bson.M{"deletedAt": now}}
+	}
+	if err := b.DB.UpdateOne(context.Background(), bson.M{"_id": objID}, update); err != nil {
+		config.ErrorStatus("failed to delete beta feedback", http.StatusInternalServerError, w, err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
 }

--- a/databases/betafeedback.go
+++ b/databases/betafeedback.go
@@ -15,6 +15,7 @@ type BetaFeedbackDatabase interface {
 	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (*MongoCursor, error)
 	CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
 	Aggregate(ctx context.Context, pipeline interface{}) (*MongoCursor, error)
+	UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error
 }
 
 type betaFeedbackDatabase struct {
@@ -40,4 +41,9 @@ func (b *betaFeedbackDatabase) CountDocuments(ctx context.Context, filter interf
 
 func (b *betaFeedbackDatabase) Aggregate(ctx context.Context, pipeline interface{}) (*MongoCursor, error) {
 	return b.db.Collection(betaFeedbackName).Aggregate(ctx, pipeline)
+}
+
+func (b *betaFeedbackDatabase) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error {
+	_, err := b.db.Collection(betaFeedbackName).UpdateOne(ctx, filter, update, opts...)
+	return err
 }

--- a/models/betafeedback.go
+++ b/models/betafeedback.go
@@ -7,22 +7,31 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 // user) — each disable creates a new document. UserID is retained for
 // follow-up but the admin UI surfaces feedback anonymously.
 type BetaFeedback struct {
-	ID        primitive.ObjectID `json:"_id"       bson:"_id"`
-	UserID    string             `json:"userId"    bson:"userId"`
+	ID     primitive.ObjectID `json:"_id"    bson:"_id"`
+	UserID string             `json:"userId" bson:"userId"`
 	// Flag is the user-preferences field name being toggled off, e.g.
 	// "betaCommandDashboard" or "betaCommandDispatch".
-	Flag      string             `json:"flag"      bson:"flag"`
+	Flag string `json:"flag" bson:"flag"`
 	// Reason is one of a small enum surfaced in the disable modal:
 	//   too_buggy | look_and_feel | preferred_old | missing_features |
 	//   performance | other
-	Reason    string             `json:"reason"    bson:"reason"`
+	Reason string `json:"reason" bson:"reason"`
 	// Feedback is an optional free-form comment from the user.
-	Feedback  string             `json:"feedback"  bson:"feedback"`
+	Feedback string `json:"feedback" bson:"feedback"`
 	// Context is the page the user was on when they disabled (e.g.
 	// "/dispatch-dashboard", "/command-dashboard"). Helps triage bug
 	// reports by where the pain happened.
 	Context   string             `json:"context"   bson:"context"`
 	CreatedAt primitive.DateTime `json:"createdAt" bson:"createdAt"`
+	// ResolvedAt is set when an admin marks the entry as completed
+	// (e.g. once the reported issue has been fixed). Nil while open.
+	ResolvedAt *primitive.DateTime `json:"resolvedAt,omitempty" bson:"resolvedAt,omitempty"`
+	// ResolvedBy is the admin email/id that marked it resolved.
+	ResolvedBy string `json:"resolvedBy,omitempty" bson:"resolvedBy,omitempty"`
+	// DeletedAt is a soft-delete marker. Entries with a non-nil
+	// DeletedAt are excluded from the admin list view. Kept around so
+	// an accidental delete can be undone.
+	DeletedAt *primitive.DateTime `json:"deletedAt,omitempty" bson:"deletedAt,omitempty"`
 }
 
 // CreateBetaFeedbackRequest is the POST /api/v1/beta-feedback body.


### PR DESCRIPTION
## Summary
- Adds `resolvedAt` / `resolvedBy` / `deletedAt` to `BetaFeedback` so admins can mark opt-out comments completed (e.g. once a fix ships) or remove spam without losing the underlying data.
- New endpoints:
  - `PATCH /api/v1/admin/beta-feedback/{id}` — toggle resolved state via `{resolved, resolvedBy}`
  - `DELETE /api/v1/admin/beta-feedback/{id}` — soft-delete; `?undo=true` restores
- `ListBetaFeedbackHandler` now excludes soft-deleted entries, accepts `?status=open|resolved|all`, and returns `openCount` / `resolvedCount` so the admin UI renders the Open/Resolved pill counts in one round-trip.

Pairs with the matching admin-console UI changes on the police-cad website (separate branch).

## Test plan
- [ ] \`go build ./...\` passes
- [ ] Existing \`GET /api/v1/admin/beta-feedback\` still returns the same shape plus the new \`openCount\`, \`resolvedCount\`, \`status\` fields
- [ ] \`PATCH .../{id}\` with \`{resolved: true}\` sets \`resolvedAt\`/\`resolvedBy\`; \`{resolved: false}\` unsets both
- [ ] \`DELETE .../{id}\` sets \`deletedAt\`; entry disappears from default list; \`?undo=true\` clears \`deletedAt\` and the entry returns
- [ ] Soft-deleted entries never appear in list regardless of \`status\` value
- [ ] Invalid \`id\` (non-hex / wrong length) returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)