### PR TITLE
feat(economy): Jobs as a first-class concept, separate from Departments

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -324,6 +324,11 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/community/{communityId}/tenCodes/{codeId}", api.Middleware(http.HandlerFunc(c.UpdateTenCodeHandler))).Methods("PUT")
 	apiCreate.Handle("/community/{communityId}/tenCodes/{codeId}", api.Middleware(http.HandlerFunc(c.DeleteTenCodeHandler))).Methods("DELETE")
 	apiCreate.Handle("/community/{communityId}/tenCodes", api.Middleware(http.HandlerFunc(c.AddTenCodeHandler))).Methods("POST")
+
+	// Economy Jobs (community-level RP occupations, distinct from Departments)
+	apiCreate.Handle("/community/{communityId}/jobs", api.Middleware(http.HandlerFunc(c.AddJobHandler))).Methods("POST")
+	apiCreate.Handle("/community/{communityId}/jobs/{jobId}", api.Middleware(http.HandlerFunc(c.UpdateJobHandler))).Methods("PUT")
+	apiCreate.Handle("/community/{communityId}/jobs/{jobId}", api.Middleware(http.HandlerFunc(c.DeleteJobHandler))).Methods("DELETE")
 	apiCreate.Handle("/community/{communityId}/members/{userId}/tenCode", api.Middleware(http.HandlerFunc(c.SetMemberTenCodeHandler))).Methods("PUT")
 	apiCreate.Handle("/community/{communityId}/members/{userId}/department-callsigns", api.Middleware(http.HandlerFunc(c.GetDepartmentCallSignsHandler))).Methods("GET")
 	apiCreate.Handle("/community/{communityId}/members/{userId}/department-callsigns", api.Middleware(http.HandlerFunc(c.SetDepartmentCallSignHandler))).Methods("PUT")

--- a/api/handlers/community_jobs.go
+++ b/api/handlers/community_jobs.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/config"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// jobRequestBody is the shape accepted by AddJobHandler / UpdateJobHandler.
+// All numeric fields use cents for money and seconds/minutes for durations,
+// matching the persistence shape — the frontend converts at the edges.
+type jobRequestBody struct {
+	Name                     string `json:"name"`
+	Description              string `json:"description"`
+	Icon                     string `json:"icon"`
+	Color                    string `json:"color"`
+	PayPerHour               int64  `json:"payPerHour"`
+	MaxSessionMinutes        int    `json:"maxSessionMinutes"`
+	AfkPromptIntervalSeconds int    `json:"afkPromptIntervalSeconds"`
+	AfkGraceSeconds          int    `json:"afkGraceSeconds"`
+	PayoutMode               string `json:"payoutMode"`
+	RequiresFirearmLicense   bool   `json:"requiresFirearmLicense"`
+	RequiresDriversLicense   bool   `json:"requiresDriversLicense"`
+	Archived                 bool   `json:"archived"`
+	SortOrder                int    `json:"sortOrder"`
+}
+
+func (b jobRequestBody) intoModel(now primitive.DateTime) models.Job {
+	payoutMode := b.PayoutMode
+	if payoutMode != "on_clockout" {
+		payoutMode = "on_heartbeat"
+	}
+	maxSession := b.MaxSessionMinutes
+	if maxSession <= 0 {
+		maxSession = 120
+	}
+	afkPrompt := b.AfkPromptIntervalSeconds
+	if afkPrompt <= 0 {
+		afkPrompt = 600
+	}
+	afkGrace := b.AfkGraceSeconds
+	if afkGrace <= 0 {
+		afkGrace = 60
+	}
+	return models.Job{
+		Name:                     b.Name,
+		Description:              b.Description,
+		Icon:                     b.Icon,
+		Color:                    b.Color,
+		PayPerHour:               b.PayPerHour,
+		MaxSessionMinutes:        maxSession,
+		AfkPromptIntervalSeconds: afkPrompt,
+		AfkGraceSeconds:          afkGrace,
+		PayoutMode:               payoutMode,
+		RequiresFirearmLicense:   b.RequiresFirearmLicense,
+		RequiresDriversLicense:   b.RequiresDriversLicense,
+		Archived:                 b.Archived,
+		SortOrder:                b.SortOrder,
+		UpdatedAt:                now,
+	}
+}
+
+// AddJobHandler appends a new Job to a community's jobs[] array.
+// POST /api/v1/community/{communityId}/jobs
+func (c Community) AddJobHandler(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["communityId"]
+
+	var body jobRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if body.Name == "" {
+		config.ErrorStatus("name is required", http.StatusBadRequest, w, nil)
+		return
+	}
+
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		config.ErrorStatus("invalid community ID", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	job := body.intoModel(now)
+	job.ID = primitive.NewObjectID()
+	job.CreatedAt = now
+
+	err = c.DB.UpdateOne(ctx, bson.M{"_id": cID}, bson.M{"$push": bson.M{"community.jobs": job}})
+	if err != nil {
+		config.ErrorStatus("failed to add job", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	actorID := resolveActorFromRequest(r)
+	logAudit(c.ALDB, cID, "job.created", "economy", actorID, resolveActorName(c.UDB, actorID), job.ID.Hex(), job.Name, nil)
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{"job": job})
+}
+
+// UpdateJobHandler patches fields on an existing Job within a community.
+// PUT /api/v1/community/{communityId}/jobs/{jobId}
+func (c Community) UpdateJobHandler(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["communityId"]
+	jobID := mux.Vars(r)["jobId"]
+
+	var body jobRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		config.ErrorStatus("invalid community ID", http.StatusBadRequest, w, err)
+		return
+	}
+	jOID, err := primitive.ObjectIDFromHex(jobID)
+	if err != nil {
+		config.ErrorStatus("invalid job ID", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	patch := body.intoModel(now)
+	filter := bson.M{"_id": cID, "community.jobs._id": jOID}
+	update := bson.M{"$set": bson.M{
+		"community.jobs.$.name":                     patch.Name,
+		"community.jobs.$.description":              patch.Description,
+		"community.jobs.$.icon":                     patch.Icon,
+		"community.jobs.$.color":                    patch.Color,
+		"community.jobs.$.payPerHour":               patch.PayPerHour,
+		"community.jobs.$.maxSessionMinutes":        patch.MaxSessionMinutes,
+		"community.jobs.$.afkPromptIntervalSeconds": patch.AfkPromptIntervalSeconds,
+		"community.jobs.$.afkGraceSeconds":          patch.AfkGraceSeconds,
+		"community.jobs.$.payoutMode":               patch.PayoutMode,
+		"community.jobs.$.requiresFirearmLicense":   patch.RequiresFirearmLicense,
+		"community.jobs.$.requiresDriversLicense":   patch.RequiresDriversLicense,
+		"community.jobs.$.archived":                 patch.Archived,
+		"community.jobs.$.sortOrder":                patch.SortOrder,
+		"community.jobs.$.updatedAt":                now,
+	}}
+	if err := c.DB.UpdateOne(ctx, filter, update); err != nil {
+		config.ErrorStatus("failed to update job", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	actorID := resolveActorFromRequest(r)
+	logAudit(c.ALDB, cID, "job.updated", "economy", actorID, resolveActorName(c.UDB, actorID), jobID, patch.Name, nil)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"message":"Job updated"}`))
+}
+
+// DeleteJobHandler removes a Job entry from a community.
+// DELETE /api/v1/community/{communityId}/jobs/{jobId}
+func (c Community) DeleteJobHandler(w http.ResponseWriter, r *http.Request) {
+	communityID := mux.Vars(r)["communityId"]
+	jobID := mux.Vars(r)["jobId"]
+
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		config.ErrorStatus("invalid community ID", http.StatusBadRequest, w, err)
+		return
+	}
+	jOID, err := primitive.ObjectIDFromHex(jobID)
+	if err != nil {
+		config.ErrorStatus("invalid job ID", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	err = c.DB.UpdateOne(ctx, bson.M{"_id": cID}, bson.M{"$pull": bson.M{"community.jobs": bson.M{"_id": jOID}}})
+	if err != nil {
+		config.ErrorStatus("failed to delete job", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	actorID := resolveActorFromRequest(r)
+	logAudit(c.ALDB, cID, "job.deleted", "economy", actorID, resolveActorName(c.UDB, actorID), jobID, "", nil)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"message":"Job deleted"}`))
+}

--- a/api/handlers/economy.go
+++ b/api/handlers/economy.go
@@ -86,17 +86,36 @@ func findUserMembership(dept *models.Department, userID string) (rankID string, 
 	return "", false
 }
 
-// findCivilianMembership returns the rankId for a civilian in a civilian-kind department.
-func findCivilianMembership(dept *models.Department, civilianID string) (rankID, userID string, found bool) {
-	if dept == nil {
-		return "", "", false
+// resolveJob returns the named job from a community plus its effective economy settings
+// (with sensible defaults applied for missing values).
+func resolveJob(community *models.Community, jobID string) (job *models.Job, payRate int64, payoutMode string, maxSessionMin, afkGrace int, ok bool) {
+	if community == nil || jobID == "" {
+		return nil, 0, "", 0, 0, false
 	}
-	for _, m := range dept.CivilianMembers {
-		if m.CivilianID == civilianID {
-			return m.RankID, m.UserID, true
+	for i := range community.Details.Jobs {
+		j := &community.Details.Jobs[i]
+		if j.ID.Hex() == jobID {
+			job = j
+			break
 		}
 	}
-	return "", "", false
+	if job == nil || job.Archived {
+		return nil, 0, "", 0, 0, false
+	}
+	payRate = job.PayPerHour
+	payoutMode = job.PayoutMode
+	if payoutMode == "" {
+		payoutMode = "on_heartbeat"
+	}
+	maxSessionMin = job.MaxSessionMinutes
+	if maxSessionMin <= 0 {
+		maxSessionMin = 120
+	}
+	afkGrace = job.AfkGraceSeconds
+	if afkGrace <= 0 {
+		afkGrace = 60
+	}
+	return job, payRate, payoutMode, maxSessionMin, afkGrace, true
 }
 
 // paySession computes earnings to credit from session.LastPayoutAt (or StartedAt) up to `now`,
@@ -208,21 +227,29 @@ func (e Economy) ensureBalanceInitialized(ctx context.Context, civ *models.Civil
 // ---- handlers ----
 
 // clockInRequest is the body for POST /api/v2/economy/clock-in.
+// Exactly one of DepartmentID or JobID must be set:
+//   - DepartmentID + (optional civilianId) → user clocks in to a CAD department (police, EMS, ...)
+//   - JobID + civilianId → civilian clocks in to a community Job (Sanitation, Mechanic, ...)
 type clockInRequest struct {
 	CommunityID  string `json:"communityId"`
-	DepartmentID string `json:"departmentId"`
+	DepartmentID string `json:"departmentId,omitempty"`
+	JobID        string `json:"jobId,omitempty"`
 	CivilianID   string `json:"civilianId,omitempty"`
 }
 
-// ClockInHandler starts a clock session for a user (or civilian, for civilian-kind depts).
+// ClockInHandler starts a clock session against either a department or a job.
 func (e Economy) ClockInHandler(w http.ResponseWriter, r *http.Request) {
 	var req clockInRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if req.CommunityID == "" || req.DepartmentID == "" {
-		config.ErrorStatus("communityId and departmentId required", http.StatusBadRequest, w, nil)
+	if req.CommunityID == "" {
+		config.ErrorStatus("communityId required", http.StatusBadRequest, w, nil)
+		return
+	}
+	if (req.DepartmentID == "" && req.JobID == "") || (req.DepartmentID != "" && req.JobID != "") {
+		config.ErrorStatus("exactly one of departmentId or jobId required", http.StatusBadRequest, w, nil)
 		return
 	}
 	userID := api.GetAuthenticatedUserIDFromContext(r.Context())
@@ -252,36 +279,69 @@ func (e Economy) ClockInHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dept, payRate, payoutMode, maxSession, afkGrace, ok := resolveDepartmentEconomy(community, req.DepartmentID, "")
-	if !ok {
-		config.ErrorStatus("department not found", http.StatusNotFound, w, nil)
-		return
-	}
-	if !dept.EconomyEnabled {
-		config.ErrorStatus("economy is disabled for this department", http.StatusForbidden, w, nil)
-		return
+	nowDT := primitive.NewDateTimeFromTime(time.Now())
+	sess := models.ClockSession{
+		ID:              primitive.NewObjectID(),
+		CommunityID:     req.CommunityID,
+		UserID:          userID,
+		CivilianID:      req.CivilianID,
+		Status:          "active",
+		StartedAt:       nowDT,
+		LastHeartbeatAt: nowDT,
+		LastPayoutAt:    nowDT,
+		CreatedAt:       nowDT,
+		UpdatedAt:       nowDT,
 	}
 
-	var rankID string
-	isCivilianDept := dept.DepartmentKind == "civilian"
-	if isCivilianDept {
+	if req.JobID != "" {
+		// ---- Job clock-in ----
 		if req.CivilianID == "" {
-			config.ErrorStatus("civilianId required for civilian-kind department", http.StatusBadRequest, w, nil)
+			config.ErrorStatus("civilianId required for job clock-in", http.StatusBadRequest, w, nil)
 			return
 		}
-		var memberUserID string
-		var found bool
-		rankID, memberUserID, found = findCivilianMembership(dept, req.CivilianID)
-		if !found || memberUserID != userID {
-			config.ErrorStatus("civilian is not a member of this department", http.StatusForbidden, w, nil)
+		civOID, err := primitive.ObjectIDFromHex(req.CivilianID)
+		if err != nil {
+			config.ErrorStatus("invalid civilianId", http.StatusBadRequest, w, err)
 			return
 		}
+		civ, err := e.CivDB.FindOne(ctx, bson.M{"_id": civOID})
+		if err != nil || civ == nil {
+			config.ErrorStatus("civilian not found", http.StatusNotFound, w, err)
+			return
+		}
+		if civ.Details.UserID != userID {
+			config.ErrorStatus("you don't own this civilian", http.StatusForbidden, w, nil)
+			return
+		}
+		if civ.Details.JobID != req.JobID {
+			config.ErrorStatus("this civilian isn't assigned to that job", http.StatusForbidden, w, nil)
+			return
+		}
+		job, payRate, payoutMode, maxSession, afkGrace, ok := resolveJob(community, req.JobID)
+		if !ok {
+			config.ErrorStatus("job not found or archived", http.StatusNotFound, w, nil)
+			return
+		}
+		sess.JobID = job.ID.Hex()
+		sess.JobName = job.Name
+		sess.PayRateSnapshot = payRate
+		sess.PayoutMode = payoutMode
+		sess.MaxSessionMinutes = maxSession
+		sess.AfkGraceSeconds = afkGrace
 	} else {
-		var found bool
-		rankID, found = findUserMembership(dept, userID)
+		// ---- Department clock-in ----
+		dept, payRate, payoutMode, maxSession, afkGrace, ok := resolveDepartmentEconomy(community, req.DepartmentID, "")
+		if !ok {
+			config.ErrorStatus("department not found", http.StatusNotFound, w, nil)
+			return
+		}
+		if !dept.EconomyEnabled {
+			config.ErrorStatus("economy is disabled for this department", http.StatusForbidden, w, nil)
+			return
+		}
+		rankID, found := findUserMembership(dept, userID)
 		// Public departments (approvalRequired=false) treat any community member
-		// as implicitly eligible — no explicit join required. Private departments
-		// still require an explicit member entry.
+		// as implicitly eligible — no explicit join required.
 		if !found && !dept.ApprovalRequired {
 			if _, inCommunity := community.Details.Members[userID]; inCommunity {
 				found = true
@@ -291,20 +351,23 @@ func (e Economy) ClockInHandler(w http.ResponseWriter, r *http.Request) {
 			config.ErrorStatus("user is not a member of this department", http.StatusForbidden, w, nil)
 			return
 		}
+		// Re-resolve with rankID for accurate pay rate.
+		if rankID != "" {
+			_, payRate, _, _, _, _ = resolveDepartmentEconomy(community, req.DepartmentID, rankID)
+		}
+		sess.DepartmentID = dept.ID.Hex()
+		sess.DepartmentName = dept.Name
+		sess.RankID = rankID
+		sess.PayRateSnapshot = payRate
+		sess.PayoutMode = payoutMode
+		sess.MaxSessionMinutes = maxSession
+		sess.AfkGraceSeconds = afkGrace
 	}
 
-	// Re-resolve with rankID for accurate pay rate.
-	if rankID != "" {
-		_, payRate, _, _, _, _ = resolveDepartmentEconomy(community, req.DepartmentID, rankID)
-	}
-
-	// Enforce one active session per civilian (civilian dept) or user (user dept).
-	activeFilter := bson.M{
-		"status":       "active",
-		"communityId":  req.CommunityID,
-	}
-	if isCivilianDept {
-		activeFilter["civilianId"] = req.CivilianID
+	// Enforce one active session per civilian, and one active dept-session per user.
+	activeFilter := bson.M{"status": "active", "communityId": req.CommunityID}
+	if sess.CivilianID != "" {
+		activeFilter["civilianId"] = sess.CivilianID
 	} else {
 		activeFilter["userId"] = userID
 		activeFilter["civilianId"] = ""
@@ -315,27 +378,6 @@ func (e Economy) ClockInHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now()
-	nowDT := primitive.NewDateTimeFromTime(now)
-	sess := models.ClockSession{
-		ID:                primitive.NewObjectID(),
-		CommunityID:       req.CommunityID,
-		DepartmentID:      req.DepartmentID,
-		DepartmentName:    dept.Name,
-		UserID:            userID,
-		CivilianID:        req.CivilianID,
-		RankID:            rankID,
-		PayRateSnapshot:   payRate,
-		PayoutMode:        payoutMode,
-		Status:            "active",
-		StartedAt:         nowDT,
-		LastHeartbeatAt:   nowDT,
-		LastPayoutAt:      nowDT,
-		MaxSessionMinutes: maxSession,
-		AfkGraceSeconds:   afkGrace,
-		CreatedAt:         nowDT,
-		UpdatedAt:         nowDT,
-	}
 	if _, err := e.SDB.InsertOne(ctx, sess); err != nil {
 		config.ErrorStatus("failed to create clock session", http.StatusInternalServerError, w, err)
 		return

--- a/models/civilian.go
+++ b/models/civilian.go
@@ -42,6 +42,7 @@ type CivilianDetails struct {
 	ApprovalNotes        string             `json:"approvalNotes" bson:"approvalNotes"`   // Admin notes for approval decisions
 	Image                string             `json:"image" bson:"image"`
 	Occupation           string             `json:"occupation" bson:"occupation"`
+	JobID                string             `json:"jobId" bson:"jobId"` // Economy: optional active Job (community.jobs[].id)
 	FirearmLicense       string             `json:"firearmLicense" bson:"firearmLicense"`
 	ActiveCommunityID    string             `json:"activeCommunityID" bson:"activeCommunityID"`
 	Deceased              bool              `json:"deceased" bson:"deceased"`

--- a/models/clockSession.go
+++ b/models/clockSession.go
@@ -7,8 +7,10 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 type ClockSession struct {
 	ID               primitive.ObjectID `json:"_id" bson:"_id,omitempty"`
 	CommunityID      string             `json:"communityId" bson:"communityId"`
-	DepartmentID     string             `json:"departmentId" bson:"departmentId"`
-	DepartmentName   string             `json:"departmentName" bson:"departmentName"`
+	DepartmentID     string             `json:"departmentId,omitempty" bson:"departmentId,omitempty"`
+	DepartmentName   string             `json:"departmentName,omitempty" bson:"departmentName,omitempty"`
+	JobID            string             `json:"jobId,omitempty" bson:"jobId,omitempty"`     // set when the session is against a community Job instead of a Department
+	JobName          string             `json:"jobName,omitempty" bson:"jobName,omitempty"` // snapshot of job.Name at clock-in
 	UserID           string             `json:"userId" bson:"userId"`
 	CivilianID       string             `json:"civilianId,omitempty" bson:"civilianId,omitempty"` // empty for user-scoped jobs (LEO/EMS/...)
 	RankID           string             `json:"rankId,omitempty" bson:"rankId,omitempty"`

--- a/models/community.go
+++ b/models/community.go
@@ -42,6 +42,7 @@ type CommunityDetails struct {
 	TenCodes               []TenCodes              `json:"tenCodes" bson:"tenCodes"`
 	Fines                  CommunityFine           `json:"fines" bson:"fines"`
 	PenalCodes             CommunityPenalCode      `json:"penalCodes" bson:"penalCodes"`
+	Jobs                   []Job                   `json:"jobs" bson:"jobs"`
 	Templates              []Template              `json:"templates" bson:"templates"`
 	Subscription           Subscription            `json:"subscription" bson:"subscription"`
 	SubscriptionCreatedBy  string                  `json:"subscriptionCreatedBy" bson:"subscriptionCreatedBy"`
@@ -239,21 +240,31 @@ type Department struct {
 	AfkPromptIntervalSeconds int                      `json:"afkPromptIntervalSeconds" bson:"afkPromptIntervalSeconds"` // e.g. 600
 	AfkGraceSeconds          int                      `json:"afkGraceSeconds" bson:"afkGraceSeconds"`                   // e.g. 60
 	PayoutMode               string                   `json:"payoutMode" bson:"payoutMode"`                             // "on_heartbeat" | "on_clockout"
-	DepartmentKind           string                   `json:"departmentKind,omitempty" bson:"departmentKind,omitempty"` // "" = user-scoped (LEO/EMS/...); "civilian" for civilian jobs
-	CivilianMembers          []CivilianMemberStatus   `json:"civilianMembers,omitempty" bson:"civilianMembers,omitempty"`
 	CreatedAt         primitive.DateTime `json:"createdAt" bson:"createdAt"`
 	UpdatedAt         primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
 	OnlineMemberCount int                `json:"onlineMemberCount" bson:"onlineMemberCount"`
 }
 
-// CivilianMemberStatus links a civilian to a civilian-kind department (e.g. Sanitation).
-type CivilianMemberStatus struct {
-	CivilianID     string             `json:"civilianID" bson:"civilianID"`
-	UserID         string             `json:"userID" bson:"userID"` // owning user, denormalized for fast lookup
-	RankID         string             `json:"rankId,omitempty" bson:"rankId,omitempty"`
-	Status         string             `json:"status" bson:"status"`
-	AssignedAt     primitive.DateTime `json:"assignedAt,omitempty" bson:"assignedAt,omitempty"`
-	AssignedBy     string             `json:"assignedBy,omitempty" bson:"assignedBy,omitempty"`
+// Job is a community-level RP occupation (Sanitation, Mechanic, Lawyer, etc.).
+// Civilians can pick one job at a time; clocking in pays at job.PayPerHour.
+// Distinct from Department, which models CAD structures (LEO/EMS/...).
+type Job struct {
+	ID                        primitive.ObjectID `json:"_id" bson:"_id"`
+	Name                      string             `json:"name" bson:"name"`
+	Description               string             `json:"description,omitempty" bson:"description,omitempty"`
+	Icon                      string             `json:"icon,omitempty" bson:"icon,omitempty"`
+	Color                     string             `json:"color,omitempty" bson:"color,omitempty"`
+	PayPerHour                int64              `json:"payPerHour" bson:"payPerHour"` // cents
+	MaxSessionMinutes         int                `json:"maxSessionMinutes" bson:"maxSessionMinutes"`
+	AfkPromptIntervalSeconds  int                `json:"afkPromptIntervalSeconds" bson:"afkPromptIntervalSeconds"`
+	AfkGraceSeconds           int                `json:"afkGraceSeconds" bson:"afkGraceSeconds"`
+	PayoutMode                string             `json:"payoutMode" bson:"payoutMode"` // "on_heartbeat" | "on_clockout"
+	RequiresFirearmLicense    bool               `json:"requiresFirearmLicense" bson:"requiresFirearmLicense"`
+	RequiresDriversLicense    bool               `json:"requiresDriversLicense" bson:"requiresDriversLicense"`
+	Archived                  bool               `json:"archived" bson:"archived"`
+	SortOrder                 int                `json:"sortOrder" bson:"sortOrder"`
+	CreatedAt                 primitive.DateTime `json:"createdAt" bson:"createdAt"`
+	UpdatedAt                 primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
 }
 
 // EconomySettings holds community-wide economy config.

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -719,7 +719,7 @@ createIndexSafe(
   { name: "clock_sessions_community_status_idx", background: true }
 );
 
-// Partial unique: only one active session per civilian.
+// Partial unique: only one active session per civilian (regardless of dept vs job).
 createIndexSafe(
   db.clock_sessions,
   { civilianId: 1 },
@@ -730,6 +730,16 @@ createIndexSafe(
     // Partial filter operators are restricted to $eq/$exists/$gt/$gte/$lt/$lte/$type/$and/$or/$in.
     // $gt: "" matches any non-empty string and skips user-scoped sessions (which have civilianId="").
     partialFilterExpression: { status: "active", civilianId: { $gt: "" } }
+  }
+);
+
+// Job-keyed lookups (e.g. "who is currently working as Sanitation?").
+createIndexSafe(
+  db.clock_sessions,
+  { jobId: 1, status: 1 },
+  {
+    name: "clock_sessions_job_status_idx",
+    background: true,
   }
 );
 


### PR DESCRIPTION
## Summary

Refactors the economy data model so that RP **Jobs** (Sanitation, Mechanic, Lawyer, etc.) are a first-class concept on the community, separate from CAD **Departments** (LEO/EMS/fire/dispatch/judicial). Phase 1 conflated them via a \`departmentKind: \"civilian\"\` flag — this PR undoes that and ships the right model before mobile is built against the old one.

Stacked on top of #104 (the Phase 1 economy branch).

### What's new

- **\`CommunityDetails.Jobs []Job\`** — embedded list like TenCodes/Fines/PenalCodes. Each job has its own \`PayPerHour\`, AFK config, payout mode, license-gate flags, archive flag, sort order.
- **CRUD endpoints** (audit-logged):
  - \`POST /api/v1/community/{communityId}/jobs\`
  - \`PUT /api/v1/community/{communityId}/jobs/{jobId}\`
  - \`DELETE /api/v1/community/{communityId}/jobs/{jobId}\`
- **\`CivilianDetails.JobID\`** — civilians can pick one active job at a time. \`Occupation\` (free-text) stays for legacy reads.
- **\`ClockSession.JobID\` + \`JobName\`** — exactly one of \`DepartmentID\` or \`JobID\` is set per session.
- **\`/api/v2/economy/clock-in\`** now accepts \`jobId\` instead of \`departmentId\`. Job branch validates the civilian owns the JobID and snapshots pay from the Job record.
- **Public-department fallback** from the prior PR is preserved.

### What's removed

- \`Department.DepartmentKind\` (was \`\"\" | \"civilian\"\`)
- \`Department.CivilianMembers []CivilianMemberStatus\`
- \`CivilianMemberStatus\` struct
- \`findCivilianMembership\` helper

Phase 1's civilian-kind department concept never had any real users (we just shipped it to dev). No migration is needed; stale fields on Mongo docs are harmless.

### Indexes

- New \`clock_sessions\` index: \`{jobId, status}\` for \"who's working as X right now?\" queries.
- Existing \`{civilianId}\` partial-unique-active index still enforces \"one active session per civilian\" across both dept and job sessions.

## Test plan

- [ ] Deploy to police-cad-dev
- [ ] Re-run \`scripts/create_indexes.js\` to add the new clock_sessions index
- [ ] POST /api/v1/community/{c}/jobs creates a job and audit-logs \`job.created\`
- [ ] PUT updates the job; DELETE removes it
- [ ] Setting \`civilian.jobId\` then POST /api/v2/economy/clock-in with \`{jobId, civilianId}\` creates a session with \`jobName\` populated and pay matching the job's PayPerHour
- [ ] Clock-in with both jobId AND departmentId returns 400
- [ ] Clock-in with neither returns 400
- [ ] Job clock-in fails 403 if civilian.jobId doesn't match the requested jobId
- [ ] Department clock-in still works for both public (no explicit member) and private (explicit member) departments
- [ ] One active session per civilian is still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)