### PR TITLE
feat(feature-requests): accept multiple excludeStatus values

### DIFF
--- a/api/handlers/featurerequest.go
+++ b/api/handlers/featurerequest.go
@@ -45,7 +45,7 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 
 	sortBy := r.URL.Query().Get("sort")
 	status := r.URL.Query().Get("status")
-	excludeStatus := r.URL.Query().Get("excludeStatus")
+	excludeStatuses := r.URL.Query()["excludeStatus"]
 	query := r.URL.Query().Get("q")
 	userID := r.URL.Query().Get("userId")
 	authorID := r.URL.Query().Get("authorId")
@@ -53,15 +53,18 @@ func (h FeatureRequestHandler) ListFeatureRequestsHandler(w http.ResponseWriter,
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	// Build filter — exclude merged tickets by default; optionally exclude released
-	// from default browsing so the main list stays focused on in-flight work.
+	// Build filter — exclude merged tickets by default; callers may additionally
+	// exclude released/declined from default browsing so the main list stays
+	// focused on in-flight work.
 	filter := bson.M{}
 	if status != "" {
 		filter["status"] = status
 	} else {
 		excluded := []string{"merged"}
-		if excludeStatus != "" {
-			excluded = append(excluded, excludeStatus)
+		for _, s := range excludeStatuses {
+			if s != "" {
+				excluded = append(excluded, s)
+			}
 		}
 		filter["status"] = bson.M{"$nin": excluded}
 	}


### PR DESCRIPTION
## Summary
- List endpoint now reads `excludeStatus` as a list (`r.URL.Query()["excludeStatus"]`) so a single request can hide multiple statuses
- Used by the website to hide both `released` and `declined` from the default Trending / Top / Newest views
- Single-value callers continue to work — empty entries are skipped, `merged` is still always excluded when no explicit `status` is set

Companion PR: Linesmerrill/police-cad#feature/hide-declined-by-default

## Test plan
- [ ] `GET /api/v2/feature-requests?excludeStatus=released&excludeStatus=declined` returns no items in either status
- [ ] `GET /api/v2/feature-requests?excludeStatus=released` (single value) still works
- [ ] `GET /api/v2/feature-requests?status=declined` still returns only declined items
- [ ] `GET /api/v2/feature-requests` with no filters still excludes `merged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)