### PR TITLE
feat(community): 30-day soft-delete with admin restore

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -634,6 +634,10 @@ type communitySearchRequest struct {
 	Query string `json:"query"`
 	Page  int    `json:"page"`  // Page number (0-based)
 	Limit int    `json:"limit"` // Records per page
+	// PendingDeletionOnly narrows the result set to communities currently
+	// scheduled for hard-deletion. When false (default) results include both
+	// active and pending-deletion communities so staff have a single search box.
+	PendingDeletionOnly bool `json:"pendingDeletionOnly,omitempty"`
 }
 
 type communitySearchResponse struct {
@@ -682,34 +686,68 @@ func (h Admin) AdminCommunitySearchHandler(w http.ResponseWriter, r *http.Reques
 	// For queries >= 3 chars, use full regex match, otherwise use prefix match
 	queryLen := len(query)
 	escapedQuery := regexp.QuoteMeta(query)
-	var filter bson.M
-	var findOpts *options.FindOptions
-
-	if queryLen >= 3 {
-		// Use regex search for queries >= 3 chars
-		filter = bson.M{"community.name": bson.M{"$regex": escapedQuery, "$options": "i"}}
-	} else {
-		// For short queries, use prefix regex
-		filter = bson.M{"community.name": bson.M{"$regex": "^" + escapedQuery, "$options": "i"}}
+	nameRegex := bson.M{"$regex": escapedQuery, "$options": "i"}
+	if queryLen < 3 {
+		nameRegex = bson.M{"$regex": "^" + escapedQuery, "$options": "i"}
 	}
-	
-	findOpts = options.Find().
+
+	// Also resolve the query against user email/username so staff can find a
+	// community by typing its owner's identifier. Cap the owner sweep to a
+	// reasonable bound so a wildcard-ish query doesn't pull millions of rows.
+	ownerIDs := []string{}
+	if queryLen >= 2 {
+		ownerFilter := bson.M{"$or": bson.A{
+			bson.M{"user.email": nameRegex},
+			bson.M{"user.username": nameRegex},
+		}}
+		ownerOpts := options.Find().SetLimit(50).SetProjection(bson.M{"_id": 1})
+		if ownerCursor, ownerErr := h.UDB.Find(ctx, ownerFilter, ownerOpts); ownerErr == nil {
+			var owners []struct {
+				ID interface{} `bson:"_id"`
+			}
+			if cerr := ownerCursor.All(ctx, &owners); cerr == nil {
+				for _, ou := range owners {
+					switch v := ou.ID.(type) {
+					case string:
+						ownerIDs = append(ownerIDs, v)
+					case primitive.ObjectID:
+						ownerIDs = append(ownerIDs, v.Hex())
+					}
+				}
+			}
+			_ = ownerCursor.Close(ctx)
+		}
+	}
+
+	matchClauses := bson.A{bson.M{"community.name": nameRegex}}
+	if len(ownerIDs) > 0 {
+		matchClauses = append(matchClauses, bson.M{"community.ownerID": bson.M{"$in": ownerIDs}})
+	}
+	filter := bson.M{"$or": matchClauses}
+	if req.PendingDeletionOnly {
+		filter = bson.M{"$and": bson.A{
+			filter,
+			bson.M{"community.pendingDeletionAt": bson.M{"$ne": nil}},
+		}}
+	}
+
+	findOpts := options.Find().
 		SetSkip(skip).
 		SetLimit(limit64).
 		SetSort(bson.M{"community.name": 1})
-	
-	// Get total count for pagination metadata
+
+	// Always include pending-deletion communities — staff need them visible to
+	// restore or to confirm a scheduled hard-deletion.
 	var totalCount int64
 	var err error
-	totalCount, err = h.CDB.CountDocuments(ctx, filter)
+	totalCount, err = h.CDB.CountDocumentsIncludingPending(ctx, filter)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "search count failed"})
 		return
 	}
-	
-	// Use community database to search with pagination
-	cursor, err := h.CDB.Find(ctx, filter, findOpts)
+
+	cursor, err := h.CDB.FindIncludingPending(ctx, filter, findOpts)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "search failed"})
@@ -767,6 +805,12 @@ func (h Admin) AdminCommunitySearchHandler(w http.ResponseWriter, r *http.Reques
 			MemberCount:     community.Details.MembersCount,
 			DepartmentCount: departmentCount,
 			RolesCount:      len(community.Details.Roles),
+		}
+		if community.Details.PendingDeletionAt != nil {
+			result.PendingDeletionAt = community.Details.PendingDeletionAt
+		}
+		if community.Details.ScheduledDeletionAt != nil {
+			result.ScheduledDeletionAt = community.Details.ScheduledDeletionAt
 		}
 		results = append(results, result)
 	}
@@ -1094,7 +1138,9 @@ func (h Admin) AdminCommunityDetailsHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	community, err := h.CDB.FindOne(r.Context(), bson.M{"_id": objectID})
+	// Use IncludingPending so admins can inspect a community even while it is
+	// scheduled for deletion (that's the whole point of the restore workflow).
+	community, err := h.CDB.FindOneIncludingPending(r.Context(), bson.M{"_id": objectID})
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			w.WriteHeader(http.StatusNotFound)
@@ -1180,6 +1226,12 @@ func (h Admin) AdminCommunityDetailsHandler(w http.ResponseWriter, r *http.Reque
 		DepartmentCount: len(community.Details.Departments),
 		RolesCount:      len(community.Details.Roles),
 		Subscription:    subscription,
+	}
+	if community.Details.PendingDeletionAt != nil {
+		details.PendingDeletionAt = community.Details.PendingDeletionAt
+	}
+	if community.Details.ScheduledDeletionAt != nil {
+		details.ScheduledDeletionAt = community.Details.ScheduledDeletionAt
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -1234,6 +1234,44 @@ func (h Admin) AdminCommunityDetailsHandler(w http.ResponseWriter, r *http.Reque
 		details.ScheduledDeletionAt = community.Details.ScheduledDeletionAt
 	}
 
+	// Owner-tier context for the admin red-flag UI. Only populate when we
+	// successfully resolved the owner; otherwise leave the fields zero so
+	// the frontend just skips the section.
+	if ownerInfo != nil {
+		ownerObjID, _ := primitive.ObjectIDFromHex(ownerInfo.ID)
+		var ownerUser models.User
+		// Re-fetch the user (we have ownerInfo from above but it's the
+		// summary type; we need Subscription too).
+		_ = h.UDB.FindOne(r.Context(), bson.M{"_id": ownerObjID}).Decode(&ownerUser)
+		plan := models.PlanFromUser(&ownerUser)
+		details.OwnerPlan = plan
+		details.OwnerCommunityCap = models.CommunityCap(plan)
+		// Other live (non-pending) communities the same owner has, minus this
+		// one. CDB.Find already excludes pending-deletion docs, so the list
+		// is naturally limited to communities they still have live.
+		othersCursor, otherErr := h.CDB.Find(r.Context(), bson.M{
+			"community.ownerID": ownerInfo.ID,
+			"_id":               bson.M{"$ne": community.ID},
+		})
+		if otherErr == nil {
+			var others []models.Community
+			if err := othersCursor.All(r.Context(), &others); err == nil {
+				rows := make([]models.AdminOwnerOtherCommunity, 0, len(others))
+				for _, o := range others {
+					rows = append(rows, models.AdminOwnerOtherCommunity{
+						ID:           o.ID.Hex(),
+						Name:         o.Details.Name,
+						Plan:         o.Details.Subscription.Plan,
+						MembersCount: o.Details.MembersCount,
+					})
+				}
+				details.OwnerOtherCommunities = rows
+				details.OwnerActiveCount = len(rows)
+			}
+			_ = othersCursor.Close(r.Context())
+		}
+	}
+
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(communityDetailsResponse{Community: details})
 }

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -244,6 +244,9 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/communities/{id}/remove-member", http.HandlerFunc(adminHandler.AdminRemoveMemberHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/roles", http.HandlerFunc(adminHandler.AdminGetCommunityRolesHandler)).Methods("GET")
 	apiCreate.Handle("/admin/communities/{community_id}/restore-pending-deletion", http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler)).Methods("POST")
+	// Admin-only smoke test for the cron-alert Discord webhook. POST with
+	// { currentUser: { roles: ["admin"] } } in the body. Returns JSON.
+	apiCreate.Handle("/admin/test-cron-alert", http.HandlerFunc(c.TestCronAlertHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}", http.HandlerFunc(adminHandler.AdminCommunityDetailsHandler)).Methods("GET")
 
 	// Admin management routes (specific before general)

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -171,6 +171,7 @@ func (a *App) New() *mux.Router {
 
 	// healthchex
 	r.HandleFunc("/health", healthCheckHandler)
+	r.HandleFunc("/health/scheduler", a.schedulerHealthHandler).Methods("GET")
 
 	apiCreate := r.PathPrefix("/api/v1").Subrouter()
 	apiV2 := r.PathPrefix("/api/v2").Subrouter()
@@ -882,6 +883,34 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 		Alive: true,
 	})
 	_, _ = io.WriteString(w, string(b))
+}
+
+// schedulerHealthHandler returns the per-job run history captured by the
+// in-process scheduler. Public (no auth) so an uptime monitor can poll it,
+// but it only exposes timestamps + counts + the last error message — no
+// PII, no auth context.
+//
+// Top-level fields:
+//   alive: bool — does the scheduler have any registered jobs?
+//   nowAt: ISO timestamp of the response (anchor for staleness math)
+//   jobs:  { [jobName]: JobStat } — see scheduler.JobStat
+func (a *App) schedulerHealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if a.Scheduler == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"alive": false,
+			"error": "scheduler not initialized",
+		})
+		return
+	}
+	stats := a.Scheduler.SnapshotJobStats()
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"alive": len(stats) > 0,
+		"nowAt": time.Now().UTC().Format(time.RFC3339),
+		"jobs":  stats,
+	})
 }
 
 // CorsMiddleware is a middleware that adds CORS headers to the response

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -243,6 +243,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/communities/{id}/transfer-ownership", http.HandlerFunc(adminHandler.AdminTransferOwnershipHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/remove-member", http.HandlerFunc(adminHandler.AdminRemoveMemberHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/roles", http.HandlerFunc(adminHandler.AdminGetCommunityRolesHandler)).Methods("GET")
+	apiCreate.Handle("/admin/communities/{community_id}/restore-pending-deletion", http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}", http.HandlerFunc(adminHandler.AdminCommunityDetailsHandler)).Methods("GET")
 
 	// Admin management routes (specific before general)
@@ -814,6 +815,7 @@ func (a *App) New() *mux.Router {
 		contentCreator.UDB,
 		contentCreator.CDB,
 		databases.NewSchedulerLockDatabase(a.dbHelper),
+		a.dbHelper,
 		economy.SDB,
 		economy.IDB,
 		economy.CivDB,

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -176,6 +176,14 @@ func (a *App) New() *mux.Router {
 	apiCreate := r.PathPrefix("/api/v1").Subrouter()
 	apiV2 := r.PathPrefix("/api/v2").Subrouter()
 
+	// Pending-deletion gate: any request whose matched route carries a
+	// community_id / communityId var is short-circuited with a 410 if the
+	// community is currently in pending-deletion state. Closes the race where
+	// an owner soft-deletes a community while members are actively using it.
+	pendingGate := CommunityPendingGate(databases.NewCommunityDatabase(a.dbHelper))
+	apiCreate.Use(pendingGate)
+	apiV2.Use(pendingGate)
+
 	// Metrics handler (must be after apiV2 is defined)
 	metricsHandler := MetricsHandler{}
 	apiV2.Handle("/metrics", http.HandlerFunc(metricsHandler.GetMetricsDashboard)).Methods("GET")

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -253,6 +253,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/communities/{id}/remove-member", http.HandlerFunc(adminHandler.AdminRemoveMemberHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/roles", http.HandlerFunc(adminHandler.AdminGetCommunityRolesHandler)).Methods("GET")
 	apiCreate.Handle("/admin/communities/{community_id}/restore-pending-deletion", http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler)).Methods("POST")
+	apiCreate.Handle("/admin/communities/{community_id}/force-delete", http.HandlerFunc(c.ForceDeleteCommunityHandler)).Methods("POST")
 	// Admin-only smoke test for the cron-alert Discord webhook. POST with
 	// { currentUser: { roles: ["admin"] } } in the body. Returns JSON.
 	apiCreate.Handle("/admin/test-cron-alert", http.HandlerFunc(c.TestCronAlertHandler)).Methods("POST")

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -236,9 +237,16 @@ func (c Community) CommunityHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	dbResp, err := c.DB.FindOne(ctx, filter)
+	// Use the IncludingPending variant so we can distinguish a pending-deletion
+	// community (410 Gone with a body that lets the client render a route-block
+	// page) from a truly missing one (404).
+	dbResp, err := c.DB.FindOneIncludingPending(ctx, filter)
 	if err != nil {
 		config.ErrorStatus("failed to get community by ID", http.StatusNotFound, w, err)
+		return
+	}
+	if dbResp.Details.PendingDeletionAt != nil {
+		writePendingDeletionGone(w, dbResp)
 		return
 	}
 
@@ -1404,100 +1412,174 @@ func (c Community) UpdateRolePermissionsHandler(w http.ResponseWriter, r *http.R
 	w.Write([]byte(`{"message": "Role permissions updated successfully"}`))
 }
 
-// DeleteCommunityByIDHandler deletes a community by ID and removes references from all users
+// CommunitySoftDeleteGraceDays is how long a community stays in the pending-deletion
+// state before the scheduler hard-deletes it. Owners cannot self-restore; staff
+// handle restores through the admin console.
+const CommunitySoftDeleteGraceDays = 30
+
+// writePendingDeletionGone writes a 410 Gone response describing a community
+// that is pending deletion. Customer-facing clients render a route-block page
+// from this payload.
+func writePendingDeletionGone(w http.ResponseWriter, comm *models.Community) {
+	payload := map[string]interface{}{
+		"error":   "pending_deletion",
+		"message": "This community is pending deletion. Contact support to restore access.",
+	}
+	if comm != nil {
+		if comm.Details.ScheduledDeletionAt != nil {
+			payload["scheduledDeletionAt"] = comm.Details.ScheduledDeletionAt.Time().UTC().Format(time.RFC3339)
+		}
+		if comm.Details.Name != "" {
+			payload["communityName"] = comm.Details.Name
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusGone)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// DeleteCommunityByIDHandler marks a community as pending deletion. The community
+// becomes hidden from all customer-facing surfaces (404/410 on direct links) and
+// is hard-deleted by the scheduler once ScheduledDeletionAt elapses.
 func (c Community) DeleteCommunityByIDHandler(w http.ResponseWriter, r *http.Request) {
 	communityID := mux.Vars(r)["community_id"]
 
-	// Convert the community ID to primitive.ObjectID
 	cID, err := primitive.ObjectIDFromHex(communityID)
 	if err != nil {
 		config.ErrorStatus("failed to get objectID from Hex", http.StatusBadRequest, w, err)
 		return
 	}
 
-	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	// Delete the community by ID
-	communityFilter := bson.M{"_id": cID}
-	err = c.DB.DeleteOne(ctx, communityFilter)
+	existing, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": cID})
 	if err != nil {
-		config.ErrorStatus("failed to delete community", http.StatusInternalServerError, w, err)
+		config.ErrorStatus("failed to load community", http.StatusNotFound, w, err)
+		return
+	}
+	if existing.Details.PendingDeletionAt != nil {
+		config.ErrorStatus("community is already pending deletion", http.StatusBadRequest, w,
+			fmt.Errorf("community %s already has pendingDeletionAt set", communityID))
 		return
 	}
 
-	// Remove the community references from all users
-	userFilter := bson.M{"user.communities.communityId": communityID}
-	userUpdate := bson.M{"$pull": bson.M{"user.communities": bson.M{"communityId": communityID}}}
-	_, err = c.UDB.UpdateMany(ctx, userFilter, userUpdate)
-	if err != nil {
-		config.ErrorStatus("failed to remove community references from users", http.StatusInternalServerError, w, err)
+	now := time.Now().UTC()
+	scheduled := now.Add(CommunitySoftDeleteGraceDays * 24 * time.Hour)
+	pendingAt := primitive.NewDateTimeFromTime(now)
+	scheduledAt := primitive.NewDateTimeFromTime(scheduled)
+
+	actorID := resolveActorFromRequest(r)
+	update := bson.M{
+		"$set": bson.M{
+			"community.pendingDeletionAt":   pendingAt,
+			"community.scheduledDeletionAt": scheduledAt,
+			"community.deletionRequestedBy": actorID,
+			"community.updatedAt":           pendingAt,
+		},
+	}
+	if err := c.DB.UpdateOne(ctx, bson.M{"_id": cID}, update); err != nil {
+		config.ErrorStatus("failed to mark community pending deletion", http.StatusInternalServerError, w, err)
 		return
 	}
 
-	// Cascade delete all child data in the background
-	bgCtx, bgCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	go func() {
-		defer bgCancel()
-		c.cascadeDeleteCommunityData(bgCtx, communityID, cID)
-	}()
+	logAudit(c.ALDB, cID, "community.pending_deletion_scheduled", "community", actorID,
+		resolveActorName(c.UDB, actorID), communityID, "", map[string]interface{}{
+			"scheduledDeletionAt": scheduled.Format(time.RFC3339),
+		})
 
+	resp := map[string]interface{}{
+		"message":             "Community scheduled for deletion",
+		"scheduledDeletionAt": scheduled.Format(time.RFC3339),
+		"graceDays":           CommunitySoftDeleteGraceDays,
+	}
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"message": "Community deleted and references removed successfully"}`))
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// cascadeDeleteCommunityData removes all child data associated with a deleted community.
-// Designed to run in a background goroutine. Best-effort: logs errors but does not fail.
-func (c Community) cascadeDeleteCommunityData(ctx context.Context, communityID string, cID primitive.ObjectID) {
-	type collectionCleanup struct {
-		name   string
-		filter bson.M
+// RestoreCommunityPendingDeletionHandler clears the soft-delete fields on a
+// community. Staff-only — restores are not exposed to community owners.
+func (c Community) RestoreCommunityPendingDeletionHandler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var payload struct {
+		CurrentUser map[string]interface{} `json:"currentUser"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	if !hasAdminOrOwnerRole(payload.CurrentUser) {
+		config.ErrorStatus("admin or owner role required", http.StatusForbidden, w,
+			fmt.Errorf("caller missing admin/owner role"))
+		return
 	}
 
-	cleanups := []collectionCleanup{
-		// Collections using string activeCommunityID
-		{"civilians", bson.M{"civilian.activeCommunityID": communityID}},
-		{"vehicles", bson.M{"vehicle.activeCommunityID": communityID}},
-		{"firearms", bson.M{"firearm.activeCommunityID": communityID}},
-		{"licenses", bson.M{"license.activeCommunityID": communityID}},
-		{"warrants", bson.M{"warrant.activeCommunityID": communityID}},
-		{"ems", bson.M{"ems.activeCommunityID": communityID}},
-		{"emsvehicles", bson.M{"vehicle.activeCommunityID": communityID}},
-		{"medicalreports", bson.M{"report.activeCommunityID": communityID}},
-		{"medications", bson.M{"medication.activeCommunityID": communityID}},
-		// Collections using string communityID
-		{"calls", bson.M{"call.communityID": communityID}},
-		{"bolos", bson.M{"bolo.communityID": communityID}},
-		{"courtcases", bson.M{"courtCase.communityID": communityID}},
-		{"courtsessions", bson.M{"courtSession.communityID": communityID}},
-		{"most_wanted_entries", bson.M{"mostWanted.communityID": communityID}},
-		// Collections using string communityId (lowercase d)
-		{"inviteCodes", bson.M{"communityId": communityID}},
-		{"tone_logs", bson.M{"communityId": communityID}},
-		// Collections using ObjectID communityId
-		{"audit_logs", bson.M{"communityId": cID}},
-		{"announcements", bson.M{"community": cID}},
+	communityID := mux.Vars(r)["community_id"]
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		config.ErrorStatus("failed to get objectID from Hex", http.StatusBadRequest, w, err)
+		return
 	}
 
-	for _, col := range cleanups {
-		deleted, err := c.DBHelper.Collection(col.name).DeleteMany(ctx, col.filter)
-		if err != nil {
-			zap.S().Errorw("cascade delete failed",
-				"collection", col.name,
-				"communityId", communityID,
-				"error", err,
-			)
-			continue
-		}
-		if deleted > 0 {
-			zap.S().Infow("cascade deleted documents",
-				"collection", col.name,
-				"communityId", communityID,
-				"count", deleted,
-			)
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	existing, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("failed to load community", http.StatusNotFound, w, err)
+		return
+	}
+	if existing.Details.PendingDeletionAt == nil {
+		config.ErrorStatus("community is not pending deletion", http.StatusBadRequest, w,
+			fmt.Errorf("community %s has no pendingDeletionAt", communityID))
+		return
+	}
+
+	now := primitive.NewDateTimeFromTime(time.Now().UTC())
+	update := bson.M{
+		"$unset": bson.M{
+			"community.pendingDeletionAt":         "",
+			"community.scheduledDeletionAt":       "",
+			"community.pendingDeletionNotifiedAt": "",
+			"community.deletionRequestedBy":       "",
+		},
+		"$set": bson.M{
+			"community.updatedAt": now,
+		},
+	}
+	if err := c.DB.UpdateOne(ctx, bson.M{"_id": cID}, update); err != nil {
+		config.ErrorStatus("failed to restore community", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	adminEmail, _ := payload.CurrentUser["email"].(string)
+	logAudit(c.ALDB, cID, "community.pending_deletion_restored", "community", adminEmail,
+		adminEmail, communityID, "", nil)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"message": "Community restored"})
+}
+
+// hasAdminOrOwnerRole reports whether the caller's currentUser payload contains
+// an admin or owner role. Mirrors the existing checkAdminOrOwnerPermissions
+// pattern used elsewhere in the admin handlers.
+func hasAdminOrOwnerRole(currentUser map[string]interface{}) bool {
+	if currentUser == nil {
+		return false
+	}
+	check := func(s string) bool { return s == "admin" || s == "owner" }
+	if role, ok := currentUser["role"].(string); ok && check(role) {
+		return true
+	}
+	roles, ok := currentUser["roles"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, r := range roles {
+		if s, ok := r.(string); ok && check(s) {
+			return true
 		}
 	}
+	return false
 }
 
 // GetBannedUsersHandler returns all banned users of a community
@@ -1745,10 +1827,16 @@ func (c Community) GetInviteCodeHandler(w http.ResponseWriter, r *http.Request) 
 		config.ErrorStatus("Invalid community ID", http.StatusBadRequest, w, err)
 		return
 	}
-	// var community models.Community
-	community, err := c.DB.FindOne(ctx, bson.M{"_id": communityObjID})
+	// Look up including pending so we can return a clear 410 (rather than a
+	// generic 404) when the community is mid-soft-delete. The website surfaces
+	// this to the user as "this community is pending deletion".
+	community, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": communityObjID})
 	if err != nil {
 		config.ErrorStatus("Community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if community.Details.PendingDeletionAt != nil {
+		writePendingDeletionGone(w, community)
 		return
 	}
 
@@ -1775,6 +1863,19 @@ func (c Community) JoinCommunityHandler(w http.ResponseWriter, r *http.Request) 
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
+
+	// Reject joins targeting a pending-deletion community before consuming an
+	// invite-code use, so a stale invite link doesn't burn a slot. The atomic
+	// invite-decrement below would otherwise charge the use and then fail at
+	// the community lookup.
+	if invitePeek, err := c.IDB.FindOne(ctx, bson.M{"code": req.InviteCode}); err == nil && invitePeek != nil {
+		if cObjID, perr := primitive.ObjectIDFromHex(invitePeek.CommunityID); perr == nil {
+			if peekComm, perr := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": cObjID}); perr == nil && peekComm.Details.PendingDeletionAt != nil {
+				writePendingDeletionGone(w, peekComm)
+				return
+			}
+		}
+	}
 
 	// Step 1: Validate the invite code with conditional decrement and increment uses
 	var invite models.InviteCode

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -306,6 +306,36 @@ func (c Community) CreateCommunityHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Enforce the owned-community cap. CDB.CountDocuments already excludes
+	// pending-deletion communities, so a user who soft-deleted their only
+	// free-tier community can immediately create a fresh one. Hard-deletes
+	// (admin force-delete) likewise free up a slot. We fetch the owner's
+	// plan from the user record rather than trusting anything client-side.
+	if ownerHex := strings.TrimSpace(newCommunity.Details.OwnerID); ownerHex != "" {
+		if ownerObjID, idErr := primitive.ObjectIDFromHex(ownerHex); idErr == nil {
+			capCtx, capCancel := api.WithQueryTimeout(r.Context())
+			defer capCancel()
+			var owner models.User
+			if err := c.UDB.FindOne(capCtx, bson.M{"_id": ownerObjID}).Decode(&owner); err == nil {
+				plan := models.PlanFromUser(&owner)
+				cap := models.CommunityCap(plan)
+				active, _ := c.DB.CountDocuments(capCtx, bson.M{"community.ownerID": ownerHex})
+				if int(active) >= cap {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusForbidden)
+					_ = json.NewEncoder(w).Encode(map[string]interface{}{
+						"error":   "community_limit_reached",
+						"message": fmt.Sprintf("Your %s plan allows up to %d communities. Upgrade your plan or delete an existing community to create another.", plan, cap),
+						"plan":    plan,
+						"cap":     cap,
+						"active":  active,
+					})
+					return
+				}
+			}
+		}
+	}
+
 	// Generate a new _id for the community
 	newCommunity.ID = primitive.NewObjectID()
 	// Set the createdAt and updatedAt fields to the current time
@@ -1558,6 +1588,72 @@ func (c Community) RestoreCommunityPendingDeletionHandler(w http.ResponseWriter,
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]string{"message": "Community restored"})
+}
+
+// ForceDeleteCommunityHandler hard-deletes a community immediately, bypassing
+// the 30-day soft-delete grace period. Staff-only — used when the owner has
+// explicitly asked support to purge their community now (e.g., free-tier user
+// who wants to start fresh and doesn't want to wait the 30 days).
+//
+// Runs the same cascade the scheduler runs at end-of-grace: removes the
+// community doc, pulls user.communities refs, and wipes child collections.
+// Requires a typed confirmation in the request body matching the community
+// name so a fat-finger on the admin console can't accidentally nuke the
+// wrong community.
+func (c Community) ForceDeleteCommunityHandler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var payload struct {
+		CurrentUser  map[string]interface{} `json:"currentUser"`
+		Confirmation string                 `json:"confirmation"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	if !hasAdminOrOwnerRole(payload.CurrentUser) {
+		config.ErrorStatus("admin or owner role required", http.StatusForbidden, w,
+			fmt.Errorf("caller missing admin/owner role"))
+		return
+	}
+
+	communityID := mux.Vars(r)["community_id"]
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		config.ErrorStatus("failed to get objectID from Hex", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	existing, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("failed to load community", http.StatusNotFound, w, err)
+		return
+	}
+	if strings.TrimSpace(payload.Confirmation) != existing.Details.Name {
+		config.ErrorStatus("confirmation does not match community name", http.StatusBadRequest, w,
+			fmt.Errorf("expected %q, got %q", existing.Details.Name, payload.Confirmation))
+		return
+	}
+
+	adminEmail, _ := payload.CurrentUser["email"].(string)
+	// Audit BEFORE the destructive call so the trail survives even if the
+	// cascade is partial. Snapshot enough of the doc to identify it later.
+	logAudit(c.ALDB, cID, "community.force_deleted", "community", adminEmail, adminEmail, communityID, "",
+		map[string]interface{}{
+			"communityName":       existing.Details.Name,
+			"ownerID":             existing.Details.OwnerID,
+			"wasPendingDeletion":  existing.Details.PendingDeletionAt != nil,
+			"scheduledDeletionAt": existing.Details.ScheduledDeletionAt,
+		})
+
+	scheduler.HardDeleteCommunityWithCascade(ctx, c.DB, c.UDB, c.DBHelper, communityID, cID)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":       "Community force-deleted",
+		"communityId":   communityID,
+		"communityName": existing.Details.Name,
+	})
 }
 
 // TestCronAlertHandler is an admin-only smoke test for the Discord cron-alert

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/api/scheduler"
 	"github.com/linesmerrill/police-cad-api/config"
 	"github.com/linesmerrill/police-cad-api/databases"
 	"github.com/linesmerrill/police-cad-api/models"
@@ -1557,6 +1558,49 @@ func (c Community) RestoreCommunityPendingDeletionHandler(w http.ResponseWriter,
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]string{"message": "Community restored"})
+}
+
+// TestCronAlertHandler is an admin-only smoke test for the Discord cron-alert
+// webhook. Synthesizes an error and sends it through the same SendCronAlert
+// path the scheduler uses, so staff can confirm the channel is wired without
+// having to wait for a real cron failure. Bypasses dedup by stamping the
+// current timestamp into the error message.
+func (c Community) TestCronAlertHandler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var payload struct {
+		CurrentUser map[string]interface{} `json:"currentUser"`
+	}
+	_ = json.Unmarshal(body, &payload)
+	if !hasAdminOrOwnerRole(payload.CurrentUser) {
+		config.ErrorStatus("admin or owner role required", http.StatusForbidden, w,
+			fmt.Errorf("caller missing admin/owner role"))
+		return
+	}
+
+	if os.Getenv("DISCORD_CRON_ERROR_WEBHOOK_URL") == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":      false,
+			"message": "DISCORD_CRON_ERROR_WEBHOOK_URL is not set on this dyno. Configure it in Heroku config vars and try again.",
+		})
+		return
+	}
+
+	caller, _ := payload.CurrentUser["email"].(string)
+	syntheticErr := fmt.Errorf("test alert from /admin/test-cron-alert at %s (triggered by %s)",
+		time.Now().UTC().Format(time.RFC3339), caller)
+	scheduler.SendCronAlert(os.Getenv("DYNO"), "testCronAlert", syntheticErr, map[string]string{
+		"phase":   "manual_smoke_test",
+		"trigger": caller,
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":      true,
+		"message": "Synthetic cron alert dispatched. Check the Discord channel — it should arrive within a few seconds.",
+	})
 }
 
 // hasAdminOrOwnerRole reports whether the caller's currentUser payload contains

--- a/api/handlers/community_members_count_test.go
+++ b/api/handlers/community_members_count_test.go
@@ -57,7 +57,7 @@ func TestCommunity_CommunityHandler_UsesLiveCount_OverwritesStored(t *testing.T)
 			MembersCount: 85, // stale, drifted
 		},
 	}
-	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+	mockCommunityDB.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": communityObjectID}).
 		Return(storedCommunity, nil)
 	mockUserDB.On("CountDocuments", mock.Anything, approvedMembersFilter(communityID)).
 		Return(int64(35), nil)
@@ -98,7 +98,7 @@ func TestCommunity_CommunityHandler_CountFails_FallsBackToStored(t *testing.T) {
 			MembersCount: 42,
 		},
 	}
-	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+	mockCommunityDB.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": communityObjectID}).
 		Return(storedCommunity, nil)
 	mockUserDB.On("CountDocuments", mock.Anything, approvedMembersFilter(communityID)).
 		Return(int64(0), errors.New("transient mongo error"))
@@ -133,7 +133,7 @@ func TestCommunity_CommunityHandler_CommunityNotFound_ReturnsNotFound(t *testing
 	mockCommunityDB := &mocks.CommunityDatabase{}
 	mockUserDB := &mocks.UserDatabase{}
 
-	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": communityObjectID}).
+	mockCommunityDB.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": communityObjectID}).
 		Return((*models.Community)(nil), mongo.ErrNoDocuments)
 
 	c := handlers.Community{
@@ -170,7 +170,7 @@ func TestCommunity_CommunityHandler_InvalidObjectID_ReturnsBadRequest(t *testing
 	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	mockCommunityDB.AssertNotCalled(t, "FindOne", mock.Anything, mock.Anything)
+	mockCommunityDB.AssertNotCalled(t, "FindOneIncludingPending", mock.Anything, mock.Anything)
 	mockUserDB.AssertNotCalled(t, "CountDocuments", mock.Anything, mock.Anything)
 }
 

--- a/api/handlers/community_pending_gate.go
+++ b/api/handlers/community_pending_gate.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/databases"
+)
+
+// CommunityPendingGate returns mux middleware that intercepts requests for a
+// community currently in pending-deletion state and responds 410 Gone with the
+// standard pending_deletion payload. The mobile and web clients listen for
+// that response globally and bounce the member out — this closes the race
+// where an owner soft-deletes a community while members are actively using it.
+//
+// The gate is a no-op for any request whose matched route doesn't carry a
+// {community_id} or {communityId} mux var, so it's safe to attach to a
+// subrouter without per-route bookkeeping. Admin restore endpoints (under
+// /api/v1/admin/) are skipped because staff need to interact with pending
+// communities to bring them back.
+func CommunityPendingGate(cdb databases.CommunityDatabase) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/api/v1/admin/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+			vars := mux.Vars(r)
+			cidStr := vars["community_id"]
+			if cidStr == "" {
+				cidStr = vars["communityId"]
+			}
+			if cidStr == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			cID, err := primitive.ObjectIDFromHex(cidStr)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx, cancel := api.WithQueryTimeout(r.Context())
+			defer cancel()
+			comm, err := cdb.FindOneIncludingPending(ctx, bson.M{"_id": cID})
+			if err == nil && comm != nil && comm.Details.PendingDeletionAt != nil {
+				writePendingDeletionGone(w, comm)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/api/handlers/community_soft_delete_test.go
+++ b/api/handlers/community_soft_delete_test.go
@@ -1,0 +1,297 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+const softDeleteCommunityID = "507f1f77bcf86cd799439011"
+
+func newSoftDeleteHandler(cdb *mocks.CommunityDatabase, udb *mocks.UserDatabase, aldb *mocks.AuditLogDatabase) handlers.Community {
+	return handlers.Community{
+		DB:   cdb,
+		UDB:  udb,
+		ALDB: aldb,
+	}
+}
+
+func newCommunityRequest(method, path string, body []byte, vars map[string]string) *http.Request {
+	var req *http.Request
+	if body == nil {
+		req, _ = http.NewRequest(method, path, nil)
+	} else {
+		req, _ = http.NewRequest(method, path, bytes.NewReader(body))
+	}
+	return mux.SetURLVars(req, vars)
+}
+
+// TestDeleteCommunity_SoftDeletesAndDoesNotCascade asserts that the rewritten
+// handler sets the soft-delete fields and does NOT issue any DeleteOne against
+// the community or cascade collections. Hard deletion now belongs to the cron.
+func TestDeleteCommunity_SoftDeletesAndDoesNotCascade(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(&models.Community{
+			ID:      cID,
+			Details: models.CommunityDetails{Name: "Test Community", OwnerID: "owner-1"},
+		}, nil)
+
+	cdb.On("UpdateOne", mock.Anything, bson.M{"_id": cID}, mock.MatchedBy(func(update bson.M) bool {
+		set, ok := update["$set"].(bson.M)
+		if !ok {
+			return false
+		}
+		_, hasPending := set["community.pendingDeletionAt"]
+		_, hasScheduled := set["community.scheduledDeletionAt"]
+		return hasPending && hasScheduled
+	})).Return(nil)
+
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	c := newSoftDeleteHandler(cdb, udb, aldb)
+
+	req := newCommunityRequest(http.MethodDelete, "/api/v1/community/"+softDeleteCommunityID, nil,
+		map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.DeleteCommunityByIDHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, float64(handlers.CommunitySoftDeleteGraceDays), body["graceDays"])
+	scheduled, ok := body["scheduledDeletionAt"].(string)
+	assert.True(t, ok, "scheduledDeletionAt should be present in response")
+	parsed, err := time.Parse(time.RFC3339, scheduled)
+	assert.NoError(t, err)
+	assert.WithinDuration(t,
+		time.Now().UTC().Add(handlers.CommunitySoftDeleteGraceDays*24*time.Hour),
+		parsed,
+		2*time.Minute,
+		"scheduledDeletionAt should be ~30 days out")
+
+	cdb.AssertNotCalled(t, "DeleteOne", mock.Anything, mock.Anything)
+	cdb.AssertExpectations(t)
+}
+
+// TestDeleteCommunity_RejectsDoubleDelete asserts the second delete on the
+// same community returns 400 rather than silently re-scheduling it.
+func TestDeleteCommunity_RejectsDoubleDelete(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+	now := primitive.NewDateTimeFromTime(time.Now())
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(&models.Community{
+			ID: cID,
+			Details: models.CommunityDetails{
+				Name:              "Already Pending",
+				PendingDeletionAt: &now,
+			},
+		}, nil)
+
+	c := newSoftDeleteHandler(cdb, udb, aldb)
+
+	req := newCommunityRequest(http.MethodDelete, "/api/v1/community/"+softDeleteCommunityID, nil,
+		map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.DeleteCommunityByIDHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestRestoreCommunity_RequiresAdminRole asserts a regular user payload is
+// rejected with 403 — restores are staff-only.
+func TestRestoreCommunity_RequiresAdminRole(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	c := newSoftDeleteHandler(cdb, udb, aldb)
+
+	payload := map[string]interface{}{
+		"currentUser": map[string]interface{}{
+			"role": "user",
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req := newCommunityRequest(http.MethodPost,
+		"/api/v1/admin/communities/"+softDeleteCommunityID+"/restore-pending-deletion",
+		body, map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestRestoreCommunity_AdminClearsFields asserts an admin call $unsets the
+// soft-delete fields on a pending community.
+func TestRestoreCommunity_AdminClearsFields(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+	now := primitive.NewDateTimeFromTime(time.Now())
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(&models.Community{
+			ID: cID,
+			Details: models.CommunityDetails{
+				Name:              "Pending",
+				PendingDeletionAt: &now,
+			},
+		}, nil)
+
+	cdb.On("UpdateOne", mock.Anything, bson.M{"_id": cID}, mock.MatchedBy(func(update bson.M) bool {
+		unset, ok := update["$unset"].(bson.M)
+		if !ok {
+			return false
+		}
+		_, hasPending := unset["community.pendingDeletionAt"]
+		_, hasScheduled := unset["community.scheduledDeletionAt"]
+		return hasPending && hasScheduled
+	})).Return(nil)
+
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	c := newSoftDeleteHandler(cdb, udb, aldb)
+
+	payload := map[string]interface{}{
+		"currentUser": map[string]interface{}{
+			"email": "staff@linespolice-cad.com",
+			"roles": []interface{}{"admin"},
+		},
+	}
+	body, _ := json.Marshal(payload)
+	req := newCommunityRequest(http.MethodPost,
+		"/api/v1/admin/communities/"+softDeleteCommunityID+"/restore-pending-deletion",
+		body, map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}
+
+// TestRestoreCommunity_RejectsNonPending asserts restoring a community that
+// is not pending deletion returns 400.
+func TestRestoreCommunity_RejectsNonPending(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(&models.Community{
+			ID:      cID,
+			Details: models.CommunityDetails{Name: "Active"},
+		}, nil)
+
+	c := newSoftDeleteHandler(cdb, udb, aldb)
+
+	payload := map[string]interface{}{
+		"currentUser": map[string]interface{}{"roles": []interface{}{"owner"}},
+	}
+	body, _ := json.Marshal(payload)
+	req := newCommunityRequest(http.MethodPost,
+		"/api/v1/admin/communities/"+softDeleteCommunityID+"/restore-pending-deletion",
+		body, map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestCommunityHandler_Returns410ForPendingDeletion asserts a direct hit to
+// the detail endpoint returns 410 Gone with the route-block payload.
+func TestCommunityHandler_Returns410ForPendingDeletion(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+	now := primitive.NewDateTimeFromTime(time.Now())
+	scheduled := primitive.NewDateTimeFromTime(time.Now().Add(30 * 24 * time.Hour))
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(&models.Community{
+			ID: cID,
+			Details: models.CommunityDetails{
+				Name:                "Pending Community",
+				PendingDeletionAt:   &now,
+				ScheduledDeletionAt: &scheduled,
+			},
+		}, nil)
+
+	c := handlers.Community{DB: cdb, UDB: udb}
+
+	req := newCommunityRequest(http.MethodGet, "/api/v1/community/"+softDeleteCommunityID, nil,
+		map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusGone, rr.Code)
+
+	var body map[string]interface{}
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "pending_deletion", body["error"])
+	assert.Equal(t, "Pending Community", body["communityName"])
+	assert.NotEmpty(t, body["scheduledDeletionAt"])
+	// CountDocuments must not run — the handler short-circuits on the pending check.
+	udb.AssertNotCalled(t, "CountDocuments", mock.Anything, mock.Anything)
+}
+
+// TestCommunityHandler_Returns404ForMissing asserts the active path still
+// surfaces a real ErrNoDocuments as 404.
+func TestCommunityHandler_Returns404ForMissing(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(softDeleteCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	udb := &mocks.UserDatabase{}
+
+	cdb.On("FindOneIncludingPending", mock.Anything, bson.M{"_id": cID}).
+		Return(nil, mongo.ErrNoDocuments)
+
+	c := handlers.Community{DB: cdb, UDB: udb}
+
+	req := newCommunityRequest(http.MethodGet, "/api/v1/community/"+softDeleteCommunityID, nil,
+		map[string]string{"community_id": softDeleteCommunityID})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.CommunityHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// Reference imports so the linter doesn't complain when one of them is
+// transiently unused while editing.
+var _ = strings.TrimSpace
+var _ = errors.New

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -4800,8 +4800,15 @@ func (u User) FetchUserCommunitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Build Mongo filter and fetch communities
+	// Build Mongo filter and fetch communities. CDB.Find/CountDocuments both
+	// exclude pending-deletion communities; recompute totalCount from the
+	// collection so the client's pagination terminates when soft-deleted
+	// communities are stripped from results (otherwise data.length stays below
+	// the user-array count forever and pagers loop).
 	communityFilter := bson.M{"_id": bson.M{"$in": filteredCommunities}}
+	if visibleCount, countErr := u.CDB.CountDocuments(ctx, communityFilter); countErr == nil {
+		totalFilteredCount = int(visibleCount)
+	}
 	opts := options.Find().SetSkip(int64(skip)).SetLimit(int64(limit))
 	cursor, err := u.CDB.Find(ctx, communityFilter, opts)
 	if err != nil {

--- a/api/scheduler/community_hard_delete.go
+++ b/api/scheduler/community_hard_delete.go
@@ -1,0 +1,71 @@
+package scheduler
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
+)
+
+// hardDeleteCommunityWithCascade runs the full community hard-delete pipeline:
+// removes the community document, pulls user.communities references, and
+// cascades deletion across all child collections.
+//
+// Mirrors the cascade that DeleteCommunityByIDHandler used to perform before
+// the soft-delete refactor. Best-effort: logs errors per collection but keeps
+// going, so a single failed collection does not block the rest.
+func (s *Scheduler) hardDeleteCommunityWithCascade(ctx context.Context, communityID string, cID primitive.ObjectID) {
+	if err := s.CDB.DeleteOne(ctx, bson.M{"_id": cID}); err != nil {
+		zap.S().Errorw("hard delete: failed to delete community document",
+			"communityId", communityID, "error", err)
+		return
+	}
+
+	if _, err := s.UDB.UpdateMany(ctx,
+		bson.M{"user.communities.communityId": communityID},
+		bson.M{"$pull": bson.M{"user.communities": bson.M{"communityId": communityID}}},
+	); err != nil {
+		zap.S().Errorw("hard delete: failed to remove community refs from users",
+			"communityId", communityID, "error", err)
+	}
+
+	type collectionCleanup struct {
+		name   string
+		filter bson.M
+	}
+
+	cleanups := []collectionCleanup{
+		{"civilians", bson.M{"civilian.activeCommunityID": communityID}},
+		{"vehicles", bson.M{"vehicle.activeCommunityID": communityID}},
+		{"firearms", bson.M{"firearm.activeCommunityID": communityID}},
+		{"licenses", bson.M{"license.activeCommunityID": communityID}},
+		{"warrants", bson.M{"warrant.activeCommunityID": communityID}},
+		{"ems", bson.M{"ems.activeCommunityID": communityID}},
+		{"emsvehicles", bson.M{"vehicle.activeCommunityID": communityID}},
+		{"medicalreports", bson.M{"report.activeCommunityID": communityID}},
+		{"medications", bson.M{"medication.activeCommunityID": communityID}},
+		{"calls", bson.M{"call.communityID": communityID}},
+		{"bolos", bson.M{"bolo.communityID": communityID}},
+		{"courtcases", bson.M{"courtCase.communityID": communityID}},
+		{"courtsessions", bson.M{"courtSession.communityID": communityID}},
+		{"most_wanted_entries", bson.M{"mostWanted.communityID": communityID}},
+		{"inviteCodes", bson.M{"communityId": communityID}},
+		{"tone_logs", bson.M{"communityId": communityID}},
+		{"audit_logs", bson.M{"communityId": cID}},
+		{"announcements", bson.M{"community": cID}},
+	}
+
+	for _, col := range cleanups {
+		deleted, err := s.DBHelper.Collection(col.name).DeleteMany(ctx, col.filter)
+		if err != nil {
+			zap.S().Errorw("hard delete: cascade delete failed",
+				"collection", col.name, "communityId", communityID, "error", err)
+			continue
+		}
+		if deleted > 0 {
+			zap.S().Infow("hard delete: cascade deleted documents",
+				"collection", col.name, "communityId", communityID, "count", deleted)
+		}
+	}
+}

--- a/api/scheduler/community_hard_delete.go
+++ b/api/scheduler/community_hard_delete.go
@@ -6,23 +6,36 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.uber.org/zap"
+
+	"github.com/linesmerrill/police-cad-api/databases"
 )
 
-// hardDeleteCommunityWithCascade runs the full community hard-delete pipeline:
+// HardDeleteCommunityWithCascade runs the full community hard-delete pipeline:
 // removes the community document, pulls user.communities references, and
 // cascades deletion across all child collections.
 //
 // Mirrors the cascade that DeleteCommunityByIDHandler used to perform before
 // the soft-delete refactor. Best-effort: logs errors per collection but keeps
 // going, so a single failed collection does not block the rest.
-func (s *Scheduler) hardDeleteCommunityWithCascade(ctx context.Context, communityID string, cID primitive.ObjectID) {
-	if err := s.CDB.DeleteOne(ctx, bson.M{"_id": cID}); err != nil {
+//
+// Exported so the admin "force delete now" endpoint can call it directly
+// rather than waiting for the daily scheduler tick to pick up the pending
+// community.
+func HardDeleteCommunityWithCascade(
+	ctx context.Context,
+	cdb databases.CommunityDatabase,
+	udb databases.UserDatabase,
+	dbHelper databases.DatabaseHelper,
+	communityID string,
+	cID primitive.ObjectID,
+) {
+	if err := cdb.DeleteOne(ctx, bson.M{"_id": cID}); err != nil {
 		zap.S().Errorw("hard delete: failed to delete community document",
 			"communityId", communityID, "error", err)
 		return
 	}
 
-	if _, err := s.UDB.UpdateMany(ctx,
+	if _, err := udb.UpdateMany(ctx,
 		bson.M{"user.communities.communityId": communityID},
 		bson.M{"$pull": bson.M{"user.communities": bson.M{"communityId": communityID}}},
 	); err != nil {
@@ -57,7 +70,7 @@ func (s *Scheduler) hardDeleteCommunityWithCascade(ctx context.Context, communit
 	}
 
 	for _, col := range cleanups {
-		deleted, err := s.DBHelper.Collection(col.name).DeleteMany(ctx, col.filter)
+		deleted, err := dbHelper.Collection(col.name).DeleteMany(ctx, col.filter)
 		if err != nil {
 			zap.S().Errorw("hard delete: cascade delete failed",
 				"collection", col.name, "communityId", communityID, "error", err)
@@ -68,4 +81,10 @@ func (s *Scheduler) hardDeleteCommunityWithCascade(ctx context.Context, communit
 				"collection", col.name, "communityId", communityID, "count", deleted)
 		}
 	}
+}
+
+// hardDeleteCommunityWithCascade is the scheduler's adapter for the exported
+// cascade. Kept as a method so existing scheduler call sites are unchanged.
+func (s *Scheduler) hardDeleteCommunityWithCascade(ctx context.Context, communityID string, cID primitive.ObjectID) {
+	HardDeleteCommunityWithCascade(ctx, s.CDB, s.UDB, s.DBHelper, communityID, cID)
 }

--- a/api/scheduler/community_pending_deletion.go
+++ b/api/scheduler/community_pending_deletion.go
@@ -1,0 +1,153 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	templates "github.com/linesmerrill/police-cad-api/templates/html"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.uber.org/zap"
+)
+
+const communityHardDeleteLockKey = "community_hard_delete_job"
+
+// processCommunityPendingDeletions runs daily. Sends a 24-hour heads-up email to
+// owners whose communities are about to be hard-deleted, then hard-deletes any
+// community whose ScheduledDeletionAt has elapsed. Idempotent across instances
+// via the shared scheduler lock.
+func (s *Scheduler) processCommunityPendingDeletions() {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	acquired, err := s.LockDB.TryAcquireLock(ctx, communityHardDeleteLockKey, s.instanceID, 25*time.Minute)
+	if err != nil {
+		zap.S().Errorw("community hard delete: failed to acquire lock", "error", err)
+		return
+	}
+	if !acquired {
+		zap.S().Debug("community hard delete job already running on another instance, skipping")
+		return
+	}
+	defer s.LockDB.ReleaseLock(ctx, communityHardDeleteLockKey, s.instanceID)
+
+	now := time.Now().UTC()
+	nowDT := primitive.NewDateTimeFromTime(now)
+	oneDayFromNowDT := primitive.NewDateTimeFromTime(now.Add(24 * time.Hour))
+
+	zap.S().Infow("running community pending-deletion job", "instance", s.instanceID)
+
+	s.sendCommunityDeletionReminders(ctx, nowDT, oneDayFromNowDT)
+	s.hardDeleteExpiredPendingCommunities(ctx, nowDT)
+}
+
+// sendCommunityDeletionReminders emails owners whose community is within 24 hours
+// of hard-deletion and hasn't already received the reminder.
+func (s *Scheduler) sendCommunityDeletionReminders(ctx context.Context, nowDT, oneDayFromNowDT primitive.DateTime) {
+	filter := bson.M{
+		"community.pendingDeletionAt": bson.M{"$ne": nil},
+		"community.scheduledDeletionAt": bson.M{
+			"$gt": nowDT,
+			"$lt": oneDayFromNowDT,
+		},
+		"community.pendingDeletionNotifiedAt": nil,
+	}
+	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
+	if err != nil {
+		zap.S().Errorw("community hard delete: reminder query failed", "error", err)
+		return
+	}
+	defer cursor.Close(ctx)
+
+	var due []models.Community
+	if err := cursor.All(ctx, &due); err != nil {
+		zap.S().Errorw("community hard delete: reminder decode failed", "error", err)
+		return
+	}
+
+	for _, c := range due {
+		s.sendPendingDeletionReminderEmail(ctx, c)
+		if err := s.CDB.UpdateOne(ctx, bson.M{"_id": c.ID}, bson.M{
+			"$set": bson.M{"community.pendingDeletionNotifiedAt": nowDT},
+		}); err != nil {
+			zap.S().Errorw("community hard delete: failed to mark reminder sent",
+				"communityId", c.ID.Hex(), "error", err)
+		}
+	}
+	zap.S().Infow("community pending-deletion reminders processed", "count", len(due))
+}
+
+// hardDeleteExpiredPendingCommunities performs the cascade hard-delete on any
+// community whose ScheduledDeletionAt has elapsed.
+func (s *Scheduler) hardDeleteExpiredPendingCommunities(ctx context.Context, nowDT primitive.DateTime) {
+	filter := bson.M{
+		"community.pendingDeletionAt":   bson.M{"$ne": nil},
+		"community.scheduledDeletionAt": bson.M{"$lte": nowDT},
+	}
+	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
+	if err != nil {
+		zap.S().Errorw("community hard delete: expired query failed", "error", err)
+		return
+	}
+	defer cursor.Close(ctx)
+
+	var expired []models.Community
+	if err := cursor.All(ctx, &expired); err != nil {
+		zap.S().Errorw("community hard delete: expired decode failed", "error", err)
+		return
+	}
+
+	for _, c := range expired {
+		// Re-check the row with a guarded UpdateOne so a concurrent admin restore
+		// (which $unset's scheduledDeletionAt) can't lose a race against the
+		// hard-delete. The marker exists only on the doc we are about to wipe;
+		// here we use it to atomically claim ownership of this row's deletion.
+		err := s.CDB.UpdateOne(ctx, bson.M{
+			"_id":                           c.ID,
+			"community.scheduledDeletionAt": c.Details.ScheduledDeletionAt,
+		}, bson.M{
+			"$set": bson.M{"community.pendingDeletionNotifiedAt": nowDT},
+		})
+		if err != nil {
+			zap.S().Warnw("community hard delete: could not claim row for deletion (likely restored)",
+				"communityId", c.ID.Hex(), "error", err)
+			continue
+		}
+		s.hardDeleteCommunityWithCascade(ctx, c.ID.Hex(), c.ID)
+	}
+	zap.S().Infow("community pending-deletion hard-deletes processed", "count", len(expired))
+}
+
+// sendPendingDeletionReminderEmail emails the community owner one day before
+// their community is hard-deleted. Best-effort; logs and moves on.
+func (s *Scheduler) sendPendingDeletionReminderEmail(ctx context.Context, c models.Community) {
+	if c.Details.OwnerID == "" {
+		return
+	}
+	ownerOID, err := primitive.ObjectIDFromHex(c.Details.OwnerID)
+	if err != nil {
+		// Some legacy owner IDs are stored as plain strings; in that case skip
+		// the email rather than fail the sweep.
+		return
+	}
+	email, displayName := s.getUserEmail(ctx, ownerOID)
+	if email == "" {
+		return
+	}
+
+	scheduled := time.Time{}
+	if c.Details.ScheduledDeletionAt != nil {
+		scheduled = c.Details.ScheduledDeletionAt.Time().UTC()
+	}
+
+	subject := "Final reminder: " + c.Details.Name + " deletes in 24 hours"
+	htmlContent := templates.RenderCommunityPendingDeletionReminderEmail(displayName, c.Details.Name, scheduled)
+	plainText := "Your community " + c.Details.Name + " is scheduled for permanent deletion in less than 24 hours. Contact support if you need it restored."
+
+	if err := s.sendEmail(email, displayName, subject, htmlContent, plainText); err != nil {
+		zap.S().Errorw("community pending-deletion: reminder email failed",
+			"communityId", c.ID.Hex(), "error", err)
+	}
+}
+

--- a/api/scheduler/community_pending_deletion.go
+++ b/api/scheduler/community_pending_deletion.go
@@ -24,6 +24,9 @@ func (s *Scheduler) processCommunityPendingDeletions() {
 	acquired, err := s.LockDB.TryAcquireLock(ctx, communityHardDeleteLockKey, s.instanceID, 25*time.Minute)
 	if err != nil {
 		zap.S().Errorw("community hard delete: failed to acquire lock", "error", err)
+		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+			"phase": "lock_acquire",
+		})
 		return
 	}
 	if !acquired {
@@ -56,6 +59,9 @@ func (s *Scheduler) sendCommunityDeletionReminders(ctx context.Context, nowDT, o
 	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("community hard delete: reminder query failed", "error", err)
+		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+			"phase": "reminder_find",
+		})
 		return
 	}
 	defer cursor.Close(ctx)
@@ -63,6 +69,9 @@ func (s *Scheduler) sendCommunityDeletionReminders(ctx context.Context, nowDT, o
 	var due []models.Community
 	if err := cursor.All(ctx, &due); err != nil {
 		zap.S().Errorw("community hard delete: reminder decode failed", "error", err)
+		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+			"phase": "reminder_decode",
+		})
 		return
 	}
 
@@ -88,6 +97,9 @@ func (s *Scheduler) hardDeleteExpiredPendingCommunities(ctx context.Context, now
 	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("community hard delete: expired query failed", "error", err)
+		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+			"phase": "expired_find",
+		})
 		return
 	}
 	defer cursor.Close(ctx)
@@ -95,6 +107,9 @@ func (s *Scheduler) hardDeleteExpiredPendingCommunities(ctx context.Context, now
 	var expired []models.Community
 	if err := cursor.All(ctx, &expired); err != nil {
 		zap.S().Errorw("community hard delete: expired decode failed", "error", err)
+		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+			"phase": "expired_decode",
+		})
 		return
 	}
 

--- a/api/scheduler/community_pending_deletion.go
+++ b/api/scheduler/community_pending_deletion.go
@@ -24,7 +24,7 @@ func (s *Scheduler) processCommunityPendingDeletions() {
 	acquired, err := s.LockDB.TryAcquireLock(ctx, communityHardDeleteLockKey, s.instanceID, 25*time.Minute)
 	if err != nil {
 		zap.S().Errorw("community hard delete: failed to acquire lock", "error", err)
-		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
 			"phase": "lock_acquire",
 		})
 		return
@@ -59,7 +59,7 @@ func (s *Scheduler) sendCommunityDeletionReminders(ctx context.Context, nowDT, o
 	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("community hard delete: reminder query failed", "error", err)
-		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
 			"phase": "reminder_find",
 		})
 		return
@@ -69,7 +69,7 @@ func (s *Scheduler) sendCommunityDeletionReminders(ctx context.Context, nowDT, o
 	var due []models.Community
 	if err := cursor.All(ctx, &due); err != nil {
 		zap.S().Errorw("community hard delete: reminder decode failed", "error", err)
-		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
 			"phase": "reminder_decode",
 		})
 		return
@@ -97,7 +97,7 @@ func (s *Scheduler) hardDeleteExpiredPendingCommunities(ctx context.Context, now
 	cursor, err := s.CDB.FindIncludingPending(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("community hard delete: expired query failed", "error", err)
-		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
 			"phase": "expired_find",
 		})
 		return
@@ -107,7 +107,7 @@ func (s *Scheduler) hardDeleteExpiredPendingCommunities(ctx context.Context, now
 	var expired []models.Community
 	if err := cursor.All(ctx, &expired); err != nil {
 		zap.S().Errorw("community hard delete: expired decode failed", "error", err)
-		s.SendCronAlert("processCommunityPendingDeletions", err, map[string]string{
+		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
 			"phase": "expired_decode",
 		})
 		return

--- a/api/scheduler/community_pending_deletion.go
+++ b/api/scheduler/community_pending_deletion.go
@@ -18,19 +18,22 @@ const communityHardDeleteLockKey = "community_hard_delete_job"
 // community whose ScheduledDeletionAt has elapsed. Idempotent across instances
 // via the shared scheduler lock.
 func (s *Scheduler) processCommunityPendingDeletions() {
+	const jobName = "processCommunityPendingDeletions"
+	s.recordStart(jobName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 
 	acquired, err := s.LockDB.TryAcquireLock(ctx, communityHardDeleteLockKey, s.instanceID, 25*time.Minute)
 	if err != nil {
 		zap.S().Errorw("community hard delete: failed to acquire lock", "error", err)
-		SendCronAlert(s.instanceID, "processCommunityPendingDeletions", err, map[string]string{
-			"phase": "lock_acquire",
-		})
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "lock_acquire"})
 		return
 	}
 	if !acquired {
 		zap.S().Debug("community hard delete job already running on another instance, skipping")
+		s.recordSkipped(jobName)
 		return
 	}
 	defer s.LockDB.ReleaseLock(ctx, communityHardDeleteLockKey, s.instanceID)
@@ -43,6 +46,7 @@ func (s *Scheduler) processCommunityPendingDeletions() {
 
 	s.sendCommunityDeletionReminders(ctx, nowDT, oneDayFromNowDT)
 	s.hardDeleteExpiredPendingCommunities(ctx, nowDT)
+	s.recordSuccess(jobName)
 }
 
 // sendCommunityDeletionReminders emails owners whose community is within 24 hours

--- a/api/scheduler/discord_alerts.go
+++ b/api/scheduler/discord_alerts.go
@@ -1,0 +1,148 @@
+package scheduler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Best-effort Discord webhook alerts for scheduler job failures.
+//
+// Reads DISCORD_CRON_ERROR_WEBHOOK_URL from the environment. Silent
+// no-op when unset so local dev / preview apps cost nothing.
+//
+// Includes a 60-second dedup window per (job, error-message) signature
+// so a hot bug at 3 AM doesn't dump 100 messages while the cron retries.
+
+const (
+	cronAlertWebhookEnv   = "DISCORD_CRON_ERROR_WEBHOOK_URL"
+	cronAlertDedupWindow  = 60 * time.Second
+	cronAlertHTTPDeadline = 5 * time.Second
+)
+
+var (
+	cronAlertMu     sync.Mutex
+	cronAlertRecent = map[string]time.Time{}
+	cronAlertClient = &http.Client{Timeout: cronAlertHTTPDeadline}
+)
+
+type discordEmbed struct {
+	Title       string         `json:"title"`
+	Description string         `json:"description,omitempty"`
+	Color       int            `json:"color,omitempty"`
+	Timestamp   string         `json:"timestamp,omitempty"`
+	Footer      *discordFooter `json:"footer,omitempty"`
+	Fields      []discordField `json:"fields,omitempty"`
+}
+
+type discordFooter struct {
+	Text string `json:"text"`
+}
+
+type discordField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline,omitempty"`
+}
+
+type discordWebhookPayload struct {
+	Embeds []discordEmbed `json:"embeds"`
+}
+
+func truncForDiscord(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+// SendCronAlert posts an error embed to Discord for a failed scheduler job.
+// `jobName` identifies which job (e.g. "processCommunityPendingDeletions"),
+// `err` is the failure, and `fields` are arbitrary key/value pairs included
+// inline on the embed. Best-effort: if anything about the POST goes wrong,
+// we log via zap and move on.
+func (s *Scheduler) SendCronAlert(jobName string, err error, fields map[string]string) {
+	webhook := os.Getenv(cronAlertWebhookEnv)
+	if webhook == "" || err == nil {
+		return
+	}
+
+	sig := jobName + "|" + err.Error()
+	now := time.Now()
+
+	cronAlertMu.Lock()
+	if t, ok := cronAlertRecent[sig]; ok && now.Sub(t) < cronAlertDedupWindow {
+		cronAlertMu.Unlock()
+		return
+	}
+	cronAlertRecent[sig] = now
+	// Prune entries older than the dedup window so the map can't grow
+	// without bound.
+	for k, t := range cronAlertRecent {
+		if now.Sub(t) > cronAlertDedupWindow {
+			delete(cronAlertRecent, k)
+		}
+	}
+	cronAlertMu.Unlock()
+
+	env := os.Getenv("APP_ENV")
+	if env == "" {
+		env = "unknown"
+	}
+	dyno := os.Getenv("DYNO")
+	if dyno == "" {
+		dyno = "local"
+	}
+
+	embedFields := []discordField{
+		{Name: "Job", Value: jobName, Inline: true},
+		{Name: "Instance", Value: s.instanceID, Inline: true},
+	}
+	for k, v := range fields {
+		embedFields = append(embedFields, discordField{
+			Name:   truncForDiscord(k, 256),
+			Value:  truncForDiscord(v, 1024),
+			Inline: false,
+		})
+	}
+
+	embed := discordEmbed{
+		Title:       fmt.Sprintf("⚠️ Cron failure · %s", truncForDiscord(err.Error(), 200)),
+		Description: fmt.Sprintf("```\n%s\n```", truncForDiscord(err.Error(), 1800)),
+		Color:       0xef4444,
+		Timestamp:   now.UTC().Format(time.RFC3339),
+		Footer:      &discordFooter{Text: "police-cad-api · " + env + " · " + dyno},
+		Fields:      embedFields,
+	}
+
+	payload := discordWebhookPayload{Embeds: []discordEmbed{embed}}
+	body, mErr := json.Marshal(payload)
+	if mErr != nil {
+		zap.S().Errorw("discord cron alert: marshal failed", "error", mErr)
+		return
+	}
+
+	go func() {
+		req, rErr := http.NewRequest(http.MethodPost, webhook, bytes.NewReader(body))
+		if rErr != nil {
+			zap.S().Warnw("discord cron alert: request build failed", "error", rErr)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, hErr := cronAlertClient.Do(req)
+		if hErr != nil {
+			zap.S().Warnw("discord cron alert: post failed", "error", hErr)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			zap.S().Warnw("discord cron alert: bad response", "status", resp.StatusCode)
+		}
+	}()
+}

--- a/api/scheduler/discord_alerts.go
+++ b/api/scheduler/discord_alerts.go
@@ -67,7 +67,12 @@ func truncForDiscord(s string, n int) string {
 // `err` is the failure, and `fields` are arbitrary key/value pairs included
 // inline on the embed. Best-effort: if anything about the POST goes wrong,
 // we log via zap and move on.
-func (s *Scheduler) SendCronAlert(jobName string, err error, fields map[string]string) {
+//
+// Exposed as a package function so handlers outside the scheduler (e.g. the
+// admin smoke-test endpoint) can fire alerts without holding a Scheduler
+// reference. Callers should pass the running dyno's DYNO env, or empty
+// string if not relevant.
+func SendCronAlert(instanceID, jobName string, err error, fields map[string]string) {
 	webhook := os.Getenv(cronAlertWebhookEnv)
 	if webhook == "" || err == nil {
 		return
@@ -100,9 +105,12 @@ func (s *Scheduler) SendCronAlert(jobName string, err error, fields map[string]s
 		dyno = "local"
 	}
 
+	if instanceID == "" {
+		instanceID = dyno
+	}
 	embedFields := []discordField{
 		{Name: "Job", Value: jobName, Inline: true},
-		{Name: "Instance", Value: s.instanceID, Inline: true},
+		{Name: "Instance", Value: instanceID, Inline: true},
 	}
 	for k, v := range fields {
 		embedFields = append(embedFields, discordField{

--- a/api/scheduler/economy_jobs.go
+++ b/api/scheduler/economy_jobs.go
@@ -14,15 +14,21 @@ import (
 // staleSessionSweep finds active clock sessions that have exceeded their max session window
 // or missed their AFK heartbeat grace, finalizes payroll, and marks them expired.
 func (s *Scheduler) staleSessionSweep() {
+	const jobName = "staleSessionSweep"
+	s.recordStart(jobName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	acquired, err := s.LockDB.TryAcquireLock(ctx, "economy_stale_session_sweep", s.instanceID, 90*time.Second)
 	if err != nil {
 		zap.S().Errorw("failed to acquire lock for stale session sweep", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "lock_acquire"})
 		return
 	}
 	if !acquired {
+		s.recordSkipped(jobName)
 		return
 	}
 	defer s.LockDB.ReleaseLock(ctx, "economy_stale_session_sweep", s.instanceID)
@@ -30,6 +36,8 @@ func (s *Scheduler) staleSessionSweep() {
 	sessions, err := s.SessionDB.Find(ctx, bson.M{"status": "active"})
 	if err != nil {
 		zap.S().Errorw("failed to find active sessions", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "find_active"})
 		return
 	}
 
@@ -49,6 +57,7 @@ func (s *Scheduler) staleSessionSweep() {
 		s.payAndCloseSession(ctx, sess, now, terminal)
 		swept++
 	}
+	s.recordSuccess(jobName)
 	if swept > 0 {
 		zap.S().Infow("Economy: swept stale sessions", "count", swept)
 	}
@@ -119,15 +128,21 @@ func (s *Scheduler) payAndCloseSession(ctx context.Context, sess *models.ClockSe
 
 // inboxDelinquencyTick flips any pending inbox item whose dueAt has passed to "delinquent".
 func (s *Scheduler) inboxDelinquencyTick() {
+	const jobName = "inboxDelinquencyTick"
+	s.recordStart(jobName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
 	acquired, err := s.LockDB.TryAcquireLock(ctx, "economy_inbox_delinquency_tick", s.instanceID, 90*time.Second)
 	if err != nil {
 		zap.S().Errorw("failed to acquire lock for inbox delinquency tick", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "lock_acquire"})
 		return
 	}
 	if !acquired {
+		s.recordSkipped(jobName)
 		return
 	}
 	defer s.LockDB.ReleaseLock(ctx, "economy_inbox_delinquency_tick", s.instanceID)
@@ -140,5 +155,9 @@ func (s *Scheduler) inboxDelinquencyTick() {
 	update := bson.M{"$set": bson.M{"status": "delinquent", "updatedAt": now}}
 	if err := s.InboxDB.UpdateMany(ctx, filter, update); err != nil {
 		zap.S().Errorw("failed to flip inbox items to delinquent", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "update_many"})
+		return
 	}
+	s.recordSuccess(jobName)
 }

--- a/api/scheduler/job_stats.go
+++ b/api/scheduler/job_stats.go
@@ -1,0 +1,108 @@
+package scheduler
+
+import (
+	"time"
+)
+
+// JobStat records the run history of a single cron job. All timestamps are
+// UTC. A consumer (e.g. /health/scheduler) can detect staleness by
+// comparing LastSucceededAt to the registered Schedule expectation.
+type JobStat struct {
+	Schedule        string    `json:"schedule"`
+	LastStartedAt   time.Time `json:"lastStartedAt,omitempty"`
+	LastSucceededAt time.Time `json:"lastSucceededAt,omitempty"`
+	LastSkippedAt   time.Time `json:"lastSkippedAt,omitempty"`
+	LastErroredAt   time.Time `json:"lastErroredAt,omitempty"`
+	LastError       string    `json:"lastError,omitempty"`
+	RunCount        int64     `json:"runCount"`
+	SuccessCount    int64     `json:"successCount"`
+	SkipCount       int64     `json:"skipCount"`
+	ErrorCount      int64     `json:"errorCount"`
+}
+
+// registerJob adds an entry for jobName with its cron schedule expression
+// so the health endpoint can surface "expected cadence" alongside the run
+// history. Called from scheduler.Start() right after AddFunc.
+func (s *Scheduler) registerJob(jobName, schedule string) {
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	if s.jobStats == nil {
+		s.jobStats = map[string]*JobStat{}
+	}
+	if _, ok := s.jobStats[jobName]; !ok {
+		s.jobStats[jobName] = &JobStat{}
+	}
+	s.jobStats[jobName].Schedule = schedule
+}
+
+// getOrInit lazily creates a JobStat so jobs that forgot to call
+// registerJob still produce useful telemetry.
+func (s *Scheduler) getOrInit(jobName string) *JobStat {
+	if s.jobStats == nil {
+		s.jobStats = map[string]*JobStat{}
+	}
+	stat, ok := s.jobStats[jobName]
+	if !ok {
+		stat = &JobStat{}
+		s.jobStats[jobName] = stat
+	}
+	return stat
+}
+
+// recordStart marks a job as starting. Called as the first line of each job.
+func (s *Scheduler) recordStart(jobName string) {
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	stat := s.getOrInit(jobName)
+	stat.LastStartedAt = time.Now().UTC()
+	stat.RunCount++
+}
+
+// recordSuccess marks a successful completion. Called at the end of the
+// happy path.
+func (s *Scheduler) recordSuccess(jobName string) {
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	stat := s.getOrInit(jobName)
+	stat.LastSucceededAt = time.Now().UTC()
+	stat.SuccessCount++
+}
+
+// recordSkipped marks a "lock held by another instance" early-return. Not
+// an error — expected on multi-dyno deployments.
+func (s *Scheduler) recordSkipped(jobName string) {
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	stat := s.getOrInit(jobName)
+	stat.LastSkippedAt = time.Now().UTC()
+	stat.SkipCount++
+}
+
+// recordError marks a failure with the error message. The Discord alert
+// hook is separate — call SendCronAlert too if this is a meaningful
+// failure (not a per-row best-effort one).
+func (s *Scheduler) recordError(jobName string, err error) {
+	if err == nil {
+		return
+	}
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	stat := s.getOrInit(jobName)
+	stat.LastErroredAt = time.Now().UTC()
+	stat.LastError = err.Error()
+	stat.ErrorCount++
+}
+
+// SnapshotJobStats returns a copy of the current stats map for the health
+// endpoint. Returning copies (not pointers) means consumers can iterate
+// without holding the scheduler lock.
+func (s *Scheduler) SnapshotJobStats() map[string]JobStat {
+	s.jobStatsMu.Lock()
+	defer s.jobStatsMu.Unlock()
+	out := make(map[string]JobStat, len(s.jobStats))
+	for name, stat := range s.jobStats {
+		out[name] = *stat
+	}
+	return out
+}
+

--- a/api/scheduler/scheduler.go
+++ b/api/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/linesmerrill/police-cad-api/databases"
@@ -32,6 +33,11 @@ type Scheduler struct {
 	InboxDB    databases.InboxItemDatabase
 	CivDB      databases.CivilianDatabase
 	instanceID string
+
+	// Per-job run stats for /health/scheduler. Multiple jobs may run in
+	// parallel goroutines, so all access goes through jobStatsMu.
+	jobStatsMu sync.Mutex
+	jobStats   map[string]*JobStat
 }
 
 // NewScheduler creates a new scheduler instance
@@ -66,41 +72,55 @@ func NewScheduler(
 		InboxDB:    inboxDB,
 		CivDB:      civDB,
 		instanceID: instanceID,
+		jobStats:   map[string]*JobStat{},
 	}
 }
 
 // Start begins the scheduler with all registered jobs
 func (s *Scheduler) Start() {
 	// Process grace period expirations and send reminders daily at 3 AM UTC
-	_, err := s.cron.AddFunc("0 3 * * *", s.processGracePeriods)
-	if err != nil {
+	const gracePeriodSchedule = "0 3 * * *"
+	if _, err := s.cron.AddFunc(gracePeriodSchedule, s.processGracePeriods); err != nil {
 		zap.S().Errorw("failed to register grace period job", "error", err)
+	} else {
+		s.registerJob("processGracePeriods", gracePeriodSchedule)
 	}
 
 	// Check for creators who need grace period warnings every 3 days at 2 AM UTC
 	// This catches creators whose follower counts may have dropped
-	_, err = s.cron.AddFunc("0 2 */3 * *", s.checkAllCreators)
-	if err != nil {
+	const checkCreatorsSchedule = "0 2 */3 * *"
+	if _, err := s.cron.AddFunc(checkCreatorsSchedule, s.checkAllCreators); err != nil {
 		zap.S().Errorw("failed to register creator check job", "error", err)
+	} else {
+		s.registerJob("checkAllCreators", checkCreatorsSchedule)
 	}
 
 	// Economy: sweep stale clock sessions every minute (only registers if DB present)
 	if s.SessionDB != nil {
-		if _, err = s.cron.AddFunc("@every 1m", s.staleSessionSweep); err != nil {
+		const staleSessionSchedule = "@every 1m"
+		if _, err := s.cron.AddFunc(staleSessionSchedule, s.staleSessionSweep); err != nil {
 			zap.S().Errorw("failed to register stale session sweep", "error", err)
+		} else {
+			s.registerJob("staleSessionSweep", staleSessionSchedule)
 		}
 	}
 	// Economy: flip overdue inbox items to delinquent every 5 minutes
 	if s.InboxDB != nil {
-		if _, err = s.cron.AddFunc("@every 5m", s.inboxDelinquencyTick); err != nil {
+		const inboxDelinquencySchedule = "@every 5m"
+		if _, err := s.cron.AddFunc(inboxDelinquencySchedule, s.inboxDelinquencyTick); err != nil {
 			zap.S().Errorw("failed to register inbox delinquency tick", "error", err)
+		} else {
+			s.registerJob("inboxDelinquencyTick", inboxDelinquencySchedule)
 		}
 	}
 
 	// Community soft-delete sweep: reminders + hard-deletes for elapsed grace periods
 	if s.CDB != nil && s.DBHelper != nil {
-		if _, err = s.cron.AddFunc("0 3 * * *", s.processCommunityPendingDeletions); err != nil {
+		const communityPendingSchedule = "0 3 * * *"
+		if _, err := s.cron.AddFunc(communityPendingSchedule, s.processCommunityPendingDeletions); err != nil {
 			zap.S().Errorw("failed to register community pending-deletion job", "error", err)
+		} else {
+			s.registerJob("processCommunityPendingDeletions", communityPendingSchedule)
 		}
 	}
 
@@ -117,6 +137,9 @@ func (s *Scheduler) Stop() {
 
 // processGracePeriods handles grace period expirations and sends reminder emails
 func (s *Scheduler) processGracePeriods() {
+	const jobName = "processGracePeriods"
+	s.recordStart(jobName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -124,10 +147,13 @@ func (s *Scheduler) processGracePeriods() {
 	acquired, err := s.LockDB.TryAcquireLock(ctx, "grace_period_job", s.instanceID, 10*time.Minute)
 	if err != nil {
 		zap.S().Errorw("failed to acquire lock for grace period job", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "lock_acquire"})
 		return
 	}
 	if !acquired {
 		zap.S().Debug("Grace period job already running on another instance, skipping")
+		s.recordSkipped(jobName)
 		return
 	}
 	defer s.LockDB.ReleaseLock(ctx, "grace_period_job", s.instanceID)
@@ -146,12 +172,16 @@ func (s *Scheduler) processGracePeriods() {
 	cursor, err := s.CCDB.Find(ctx, expiredFilter)
 	if err != nil {
 		zap.S().Errorw("failed to find expired grace periods", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "expired_find"})
 		return
 	}
 
 	var expiredCreators []models.ContentCreator
 	if err := cursor.All(ctx, &expiredCreators); err != nil {
 		zap.S().Errorw("failed to decode expired creators", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "expired_decode"})
 		return
 	}
 	cursor.Close(ctx)
@@ -174,12 +204,16 @@ func (s *Scheduler) processGracePeriods() {
 	cursor, err = s.CCDB.Find(ctx, reminderFilter)
 	if err != nil {
 		zap.S().Errorw("failed to find creators needing reminder", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "reminder_find"})
 		return
 	}
 
 	var reminderCreators []models.ContentCreator
 	if err := cursor.All(ctx, &reminderCreators); err != nil {
 		zap.S().Errorw("failed to decode reminder creators", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "reminder_decode"})
 		return
 	}
 	cursor.Close(ctx)
@@ -189,6 +223,7 @@ func (s *Scheduler) processGracePeriods() {
 		s.sendReminderEmail(ctx, creator)
 	}
 
+	s.recordSuccess(jobName)
 	zap.S().Infow("Grace period processing complete",
 		"expiredProcessed", len(expiredCreators),
 		"remindersSent", len(reminderCreators),
@@ -340,6 +375,9 @@ func (s *Scheduler) removeCreator(ctx context.Context, creator models.ContentCre
 // checkAllCreators periodically checks all active creators for low follower counts
 // This catches cases where followers may have dropped since their last sync
 func (s *Scheduler) checkAllCreators() {
+	const jobName = "checkAllCreators"
+	s.recordStart(jobName)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
@@ -347,10 +385,13 @@ func (s *Scheduler) checkAllCreators() {
 	acquired, err := s.LockDB.TryAcquireLock(ctx, "check_all_creators_job", s.instanceID, 15*time.Minute)
 	if err != nil {
 		zap.S().Errorw("failed to acquire lock for creator check job", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "lock_acquire"})
 		return
 	}
 	if !acquired {
 		zap.S().Debug("Creator check job already running on another instance, skipping")
+		s.recordSkipped(jobName)
 		return
 	}
 	defer s.LockDB.ReleaseLock(ctx, "check_all_creators_job", s.instanceID)
@@ -372,12 +413,16 @@ func (s *Scheduler) checkAllCreators() {
 	cursor, err := s.CCDB.Find(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("failed to find creators for check", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "find"})
 		return
 	}
 
 	var creators []models.ContentCreator
 	if err := cursor.All(ctx, &creators); err != nil {
 		zap.S().Errorw("failed to decode creators", "error", err)
+		s.recordError(jobName, err)
+		SendCronAlert(s.instanceID, jobName, err, map[string]string{"phase": "decode"})
 		return
 	}
 	cursor.Close(ctx)
@@ -398,6 +443,7 @@ func (s *Scheduler) checkAllCreators() {
 		}
 	}
 
+	s.recordSuccess(jobName)
 	zap.S().Infow("Periodic creator check complete",
 		"creatorsChecked", len(creators),
 		"lowFollowersFound", lowFollowerCount,

--- a/api/scheduler/scheduler.go
+++ b/api/scheduler/scheduler.go
@@ -26,6 +26,7 @@ type Scheduler struct {
 	UDB     databases.UserDatabase
 	CDB        databases.CommunityDatabase
 	LockDB     databases.SchedulerLockDatabase
+	DBHelper   databases.DatabaseHelper
 	// Economy
 	SessionDB  databases.ClockSessionDatabase
 	InboxDB    databases.InboxItemDatabase
@@ -41,6 +42,7 @@ func NewScheduler(
 	uDB databases.UserDatabase,
 	cDB databases.CommunityDatabase,
 	lockDB databases.SchedulerLockDatabase,
+	dbHelper databases.DatabaseHelper,
 	sessionDB databases.ClockSessionDatabase,
 	inboxDB databases.InboxItemDatabase,
 	civDB databases.CivilianDatabase,
@@ -59,6 +61,7 @@ func NewScheduler(
 		UDB:        uDB,
 		CDB:        cDB,
 		LockDB:     lockDB,
+		DBHelper:   dbHelper,
 		SessionDB:  sessionDB,
 		InboxDB:    inboxDB,
 		CivDB:      civDB,
@@ -91,6 +94,13 @@ func (s *Scheduler) Start() {
 	if s.InboxDB != nil {
 		if _, err = s.cron.AddFunc("@every 5m", s.inboxDelinquencyTick); err != nil {
 			zap.S().Errorw("failed to register inbox delinquency tick", "error", err)
+		}
+	}
+
+	// Community soft-delete sweep: reminders + hard-deletes for elapsed grace periods
+	if s.CDB != nil && s.DBHelper != nil {
+		if _, err = s.cron.AddFunc("0 3 * * *", s.processCommunityPendingDeletions); err != nil {
+			zap.S().Errorw("failed to register community pending-deletion job", "error", err)
 		}
 	}
 

--- a/databases/community.go
+++ b/databases/community.go
@@ -6,21 +6,43 @@ import (
 	"context"
 
 	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const collectionName = "communities"
 
-// CommunityDatabase contains the methods to use with the community database
+// excludePending wraps a filter with a clause that excludes communities marked
+// pending deletion. A community is "pending" iff community.pendingDeletionAt is
+// set; we match on null OR missing so legacy docs (which lack the field) are
+// treated as active.
+func excludePending(filter interface{}) interface{} {
+	notPending := bson.M{"community.pendingDeletionAt": nil}
+	if filter == nil {
+		return notPending
+	}
+	return bson.M{"$and": bson.A{filter, notPending}}
+}
+
+// CommunityDatabase contains the methods to use with the community database.
+//
+// FindOne / Find / CountDocuments transparently exclude communities marked
+// pending deletion (community.pendingDeletionAt set). Use the *IncludingPending
+// variants from contexts that explicitly need to see pending-deletion
+// communities — the admin console, the scheduler hard-delete sweep, and the
+// detail endpoint that returns 410 for a direct link to a pending community.
 type CommunityDatabase interface {
 	FindOne(ctx context.Context, filter interface{}) (*models.Community, error)
+	FindOneIncludingPending(ctx context.Context, filter interface{}) (*models.Community, error)
 	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (MongoCursor, error)
+	FindIncludingPending(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (MongoCursor, error)
 	InsertOne(ctx context.Context, community models.Community, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error)
 	UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error
 	DeleteOne(ctx context.Context, filter interface{}, opts ...*options.DeleteOptions) error
 	Aggregate(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*MongoCursor, error)
 	CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	CountDocumentsIncludingPending(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
 }
 
 type communityDatabase struct {
@@ -35,6 +57,10 @@ func NewCommunityDatabase(db DatabaseHelper) CommunityDatabase {
 }
 
 func (c *communityDatabase) FindOne(ctx context.Context, filter interface{}) (*models.Community, error) {
+	return c.FindOneIncludingPending(ctx, excludePending(filter))
+}
+
+func (c *communityDatabase) FindOneIncludingPending(ctx context.Context, filter interface{}) (*models.Community, error) {
 	community := &models.Community{}
 	err := c.db.Collection(collectionName).FindOne(ctx, filter).Decode(&community)
 	if err != nil {
@@ -44,6 +70,10 @@ func (c *communityDatabase) FindOne(ctx context.Context, filter interface{}) (*m
 }
 
 func (c *communityDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (MongoCursor, error) {
+	return c.FindIncludingPending(ctx, excludePending(filter), opts...)
+}
+
+func (c *communityDatabase) FindIncludingPending(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (MongoCursor, error) {
 	cursor, err := c.db.Collection(collectionName).Find(ctx, filter, opts...)
 	if err != nil {
 		return MongoCursor{}, err
@@ -71,5 +101,9 @@ func (c *communityDatabase) Aggregate(ctx context.Context, pipeline mongo.Pipeli
 }
 
 func (c *communityDatabase) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	return c.CountDocumentsIncludingPending(ctx, excludePending(filter), opts...)
+}
+
+func (c *communityDatabase) CountDocumentsIncludingPending(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
 	return c.db.Collection(collectionName).CountDocuments(ctx, filter, opts...)
 }

--- a/databases/community.go
+++ b/databases/community.go
@@ -27,11 +27,12 @@ func excludePending(filter interface{}) interface{} {
 
 // CommunityDatabase contains the methods to use with the community database.
 //
-// FindOne / Find / CountDocuments transparently exclude communities marked
-// pending deletion (community.pendingDeletionAt set). Use the *IncludingPending
-// variants from contexts that explicitly need to see pending-deletion
-// communities — the admin console, the scheduler hard-delete sweep, and the
-// detail endpoint that returns 410 for a direct link to a pending community.
+// FindOne / Find / CountDocuments / Aggregate transparently exclude communities
+// marked pending deletion (community.pendingDeletionAt set). Use the
+// *IncludingPending variants from contexts that explicitly need to see
+// pending-deletion communities — the admin console, the scheduler hard-delete
+// sweep, and the detail endpoint that returns 410 for a direct link to a
+// pending community.
 type CommunityDatabase interface {
 	FindOne(ctx context.Context, filter interface{}) (*models.Community, error)
 	FindOneIncludingPending(ctx context.Context, filter interface{}) (*models.Community, error)
@@ -41,6 +42,7 @@ type CommunityDatabase interface {
 	UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error
 	DeleteOne(ctx context.Context, filter interface{}, opts ...*options.DeleteOptions) error
 	Aggregate(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*MongoCursor, error)
+	AggregateIncludingPending(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*MongoCursor, error)
 	CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
 	CountDocumentsIncludingPending(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
 }
@@ -96,7 +98,22 @@ func (c *communityDatabase) DeleteOne(ctx context.Context, filter interface{}, o
 
 }
 
+// Aggregate prepends a $match stage that excludes pending-deletion communities,
+// so customer-facing aggregations (discover, leaderboard, prioritized, tag
+// browse, elite, random) automatically hide them. The pipeline stage is cheap
+// — MongoDB collapses consecutive $match stages during optimization, and the
+// communities collection has indexes on the fields these pipelines start with.
+//
+// If the caller passes a pipeline that must run first (e.g. $geoNear, $search),
+// use AggregateIncludingPending and inject the filter into the pipeline by hand.
 func (c *communityDatabase) Aggregate(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*MongoCursor, error) {
+	prefixed := make(mongo.Pipeline, 0, len(pipeline)+1)
+	prefixed = append(prefixed, bson.D{{Key: "$match", Value: bson.M{"community.pendingDeletionAt": nil}}})
+	prefixed = append(prefixed, pipeline...)
+	return c.AggregateIncludingPending(ctx, prefixed, opts...)
+}
+
+func (c *communityDatabase) AggregateIncludingPending(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*MongoCursor, error) {
 	return c.db.Collection(collectionName).Aggregate(ctx, pipeline, opts...)
 }
 

--- a/databases/mocks/CommunityDatabase.go
+++ b/databases/mocks/CommunityDatabase.go
@@ -182,6 +182,106 @@ func (_m *CommunityDatabase) FindOne(ctx context.Context, filter interface{}) (*
 	return r0, r1
 }
 
+// FindOneIncludingPending provides a mock function with given fields: ctx, filter
+func (_m *CommunityDatabase) FindOneIncludingPending(ctx context.Context, filter interface{}) (*models.Community, error) {
+	ret := _m.Called(ctx, filter)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindOneIncludingPending")
+	}
+
+	var r0 *models.Community
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) (*models.Community, error)); ok {
+		return rf(ctx, filter)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}) *models.Community); ok {
+		r0 = rf(ctx, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.Community)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}) error); ok {
+		r1 = rf(ctx, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// FindIncludingPending provides a mock function with given fields: ctx, filter, opts
+func (_m *CommunityDatabase) FindIncludingPending(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (databases.MongoCursor, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, filter)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindIncludingPending")
+	}
+
+	var r0 databases.MongoCursor
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, ...*options.FindOptions) (databases.MongoCursor, error)); ok {
+		return rf(ctx, filter, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, ...*options.FindOptions) databases.MongoCursor); ok {
+		r0 = rf(ctx, filter, opts...)
+	} else {
+		r0 = ret.Get(0).(databases.MongoCursor)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}, ...*options.FindOptions) error); ok {
+		r1 = rf(ctx, filter, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CountDocumentsIncludingPending provides a mock function with given fields: ctx, filter, opts
+func (_m *CommunityDatabase) CountDocumentsIncludingPending(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, filter)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountDocumentsIncludingPending")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, ...*options.CountOptions) (int64, error)); ok {
+		return rf(ctx, filter, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, ...*options.CountOptions) int64); ok {
+		r0 = rf(ctx, filter, opts...)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, interface{}, ...*options.CountOptions) error); ok {
+		r1 = rf(ctx, filter, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // InsertOne provides a mock function with given fields: ctx, community, opts
 func (_m *CommunityDatabase) InsertOne(ctx context.Context, community models.Community, opts ...*options.InsertOneOptions) (databases.InsertOneResultHelper, error) {
 	_va := make([]interface{}, len(opts))

--- a/databases/mocks/CommunityDatabase.go
+++ b/databases/mocks/CommunityDatabase.go
@@ -57,6 +57,43 @@ func (_m *CommunityDatabase) Aggregate(ctx context.Context, pipeline mongo.Pipel
 	return r0, r1
 }
 
+// AggregateIncludingPending provides a mock function with given fields: ctx, pipeline, opts
+func (_m *CommunityDatabase) AggregateIncludingPending(ctx context.Context, pipeline mongo.Pipeline, opts ...*options.AggregateOptions) (*databases.MongoCursor, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, pipeline)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AggregateIncludingPending")
+	}
+
+	var r0 *databases.MongoCursor
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, mongo.Pipeline, ...*options.AggregateOptions) (*databases.MongoCursor, error)); ok {
+		return rf(ctx, pipeline, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, mongo.Pipeline, ...*options.AggregateOptions) *databases.MongoCursor); ok {
+		r0 = rf(ctx, pipeline, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*databases.MongoCursor)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, mongo.Pipeline, ...*options.AggregateOptions) error); ok {
+		r1 = rf(ctx, pipeline, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountDocuments provides a mock function with given fields: ctx, filter, opts
 func (_m *CommunityDatabase) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
 	_va := make([]interface{}, len(opts))

--- a/models/admin.go
+++ b/models/admin.go
@@ -280,14 +280,16 @@ type AdminUserResult struct {
 }
 
 type AdminCommunityResult struct {
-	ID              string      `json:"id"`
-	Name            string      `json:"name"`
-	Visibility      string      `json:"visibility"`  // "public" or "private"
-	CreatedAt       interface{} `json:"createdAt"`
-	Owner           *OwnerInfo  `json:"owner,omitempty"`
-	MemberCount     int         `json:"memberCount"`
-	DepartmentCount int         `json:"departmentCount"`
-	RolesCount      int         `json:"rolesCount"`
+	ID                  string      `json:"id"`
+	Name                string      `json:"name"`
+	Visibility          string      `json:"visibility"` // "public" or "private"
+	CreatedAt           interface{} `json:"createdAt"`
+	Owner               *OwnerInfo  `json:"owner,omitempty"`
+	MemberCount         int         `json:"memberCount"`
+	DepartmentCount     int         `json:"departmentCount"`
+	RolesCount          int         `json:"rolesCount"`
+	PendingDeletionAt   interface{} `json:"pendingDeletionAt,omitempty"`
+	ScheduledDeletionAt interface{} `json:"scheduledDeletionAt,omitempty"`
 }
 
 type OwnerInfo struct {
@@ -352,16 +354,18 @@ type AdminRoleMember struct {
 }
 
 type AdminCommunityDetails struct {
-	ID              string                 `json:"id"`
-	Name            string                 `json:"name"`
-	Visibility      string                 `json:"visibility"`  // "public" or "private"
-	CreatedAt       interface{}            `json:"createdAt"`
-	Owner           *OwnerInfo             `json:"owner,omitempty"`
-	MemberCount     int                    `json:"memberCount"`
-	Departments     []CommunityDept        `json:"departments,omitempty"`
-	DepartmentCount int                    `json:"departmentCount"`
-	RolesCount      int                    `json:"rolesCount"`
-	Subscription    *CommunitySubscription `json:"subscription,omitempty"`
+	ID                  string                 `json:"id"`
+	Name                string                 `json:"name"`
+	Visibility          string                 `json:"visibility"` // "public" or "private"
+	CreatedAt           interface{}            `json:"createdAt"`
+	Owner               *OwnerInfo             `json:"owner,omitempty"`
+	MemberCount         int                    `json:"memberCount"`
+	Departments         []CommunityDept        `json:"departments,omitempty"`
+	DepartmentCount     int                    `json:"departmentCount"`
+	RolesCount          int                    `json:"rolesCount"`
+	Subscription        *CommunitySubscription `json:"subscription,omitempty"`
+	PendingDeletionAt   interface{}            `json:"pendingDeletionAt,omitempty"`
+	ScheduledDeletionAt interface{}            `json:"scheduledDeletionAt,omitempty"`
 }
 
 type CommunityDept struct {

--- a/models/admin.go
+++ b/models/admin.go
@@ -366,6 +366,26 @@ type AdminCommunityDetails struct {
 	Subscription        *CommunitySubscription `json:"subscription,omitempty"`
 	PendingDeletionAt   interface{}            `json:"pendingDeletionAt,omitempty"`
 	ScheduledDeletionAt interface{}            `json:"scheduledDeletionAt,omitempty"`
+
+	// Owner tier context — populated when the community is pending deletion
+	// so the admin console can flag whether a restore would put the owner
+	// over their cap. The "other" list excludes this community itself and
+	// any other pending-deletion entries (so it's a true picture of what
+	// the owner already has live).
+	OwnerPlan             string                       `json:"ownerPlan,omitempty"`
+	OwnerCommunityCap     int                          `json:"ownerCommunityCap,omitempty"`
+	OwnerActiveCount      int                          `json:"ownerActiveCount,omitempty"`
+	OwnerOtherCommunities []AdminOwnerOtherCommunity   `json:"ownerOtherCommunities,omitempty"`
+}
+
+// AdminOwnerOtherCommunity is a thin row used by the admin community detail
+// panel to list the other communities an owner has live, so staff can see
+// whether a restore would put them over their plan cap.
+type AdminOwnerOtherCommunity struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Plan         string `json:"plan,omitempty"`
+	MembersCount int    `json:"membersCount"`
 }
 
 type CommunityDept struct {

--- a/models/community.go
+++ b/models/community.go
@@ -69,6 +69,14 @@ type CommunityDetails struct {
 	MostWantedVisibleFields []string               `json:"mostWantedVisibleFields" bson:"mostWantedVisibleFields"`
 	MostWantedCustomFields  []MostWantedCustomField `json:"mostWantedCustomFields" bson:"mostWantedCustomFields"`
 	Economy                EconomySettings         `json:"economy" bson:"economy"`
+	// Soft-delete fields. When PendingDeletionAt is set, the community is hidden
+	// from all customer-facing surfaces and the scheduler hard-deletes it once
+	// ScheduledDeletionAt elapses. The community owner cannot self-restore;
+	// staff handle restores through the admin console.
+	PendingDeletionAt         *primitive.DateTime `json:"pendingDeletionAt,omitempty" bson:"pendingDeletionAt,omitempty"`
+	ScheduledDeletionAt       *primitive.DateTime `json:"scheduledDeletionAt,omitempty" bson:"scheduledDeletionAt,omitempty"`
+	PendingDeletionNotifiedAt *primitive.DateTime `json:"pendingDeletionNotifiedAt,omitempty" bson:"pendingDeletionNotifiedAt,omitempty"`
+	DeletionRequestedBy       string              `json:"deletionRequestedBy,omitempty" bson:"deletionRequestedBy,omitempty"`
 	CreatedAt              primitive.DateTime      `json:"createdAt" bson:"createdAt"`
 	UpdatedAt              primitive.DateTime      `json:"updatedAt" bson:"updatedAt"`
 }

--- a/models/tiers.go
+++ b/models/tiers.go
@@ -1,0 +1,58 @@
+package models
+
+import "strings"
+
+// Tier identifiers. The canonical wire/db values are lowercase; helpers below
+// normalize incoming strings so historical mixed-case values still resolve.
+const (
+	TierFree        = "free"
+	TierBase        = "base"
+	TierPremium     = "premium"
+	TierPremiumPlus = "premium_plus"
+)
+
+// CommunityCapUnlimited is returned from CommunityCap for tiers with no cap.
+// Use it as a sentinel — callers should compare with `< CommunityCapUnlimited`
+// rather than checking specific large numbers.
+const CommunityCapUnlimited = 1 << 30
+
+// communityCaps is the canonical owned-community cap per plan. Mobile and web
+// surfaces historically hardcoded these in their own copies; the API is now
+// the source of truth, and both clients should read the effective cap from
+// the admin/user endpoints rather than redefining it.
+//
+// Pending-deletion communities do not count against this cap — they're hidden
+// from the owner and from any count returned by CommunityDatabase.Find/Count.
+// If a staff member restores a pending community that would put the owner
+// over their cap, the admin console surfaces the warning so they can resolve
+// (transfer ownership, force-delete, etc.) before clicking restore.
+var communityCaps = map[string]int{
+	TierFree:        1,
+	TierBase:        5,
+	TierPremium:     10,
+	TierPremiumPlus: CommunityCapUnlimited,
+}
+
+// PlanFromUser returns the user's effective community-creation tier. An
+// inactive subscription falls back to free so a lapsed paid user can't keep
+// creating communities at their old cap.
+func PlanFromUser(u *User) string {
+	if u == nil {
+		return TierFree
+	}
+	plan := strings.ToLower(strings.TrimSpace(u.Details.Subscription.Plan))
+	if plan == "" || !u.Details.Subscription.Active {
+		return TierFree
+	}
+	return plan
+}
+
+// CommunityCap returns the owned-community cap for a given plan. Unknown
+// plans fall back to the free cap — fail closed so a typo in a webhook
+// payload can't accidentally grant unlimited communities.
+func CommunityCap(plan string) int {
+	if cap, ok := communityCaps[strings.ToLower(strings.TrimSpace(plan))]; ok {
+		return cap
+	}
+	return communityCaps[TierFree]
+}

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -819,5 +819,18 @@ createIndexSafe(
   }
 );
 
+// Community soft-delete sweep: the daily cron filters by
+// community.scheduledDeletionAt. Sparse so the vast majority of communities
+// (which are not pending deletion) carry no index entry.
+createIndexSafe(
+  db.communities,
+  { "community.scheduledDeletionAt": 1 },
+  {
+    name: "communities_scheduled_deletion_idx",
+    background: true,
+    sparse: true
+  }
+);
+
 print("\n=== All indexes (including Performance Advisor recommendations) processed ===");
 

--- a/templates/html/communityPendingDeletion.go
+++ b/templates/html/communityPendingDeletion.go
@@ -1,0 +1,61 @@
+package templates
+
+import (
+	"fmt"
+	"time"
+)
+
+// RenderCommunityPendingDeletionReminderEmail builds the HTML for the
+// 24-hour-before-hard-delete reminder. Owner cannot self-restore; the email
+// directs them to contact support if they need the community back.
+func RenderCommunityPendingDeletionReminderEmail(displayName, communityName string, scheduledDeletionAt time.Time) string {
+	if displayName == "" {
+		displayName = "there"
+	}
+	scheduled := "shortly"
+	if !scheduledDeletionAt.IsZero() {
+		scheduled = scheduledDeletionAt.Format("Mon, Jan 2 2006 15:04 UTC")
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+  <title>Community Deletion Reminder - Lines Police CAD</title>
+  <style type="text/css">
+    body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; padding: 0; background-color: #0a0a0f; }
+    .container { max-width: 600px; margin: 0 auto; background-color: #12121f; }
+    .header { background: linear-gradient(135deg, #ef4444 0%%, #b91c1c 100%%); padding: 40px 30px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 22px; font-weight: 700; }
+    .content { padding: 40px 30px; color: #e5e7eb; }
+    .content h2 { color: #fff; margin-top: 0; }
+    .highlight-box { background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 12px; padding: 20px; margin: 20px 0; }
+    .highlight-box strong { color: #fca5a5; }
+    .footer { padding: 30px; text-align: center; color: #6b7280; font-size: 12px; border-top: 1px solid rgba(255,255,255,0.1); }
+    .footer a { color: #38bdf8; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Last chance: %s deletes in 24 hours</h1>
+    </div>
+    <div class="content">
+      <h2>Hi %s,</h2>
+      <p>This is a heads-up that your community <strong>%s</strong> is scheduled for permanent deletion on <strong>%s</strong>.</p>
+
+      <div class="highlight-box">
+        <p style="margin: 0;">Once deleted, all civilians, departments, vehicles, calls, court cases, BOLOs, and other community data will be <strong>permanently removed</strong>. This cannot be undone after the deadline.</p>
+      </div>
+
+      <p>If you scheduled this deletion intentionally, no action is needed.</p>
+      <p>If this was a mistake or you've changed your mind, please reply to this email or contact support before the deadline so we can restore the community.</p>
+    </div>
+    <div class="footer">
+      <p>Lines Police CAD &middot; <a href="https://linespolice-cad.com">linespolice-cad.com</a></p>
+    </div>
+  </div>
+</body>
+</html>`, communityName, displayName, communityName, scheduled)
+}


### PR DESCRIPTION
## Summary

- `DELETE /community/:id` now flags the community as pending deletion (`pendingDeletionAt`, `scheduledDeletionAt = now + 30d`) instead of hard-deleting. The community vanishes from every customer-facing surface immediately; the existing 18-collection cascade is run by a new scheduler job once the 30 days elapse.
- Owners cannot self-restore. A new `POST /admin/communities/:id/restore-pending-deletion` lets staff `$unset` the soft-delete fields. Surfaced in the admin console (separate PR on `police-cad`).
- Detail endpoint returns `410 Gone` with `{ error: "pending_deletion", scheduledDeletionAt, communityName }` so the frontend can render a clear "contact support" page instead of a 404.

## How it's hidden everywhere

`CommunityDatabase.{Find,FindOne,CountDocuments}` now wrap the caller's filter with `community.pendingDeletionAt: nil`. Callers that need to see pending-deletion docs (the cron, admin search, the detail endpoint that returns 410) opt in via new `*IncludingPending` variants. This avoided touching ~50 read callsites individually.

## Other gotchas handled

- Invite-code joins pre-check pending state so a stale invite link doesn't burn a use before failing at lookup (`JoinCommunityHandler`).
- Admin community search now searches by community name OR owner email/username, with a `pendingDeletionOnly` toggle. Results carry `pendingDeletionAt` / `scheduledDeletionAt`.
- Daily `0 3 * * *` job (uses existing `LockDB`): sends a 24h reminder email (gated by `pendingDeletionNotifiedAt`) then hard-deletes elapsed pending communities. CAS-style guard prevents a race where an admin restores in the same tick.
- New sparse index `communities_scheduled_deletion_idx` on `community.scheduledDeletionAt` (appended to `scripts/create_indexes.js`).

## Test plan

- [x] Unit tests: `TestDeleteCommunity_SoftDeletesAndDoesNotCascade`, `TestDeleteCommunity_RejectsDoubleDelete`, `TestRestoreCommunity_RequiresAdminRole`, `TestRestoreCommunity_AdminClearsFields`, `TestRestoreCommunity_RejectsNonPending`, `TestCommunityHandler_Returns410ForPendingDeletion`, `TestCommunityHandler_Returns404ForMissing` — all passing.
- [ ] Deploy to `police-cad-dev`, soft-delete a test community, verify:
  - [ ] `GET /community/:id` returns 410 with the payload
  - [ ] Community no longer appears in user community lists
  - [ ] Invite code into the community returns 410
  - [ ] Admin search with `pendingDeletionOnly: true` finds it
  - [ ] Admin restore endpoint clears the fields and the community reappears
- [ ] Manually trigger the scheduler (or short-circuit the date) on dev to confirm the cascade still wipes all 18 collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)