### PR TITLE
feat(cloudinary): accept upload_preset override in signature request

### DIFF
--- a/api/handlers/cloudinary.go
+++ b/api/handlers/cloudinary.go
@@ -15,16 +15,25 @@ import (
 type CloudinaryHandler struct{}
 
 // GenerateSignature generates a signature for Cloudinary uploads.
-// Accepts optional parameters in the request body (e.g. "folder") that will be
-// included in the signed string so Cloudinary can verify them.
+// Accepts optional parameters in the request body (e.g. "folder", "upload_preset")
+// that will be included in the signed string so Cloudinary can verify them.
+//
+// Callers may pass "upload_preset" in the body to override the server default.
+// This is how the community-map uploader opts into a full-resolution preset
+// while everything else keeps the avatar/evidence-friendly default.
 func (c CloudinaryHandler) GenerateSignature(w http.ResponseWriter, r *http.Request) {
-	uploadPreset := os.Getenv("CLOUDINARY_UPLOAD_PRESET")
 	apiSecret := os.Getenv("CLOUDINARY_API_SECRET")
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 
 	// Decode optional extra parameters from request body
 	var body map[string]string
 	_ = json.NewDecoder(r.Body).Decode(&body) // OK if empty/nil
+
+	// Pick the upload preset: explicit body override, else server default.
+	uploadPreset := os.Getenv("CLOUDINARY_UPLOAD_PRESET")
+	if v, ok := body["upload_preset"]; ok && v != "" {
+		uploadPreset = v
+	}
 
 	// Create the parameters to sign
 	paramsToSign := url.Values{
@@ -47,10 +56,13 @@ func (c CloudinaryHandler) GenerateSignature(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Respond with the timestamp and signature
+	// Echo the preset back so the client uses the exact value we signed —
+	// otherwise a stale window.CLOUDINARY_UPLOAD_PRESET on the page would
+	// mismatch the signature and Cloudinary would reject the upload.
 	response := map[string]string{
-		"timestamp": timestamp,
-		"signature": signature,
+		"timestamp":     timestamp,
+		"signature":     signature,
+		"upload_preset": uploadPreset,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)


### PR DESCRIPTION
## Summary
- Lets callers pass `upload_preset` in the signature body to opt into a per-asset preset instead of the env default
- Echoes the signed preset back in the response so the client can't accidentally send a different preset than what was signed
- Unblocks the community-map full-resolution fix on web and mobile (separate PRs)

## Why
The default `ml_default` Cloudinary preset has an incoming transformation that caps assets at ~1000px. Correct for avatars/evidence/BOLOs, but it was visibly destroying community maps — owners were uploading 8192px JPEGs that came back as blurry 1000px sources, unreadable at any zoom. Delivery transforms couldn't help because the stored bytes were already small.

The web and mobile community-map upload paths now pass a separate `community-maps` preset (configured in the Cloudinary dashboard with no incoming transformation). All other callers stay on `ml_default`.

## Required config
A new upload preset named `community-maps` already exists in the Cloudinary dashboard:
- Signing Mode: Signed
- Incoming Transformation: empty

No env changes needed — the override is per-request.

## Test plan
- [ ] Deploy to police-cad-dev
- [ ] Existing uploads (avatars, vehicles, firearms, etc.) still succeed and still get the 1000px cap
- [ ] Community map upload at High preset produces a Cloudinary asset with width matching the source (≥4000px for High)
- [ ] Old `community-map.ejs` clients that don't yet pass the override fall back to the env default with no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)