### PR TITLE
fix(communities): self-heal stored membersCount drift in list endpoints

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -490,30 +490,54 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 	isEmailQuery := strings.Contains(query, "@") // Detect if query looks like an email
 	var filter bson.M
 	var findOpts *options.FindOptions
+	var countOpts *options.CountOptions
 
 	// Use request context with timeout
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
+
 	var err error
 
+	// Projection: only pull fields needed for AdminUserResult. Some user docs
+	// are very large (huge communities/notifications arrays); without this the
+	// driver decodes the whole document just to extract ~8 fields, which can
+	// blow past the query timeout for affected accounts.
+	resultProjection := bson.M{
+		"_id":                       1,
+		"user.email":                1,
+		"user.username":             1,
+		"user.profilePicture":       1,
+		"user.isDeactivated":        1,
+		"user.createdAt":            1,
+		"user.deactivatedAt":        1,
+		"user.deactivationReason":   1,
+		"user.deactivatedByAdminId": 1,
+	}
+
 	if isEmailQuery {
-		// For email queries, use direct lookup only (fastest - uses user_email_idx index)
-		filter = bson.M{"user.email": query} // Direct lookup uses user_email_idx (case-insensitive collation)
+		// For email queries, use direct lookup only (fastest - uses user_email_idx index).
+		// The index is defined with collation {locale:"en", strength:2}; the query
+		// must specify the same collation or Mongo will fall back to a COLLSCAN.
+		filter = bson.M{"user.email": query}
+		emailCollation := &options.Collation{Locale: "en", Strength: 2}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"user.email": 1},
+			Projection: resultProjection,
+			Collation:  emailCollation,
 		}
+		countOpts = options.Count().SetCollation(emailCollation)
 	} else if queryLen >= 3 {
 		// Use $text search for name/username queries
 		filter = bson.M{
 			"$text": bson.M{"$search": query}, // Uses user_search_text_idx for name/username
 		}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"score": bson.M{"$meta": "textScore"}, "user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"score": bson.M{"$meta": "textScore"}, "user.email": 1},
+			Projection: resultProjection,
 		}
 	} else {
 		// For very short queries, use regex but limit aggressively
@@ -525,16 +549,21 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"user.email": 1},
+			Projection: resultProjection,
 		}
 	}
-	
+
 	// Get total count for pagination metadata (skip for very short queries to avoid slow count)
 	var totalCount int64
 	if isEmailQuery || queryLen >= 3 {
-		totalCount, err = h.UDB.CountDocuments(ctx, filter)
+		if countOpts != nil {
+			totalCount, err = h.UDB.CountDocuments(ctx, filter, countOpts)
+		} else {
+			totalCount, err = h.UDB.CountDocuments(ctx, filter)
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "search count failed"})
@@ -544,7 +573,7 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 		// For short queries, estimate count based on results (faster)
 		totalCount = 0 // Will be estimated from results
 	}
-	
+
 	// Use existing user database to search with pagination
 	cursor, err := h.UDB.Find(ctx, filter, findOpts)
 	if err != nil {
@@ -560,9 +589,10 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 				},
 			}
 			findOpts = &options.FindOptions{
-				Skip:  &skip,
-				Limit: &limit64,
-				Sort:  bson.M{"user.email": 1},
+				Skip:       &skip,
+				Limit:      &limit64,
+				Sort:       bson.M{"user.email": 1},
+				Projection: resultProjection,
 			}
 			// Retry count with new filter
 			totalCount, err = h.UDB.CountDocuments(ctx, filter)

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -993,6 +993,23 @@ func (c Community) UpdateCommunityFieldHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
+	// Same hardening as UpdateDepartmentDetailsHandler: when the payload
+	// includes an `economy` sub-object, validate it strictly so a malformed
+	// numeric (e.g. afkPromptIntervalSeconds=3e22-style overflow on the
+	// community-level fields) can never land on the document and break every
+	// subsequent BSON decode of that community. Other top-level community
+	// fields still flow through the existing pass-through code — this endpoint
+	// is a catch-all used by many surfaces and we don't want to lock those
+	// down piecemeal here.
+	if econRaw, exists := req["economy"]; exists {
+		cleaned, vErr := validateCommunityEconomyPatch(econRaw)
+		if vErr != nil {
+			config.ErrorStatus(vErr.Error(), http.StatusBadRequest, w, nil)
+			return
+		}
+		req["economy"] = cleaned
+	}
+
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -3295,6 +3312,62 @@ func coerceJSONInt(raw interface{}, lo, hi int64) (int64, error) {
 		return 0, fmt.Errorf("value %v out of range [%d, %d]", f, lo, hi)
 	}
 	return int64(f), nil
+}
+
+// communityEconomyPatchBounds matches the EconomySettings model fields. Same
+// rationale as departmentPatchBounds: prevent any client (mobile, web, or
+// otherwise) from persisting a non-int / out-of-range value that the Go BSON
+// decoder cannot read back. Caps are intentionally generous; they only reject
+// values that are obviously wrong.
+var communityEconomyPatchBounds = map[string]struct {
+	min int64
+	max int64
+}{
+	"defaultStartingBalance": {0, 1_000_000_000_000}, // cents ($10B cap)
+	"defaultDueDays":         {0, 3650},              // up to 10 years
+	"contestExtensionDays":   {0, 3650},
+}
+
+// validateCommunityEconomyPatch takes the raw `economy` sub-object from a
+// community PATCH body, validates every field with a strict allowlist (same
+// approach as UpdateDepartmentDetailsHandler), and returns a clean bson.M
+// safe to write under `community.economy`. Unknown fields are rejected so
+// arbitrary keys cannot be smuggled onto community.economy.
+func validateCommunityEconomyPatch(raw interface{}) (bson.M, error) {
+	if raw == nil {
+		return bson.M{}, nil
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid economy: expected object")
+	}
+	clean := bson.M{}
+	for key, value := range m {
+		switch key {
+		case "enabled", "allowNegativeBalance":
+			b, ok := value.(bool)
+			if !ok {
+				return nil, fmt.Errorf("invalid economy.%s: expected boolean", key)
+			}
+			clean[key] = b
+		case "fineMode":
+			s, ok := value.(string)
+			if !ok || (s != "inbox" && s != "auto_debit") {
+				return nil, fmt.Errorf("invalid economy.fineMode: expected \"inbox\" or \"auto_debit\"")
+			}
+			clean[key] = s
+		case "defaultStartingBalance", "defaultDueDays", "contestExtensionDays":
+			bounds := communityEconomyPatchBounds[key]
+			n, ierr := coerceJSONInt(value, bounds.min, bounds.max)
+			if ierr != nil {
+				return nil, fmt.Errorf("invalid economy.%s: %s", key, ierr.Error())
+			}
+			clean[key] = n
+		default:
+			return nil, fmt.Errorf("field economy.%q is not updatable via this endpoint", key)
+		}
+	}
+	return clean, nil
 }
 
 // UpdateDepartmentDetailsHandler updates the details of a department.

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -7403,67 +7403,123 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 			}
 		}
 
-		// Build aggregation to fetch top communities by membersCount
-		match := bson.M{
-			"community.visibility":   "public",
-			"community.membersCount": bson.M{"$gte": 1},
-		}
-
-		// Use aggregation for sorting and paging by indexed field
+		// Rank by LIVE approved-member count from the users collection rather
+		// than the denormalized community.membersCount. Stored counts drift
+		// (sometimes severely — observed gaps in the thousands), so sorting on
+		// them buries actually-large communities under ghost rankings. The
+		// users collection is the source of truth.
+		//
+		// Pipeline: pre-filter users with at least one approved community,
+		// unwind, group by communityId with $sum=1, lookup community metadata
+		// scoped to public+non-pending, sort by live count, then $facet for
+		// {rows, total} in one round trip. Cached top-10 for 24h hides the
+		// cost; cache resets on process restart (deploy).
+		approvedMatch := bson.M{"user.communities": bson.M{"$elemMatch": bson.M{"status": "approved"}}}
 		pipeline := mongo.Pipeline{
-			bson.D{{Key: "$match", Value: match}},
-			bson.D{{Key: "$project", Value: bson.M{
-				"_id":          1,
-				"name":         "$community.name",
-				"imageLink":    "$community.imageLink",
-				"membersCount": "$community.membersCount",
-				"plan":         "$community.subscription.plan",
+			{{Key: "$match", Value: approvedMatch}},
+			{{Key: "$unwind", Value: "$user.communities"}},
+			{{Key: "$match", Value: bson.M{"user.communities.status": "approved"}}},
+			{{Key: "$group", Value: bson.M{
+				"_id":   "$user.communities.communityId",
+				"count": bson.M{"$sum": 1},
 			}}},
-			bson.D{{Key: "$sort", Value: bson.M{"membersCount": -1}}},
-			bson.D{{Key: "$skip", Value: int64(page * limit)}},
-			bson.D{{Key: "$limit", Value: int64(limit)}},
+			{{Key: "$lookup", Value: bson.M{
+				"from": "communities",
+				"let":  bson.M{"cidStr": "$_id"},
+				"pipeline": bson.A{
+					bson.M{"$match": bson.M{"$expr": bson.M{"$eq": bson.A{
+						"$_id",
+						bson.M{"$convert": bson.M{
+							"input":   "$$cidStr",
+							"to":      "objectId",
+							"onError": nil,
+						}},
+					}}}},
+					bson.M{"$match": bson.M{
+						"community.visibility":       "public",
+						"community.pendingDeletionAt": nil,
+					}},
+					bson.M{"$project": bson.M{
+						"name":      "$community.name",
+						"imageLink": "$community.imageLink",
+						"plan":      "$community.subscription.plan",
+					}},
+				},
+				"as": "community",
+			}}},
+			{{Key: "$match", Value: bson.M{"community.0": bson.M{"$exists": true}}}},
+			{{Key: "$unwind", Value: "$community"}},
+			{{Key: "$sort", Value: bson.D{{Key: "count", Value: -1}, {Key: "_id", Value: 1}}}},
+			{{Key: "$facet", Value: bson.M{
+				"rows": bson.A{
+					bson.M{"$skip": int64(page * limit)},
+					bson.M{"$limit": int64(limit)},
+				},
+				"total": bson.A{
+					bson.M{"$count": "total"},
+				},
+			}}},
 		}
 
-		cur, err := c.DB.Aggregate(ctx, pipeline)
+		cur, err := c.UDB.Aggregate(ctx, pipeline)
 		if err != nil {
 			config.ErrorStatus("failed to fetch leaderboard", http.StatusInternalServerError, w, err)
 			return
 		}
 		defer cur.Close(ctx)
 
-		var docs []struct {
-			ID           primitive.ObjectID `bson:"_id"`
-			Name         string             `bson:"name"`
-			ImageLink    string             `bson:"imageLink"`
-			MembersCount int                `bson:"membersCount"`
-			Plan         string             `bson:"plan"`
+		var facetResults []struct {
+			Rows []struct {
+				ID        string `bson:"_id"`
+				Count     int    `bson:"count"`
+				Community struct {
+					ID        primitive.ObjectID `bson:"_id"`
+					Name      string             `bson:"name"`
+					ImageLink string             `bson:"imageLink"`
+					Plan      string             `bson:"plan"`
+				} `bson:"community"`
+			} `bson:"rows"`
+			Total []struct {
+				Total int64 `bson:"total"`
+			} `bson:"total"`
 		}
-		if err := cur.All(ctx, &docs); err != nil {
+		if err := cur.All(ctx, &facetResults); err != nil {
 			config.ErrorStatus("failed to decode leaderboard", http.StatusInternalServerError, w, err)
 			return
 		}
 
-		// Count total for pagination
-		totalCount, _ := c.DB.CountDocuments(ctx, match)
-
-		// Self-heal displayed membersCount with a live count. Sorting still uses
-		// the stored field (sorting on a live computed value would require
-		// pulling all communities into memory), so rankings can be slightly off
-		// from the displayed numbers until stored values are backfilled. The
-		// numbers shown are correct.
-		leaderboardIDs := make([]string, 0, len(docs))
-		for _, d := range docs {
-			leaderboardIDs = append(leaderboardIDs, d.ID.Hex())
+		var docs []struct {
+			ID           primitive.ObjectID
+			Name         string
+			ImageLink    string
+			MembersCount int
+			Plan         string
 		}
-		liveCounts := liveMemberCounts(ctx, c.UDB, leaderboardIDs)
+		var totalCount int64
+		if len(facetResults) > 0 {
+			for _, r := range facetResults[0].Rows {
+				docs = append(docs, struct {
+					ID           primitive.ObjectID
+					Name         string
+					ImageLink    string
+					MembersCount int
+					Plan         string
+				}{
+					ID:           r.Community.ID,
+					Name:         r.Community.Name,
+					ImageLink:    r.Community.ImageLink,
+					MembersCount: r.Count,
+					Plan:         r.Community.Plan,
+				})
+			}
+			if len(facetResults[0].Total) > 0 {
+				totalCount = facetResults[0].Total[0].Total
+			}
+		}
 
 		// Build response data with placeholders for non-members stats to avoid heavy computation
 		responseData := make([]map[string]interface{}, 0, len(docs))
 		for _, d := range docs {
-			membersCount := d.MembersCount
-			if live, ok := liveCounts[d.ID.Hex()]; ok {
-				membersCount = live
-			}
 			item := map[string]interface{}{
 				"_id":  d.ID.Hex(),
 				"name": d.Name,
@@ -7473,7 +7529,7 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 					}
 					return d.ImageLink
 				}(),
-				"membersCount":     membersCount,
+				"membersCount":     d.MembersCount,
 				"onlineCount":      0,
 				"activityScore":    0,
 				"growthPercentage": 0.0,
@@ -7561,6 +7617,16 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 	callsCollection := c.DBHelper.Collection("calls")
 	reportsCollection := c.DBHelper.Collection("reports")
 
+	// Self-heal displayed membersCount with live counts before computing
+	// stats. Sort key for activity/growth statTypes is unaffected (it's the
+	// activity/growth score, not member count) — this only ensures the number
+	// rendered in the response column reflects reality.
+	slowPathIDs := make([]string, 0, len(communities))
+	for _, comm := range communities {
+		slowPathIDs = append(slowPathIDs, comm.ID.Hex())
+	}
+	slowPathLiveCounts := liveMemberCounts(ctx, c.UDB, slowPathIDs)
+
 	// Calculate stats for each community
 	type CommunityStats struct {
 		Community     models.Community
@@ -7574,9 +7640,13 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 
 	for _, comm := range communities {
 		communityID := comm.ID.Hex()
+		membersCount := comm.Details.MembersCount
+		if live, ok := slowPathLiveCounts[communityID]; ok {
+			membersCount = live
+		}
 		stats := CommunityStats{
 			Community:    comm,
-			MembersCount: comm.Details.MembersCount,
+			MembersCount: membersCount,
 		}
 
 		// Calculate online count - users with this community who are online

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -3246,13 +3246,58 @@ func (c Community) UpdateDepartmentImageLinkHandler(w http.ResponseWriter, r *ht
 	w.Write([]byte(`{"message": "Department image link updated successfully"}`))
 }
 
-// UpdateDepartmentDetailsHandler updates the details of a department
+// departmentPatchBounds are the per-field sanity limits applied to numeric
+// economy fields when updating a department. They guard against junk values
+// (NaN, Infinity, scientific-notation doubles, negative numbers) ever landing
+// on the document — those used to permanently break community reads because
+// the Go BSON decoder would overflow trying to coerce a Double back into the
+// int-typed model field. Bounds are intentionally generous; they only reject
+// values that are obviously wrong.
+var departmentPatchBounds = map[string]struct {
+	min int64
+	max int64
+}{
+	"basePayPerHour":           {0, 1_000_000_000},     // cents/hr (cap = $10M/hr)
+	"maxSessionMinutes":        {1, 24 * 60 * 7},       // 1 min .. 1 week
+	"afkPromptIntervalSeconds": {30, 86400},            // 30s .. 1 day
+	"afkGraceSeconds":          {10, 86400},            // 10s .. 1 day
+}
+
+// coerceJSONInt accepts any JSON number (decoded as float64 by encoding/json),
+// rejects NaN/Infinity/non-integer/out-of-range values, and returns the int64.
+// JSON booleans, strings, and other types are rejected — clients must send a
+// real number for numeric fields.
+func coerceJSONInt(raw interface{}, lo, hi int64) (int64, error) {
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, fmt.Errorf("expected number, got %T", raw)
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("value is not finite")
+	}
+	if f != math.Trunc(f) {
+		return 0, fmt.Errorf("value must be an integer")
+	}
+	if f < float64(lo) || f > float64(hi) {
+		return 0, fmt.Errorf("value %v out of range [%d, %d]", f, lo, hi)
+	}
+	return int64(f), nil
+}
+
+// UpdateDepartmentDetailsHandler updates the details of a department.
+//
+// The body is a partial document — every field is optional. We allowlist the
+// fields that legitimate clients (web + mobile) actually send, validate types
+// and (for numeric fields) ranges, and write only those fields. Anything else
+// is rejected with 400 to keep the document well-formed and to close a
+// mass-assignment vector (callers could previously set _id, members, ranks,
+// etc. by simply naming the field in the JSON body).
 func (c Community) UpdateDepartmentDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	communityID := mux.Vars(r)["communityId"]
 	departmentID := mux.Vars(r)["departmentId"]
 
-	var updatedDetails map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&updatedDetails); err != nil {
+	var raw map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
 		return
 	}
@@ -3268,14 +3313,71 @@ func (c Community) UpdateDepartmentDetailsHandler(w http.ResponseWriter, r *http
 		return
 	}
 
+	update := bson.M{}
+	for key, value := range raw {
+		switch key {
+		// String fields
+		case "name", "description", "image", "toneSound":
+			s, ok := value.(string)
+			if !ok {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected string", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = s
+
+		// Constrained string enums
+		case "payoutMode":
+			s, ok := value.(string)
+			if !ok || (s != "on_heartbeat" && s != "on_clockout") {
+				config.ErrorStatus("invalid payoutMode: expected \"on_heartbeat\" or \"on_clockout\"", http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = s
+
+		// Bool fields
+		case "approvalRequired", "restrictCivilianRecordDeletion", "economyEnabled":
+			b, ok := value.(bool)
+			if !ok {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected boolean", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = b
+
+		// Range-checked numeric fields
+		case "basePayPerHour", "maxSessionMinutes", "afkPromptIntervalSeconds", "afkGraceSeconds":
+			bounds := departmentPatchBounds[key]
+			n, ierr := coerceJSONInt(value, bounds.min, bounds.max)
+			if ierr != nil {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: %s", key, ierr.Error()), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = n
+
+		// Opaque object fields — passed through as-is. These are too deeply
+		// structured to validate inline here; the model decoder will reject
+		// truly malformed shapes on the next read.
+		case "template", "templateRef":
+			if _, ok := value.(map[string]interface{}); !ok && value != nil {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected object", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = value
+
+		default:
+			config.ErrorStatus(fmt.Sprintf("field %q is not updatable via this endpoint", key), http.StatusBadRequest, w, nil)
+			return
+		}
+	}
+
+	if len(update) == 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "no fields to update"}`))
+		return
+	}
+
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-
-	update := bson.M{}
-	for key, value := range updatedDetails {
-		update["community.departments.$."+key] = value
-	}
 
 	filter := bson.M{"_id": cID, "community.departments._id": dID}
 	err = c.DB.UpdateOne(ctx, filter, bson.M{"$set": update})

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -534,6 +534,19 @@ func (c Community) CommunitiesByOwnerIDHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(communities))
+	for _, comm := range communities {
+		ids = append(ids, comm.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, c.UDB, ids)
+	for i := range communities {
+		if live, ok := liveCounts[communities[i].ID.Hex()]; ok {
+			communities[i].Details.MembersCount = live
+		}
+	}
+
 	b, err := json.Marshal(communities)
 	if err != nil {
 		config.ErrorStatus("failed to marshal response", http.StatusInternalServerError, w, err)
@@ -3812,14 +3825,26 @@ func (c Community) FetchEliteCommunitiesHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(decodedCommunities))
+	for _, item := range decodedCommunities {
+		ids = append(ids, item.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, c.UDB, ids)
+
 	// Trimmed down result structure
 	var responseData []map[string]interface{}
 	for _, item := range decodedCommunities {
+		membersCount := item.Community.MembersCount
+		if live, ok := liveCounts[item.ID.Hex()]; ok {
+			membersCount = live
+		}
 		responseData = append(responseData, map[string]interface{}{
 			"_id":                    item.ID,
 			"name":                   item.Community.Name,
 			"imageLink":              item.Community.ImageLink,
-			"membersCount":           item.Community.MembersCount,
+			"membersCount":           membersCount,
 			"tags":                   item.Community.Tags,
 			"promotionalText":        item.Community.PromotionalText,
 			"promotionalDescription": item.Community.PromotionalDescription,
@@ -4459,14 +4484,26 @@ func (c Community) FetchCommunitiesByTagHandlerV2(w http.ResponseWriter, r *http
 
 	results := aggRes.results
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(results))
+	for _, item := range results {
+		ids = append(ids, item.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, c.UDB, ids)
+
 	// Format response
 	var data []map[string]interface{}
 	for _, item := range results {
+		membersCount := item.Community.MembersCount
+		if live, ok := liveCounts[item.ID.Hex()]; ok {
+			membersCount = live
+		}
 		data = append(data, map[string]interface{}{
 			"_id":                    item.ID,
 			"name":                   item.Community.Name,
 			"imageLink":              item.Community.ImageLink,
-			"membersCount":           item.Community.MembersCount,
+			"membersCount":           membersCount,
 			"tags":                   item.Community.Tags,
 			"promotionalText":        item.Community.PromotionalText,
 			"promotionalDescription": item.Community.PromotionalDescription,
@@ -7409,9 +7446,24 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 		// Count total for pagination
 		totalCount, _ := c.DB.CountDocuments(ctx, match)
 
+		// Self-heal displayed membersCount with a live count. Sorting still uses
+		// the stored field (sorting on a live computed value would require
+		// pulling all communities into memory), so rankings can be slightly off
+		// from the displayed numbers until stored values are backfilled. The
+		// numbers shown are correct.
+		leaderboardIDs := make([]string, 0, len(docs))
+		for _, d := range docs {
+			leaderboardIDs = append(leaderboardIDs, d.ID.Hex())
+		}
+		liveCounts := liveMemberCounts(ctx, c.UDB, leaderboardIDs)
+
 		// Build response data with placeholders for non-members stats to avoid heavy computation
 		responseData := make([]map[string]interface{}, 0, len(docs))
 		for _, d := range docs {
+			membersCount := d.MembersCount
+			if live, ok := liveCounts[d.ID.Hex()]; ok {
+				membersCount = live
+			}
 			item := map[string]interface{}{
 				"_id":  d.ID.Hex(),
 				"name": d.Name,
@@ -7421,7 +7473,7 @@ func (c Community) CommunityLeaderboardHandler(w http.ResponseWriter, r *http.Re
 					}
 					return d.ImageLink
 				}(),
-				"membersCount":     d.MembersCount,
+				"membersCount":     membersCount,
 				"onlineCount":      0,
 				"activityScore":    0,
 				"growthPercentage": 0.0,

--- a/api/handlers/community_member_counts.go
+++ b/api/handlers/community_member_counts.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
+
+	"github.com/linesmerrill/police-cad-api/databases"
+)
+
+// liveMemberCounts returns the live approved-member count per community ID,
+// computed from the users collection. The stored `community.membersCount` is
+// a denormalized counter and drifts over time (e.g. user account deletions,
+// historical ban paths that did not decrement). Mirrors the single-community
+// self-heal in CommunityHandler. Returns an empty map on aggregation error
+// so callers can fall back to whatever stored value they already have.
+//
+// Backed by the {user.communities.communityId, user.communities.status}
+// compound index (scripts/create_indexes.js).
+func liveMemberCounts(ctx context.Context, udb databases.UserDatabase, ids []string) map[string]int {
+	counts := make(map[string]int, len(ids))
+	if len(ids) == 0 {
+		return counts
+	}
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{
+			"user.communities": bson.M{"$elemMatch": bson.M{
+				"communityId": bson.M{"$in": ids},
+				"status":      "approved",
+			}},
+		}}},
+		{{Key: "$unwind", Value: "$user.communities"}},
+		{{Key: "$match", Value: bson.M{
+			"user.communities.communityId": bson.M{"$in": ids},
+			"user.communities.status":      "approved",
+		}}},
+		{{Key: "$group", Value: bson.M{
+			"_id":   "$user.communities.communityId",
+			"count": bson.M{"$sum": 1},
+		}}},
+	}
+
+	cursor, err := udb.Aggregate(ctx, pipeline)
+	if err != nil {
+		zap.S().Warnw("failed to compute live member counts; callers will fall back to stored values",
+			"community_count", len(ids), "error", err)
+		return counts
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		ID    string `bson:"_id"`
+		Count int    `bson:"count"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		zap.S().Warnw("failed to decode live member counts; callers will fall back to stored values",
+			"community_count", len(ids), "error", err)
+		return counts
+	}
+
+	for _, r := range results {
+		counts[r.ID] = r.Count
+	}
+	return counts
+}

--- a/api/handlers/community_member_counts_test.go
+++ b/api/handlers/community_member_counts_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/linesmerrill/police-cad-api/databases"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+)
+
+// liveMemberCounts is the batched analogue of CommunityHandler's per-community
+// self-heal. These tests pin its behaviour because the list handlers all rely
+// on it to correct drifted stored values.
+
+func TestLiveMemberCounts_ReturnsCountsKeyedByCommunityID(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+
+	aggResults := []interface{}{
+		bson.M{"_id": "community-a", "count": 62},
+		bson.M{"_id": "community-c", "count": 7},
+	}
+	cursor, err := databases.NewMongoCursorFromDocuments(aggResults)
+	assert.NoError(t, err)
+
+	mockUDB.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil)
+
+	got := liveMemberCounts(context.Background(), mockUDB, []string{"community-a", "community-b", "community-c"})
+
+	assert.Equal(t, 62, got["community-a"], "live count overwrites stored value")
+	assert.Equal(t, 7, got["community-c"])
+	_, hasB := got["community-b"]
+	assert.False(t, hasB,
+		"communities with zero approved members aren't in the aggregation result; "+
+			"caller must keep the stored value (often 0/1) when key is missing")
+}
+
+func TestLiveMemberCounts_AggregateError_ReturnsEmptyMap_NotError(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+	mockUDB.On("Aggregate", mock.Anything, mock.Anything).
+		Return(databases.MongoCursor{}, errors.New("transient mongo error"))
+
+	got := liveMemberCounts(context.Background(), mockUDB, []string{"community-a"})
+
+	assert.Empty(t, got,
+		"on aggregation failure the helper returns an empty map so callers "+
+			"fall back to the stored values they already have")
+}
+
+func TestLiveMemberCounts_EmptyIDs_NoQuery(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+	// No Aggregate expectation — empty ID list must short-circuit.
+
+	got := liveMemberCounts(context.Background(), mockUDB, nil)
+
+	assert.Empty(t, got)
+	mockUDB.AssertNotCalled(t, "Aggregate", mock.Anything, mock.Anything)
+}

--- a/api/handlers/search.go
+++ b/api/handlers/search.go
@@ -477,6 +477,19 @@ func (s Search) SearchCommunityHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(communities))
+	for _, comm := range communities {
+		ids = append(ids, comm.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, s.UserDB, ids)
+	for i := range communities {
+		if live, ok := liveCounts[communities[i].ID.Hex()]; ok {
+			communities[i].Details.MembersCount = live
+		}
+	}
+
 	// For very short queries (1-2 chars), skip expensive CountDocuments
 	// Return results with estimated count based on current page results
 	var totalCount int64

--- a/api/handlers/update_community_economy_test.go
+++ b/api/handlers/update_community_economy_test.go
@@ -1,0 +1,192 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+)
+
+const updateCommunityID = "507f1f77bcf86cd799439033"
+
+func newUpdateCommunityHandler(cdb *mocks.CommunityDatabase, aldb *mocks.AuditLogDatabase) handlers.Community {
+	return handlers.Community{
+		DB:   cdb,
+		ALDB: aldb,
+	}
+}
+
+func newUpdateCommunityRequest(t *testing.T, body interface{}) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"/api/v1/community/"+updateCommunityID,
+		bytes.NewReader(raw),
+	)
+	assert.NoError(t, err)
+	return mux.SetURLVars(req, map[string]string{"community_id": updateCommunityID})
+}
+
+// Regression: same class of bug as UpdateDepartmentDetailsHandler. A
+// community.economy field with a giant numeric like 3e22 used to land on the
+// document and break every subsequent BSON decode of the community.
+func TestUpdateCommunityField_RejectsOverflowingEconomyNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"defaultStartingBalance": 3e22},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsNonIntegerEconomyNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"defaultDueDays": 12.5},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsInvalidFineMode(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"fineMode": "yacht_seizure"},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsUnknownEconomyKey(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"superSecretBackdoor": true},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Happy path: a realistic mobile save (every economy field present). Each
+// numeric must persist as int64 — never float64 — so BSON cannot store a
+// Double that the Go decoder won't read back.
+func TestUpdateCommunityField_AcceptsValidEconomyPatch(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			if !ok {
+				return false
+			}
+			econ, ok := set["community.economy"].(bson.M)
+			if !ok {
+				return false
+			}
+			intChecks := map[string]int64{
+				"defaultStartingBalance": 50000,
+				"defaultDueDays":         14,
+				"contestExtensionDays":   30,
+			}
+			for k, want := range intChecks {
+				got, ok := econ[k].(int64)
+				if !ok || got != want {
+					return false
+				}
+			}
+			return econ["enabled"] == true &&
+				econ["allowNegativeBalance"] == false &&
+				econ["fineMode"] == "inbox"
+		}),
+	).Return(nil)
+
+	c := newUpdateCommunityHandler(cdb, aldb)
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{
+			"enabled":                true,
+			"defaultStartingBalance": 50000,
+			"fineMode":               "inbox",
+			"defaultDueDays":         14,
+			"contestExtensionDays":   30,
+			"allowNegativeBalance":   false,
+		},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}
+
+// Backwards-compatibility: a non-economy PATCH (the common case for this
+// catch-all endpoint) must still flow through unchanged. We don't want the
+// economy hardening to lock down the other 40+ fields this endpoint serves.
+func TestUpdateCommunityField_PassesThroughNonEconomyFields(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			return ok && set["community.name"] == "Renamed Town"
+		}),
+	).Return(nil)
+
+	c := newUpdateCommunityHandler(cdb, aldb)
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"name": "Renamed Town",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}

--- a/api/handlers/update_department_details_test.go
+++ b/api/handlers/update_department_details_test.go
@@ -1,0 +1,211 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+)
+
+// Shared IDs for these tests.
+const (
+	updateDeptCommunityID  = "507f1f77bcf86cd799439011"
+	updateDeptDepartmentID = "507f1f77bcf86cd799439022"
+)
+
+func newUpdateDeptHandler(cdb *mocks.CommunityDatabase, aldb *mocks.AuditLogDatabase) handlers.Community {
+	return handlers.Community{
+		DB:   cdb,
+		ALDB: aldb,
+	}
+}
+
+func newUpdateDeptRequest(t *testing.T, body interface{}) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"/api/v1/community/"+updateDeptCommunityID+"/departments/"+updateDeptDepartmentID,
+		bytes.NewReader(raw),
+	)
+	assert.NoError(t, err)
+	return mux.SetURLVars(req, map[string]string{
+		"communityId":  updateDeptCommunityID,
+		"departmentId": updateDeptDepartmentID,
+	})
+}
+
+// TestUpdateDepartmentDetails_RejectsOutOfRangeAfkPrompt is the regression
+// test for the original bug: a client sent afkPromptIntervalSeconds=3e22, the
+// handler accepted it blindly, MongoDB stored a BSON double, and every
+// community read afterwards 500'd with "overflows int64". The hardened
+// handler now refuses values outside the documented range.
+func TestUpdateDepartmentDetails_RejectsOutOfRangeAfkPrompt(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"afkPromptIntervalSeconds": 3e22,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsNonIntegerNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"maxSessionMinutes": 12.5,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsNegativeBasePay(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"basePayPerHour": -100,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateDepartmentDetails_RejectsUnknownField closes the mass-assignment
+// vector: the old handler would happily write `_id` or `members` if a client
+// named those fields in the body.
+func TestUpdateDepartmentDetails_RejectsUnknownField(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"_id":     "deadbeefdeadbeefdeadbeef",
+		"members": []map[string]string{{"userID": "attacker"}},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsInvalidPayoutMode(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"payoutMode": "instant_yacht",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateDepartmentDetails_AcceptsValidEconomyPatch is the happy path: a
+// realistic mixed payload the real economy-settings UI sends. It must persist
+// every field with the correct typed value (int64 for the numeric ones, so
+// the Go BSON decoder can round-trip without overflow).
+func TestUpdateDepartmentDetails_AcceptsValidEconomyPatch(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateDeptCommunityID)
+	dID, _ := primitive.ObjectIDFromHex(updateDeptDepartmentID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	// audit log InsertOne fires on a goroutine — allow but do not require
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID, "community.departments._id": dID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			if !ok {
+				return false
+			}
+			// Every numeric field must be persisted as int64 (not float64), or
+			// the BSON encoder would write a NumberDouble and we'd be right
+			// back where we started.
+			checks := map[string]int64{
+				"community.departments.$.basePayPerHour":           5000,
+				"community.departments.$.maxSessionMinutes":        180,
+				"community.departments.$.afkPromptIntervalSeconds": 300,
+				"community.departments.$.afkGraceSeconds":          45,
+			}
+			for k, want := range checks {
+				got, ok := set[k].(int64)
+				if !ok || got != want {
+					return false
+				}
+			}
+			if set["community.departments.$.economyEnabled"] != true {
+				return false
+			}
+			if set["community.departments.$.payoutMode"] != "on_clockout" {
+				return false
+			}
+			return true
+		}),
+	).Return(nil)
+
+	c := newUpdateDeptHandler(cdb, aldb)
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"economyEnabled":           true,
+		"basePayPerHour":           5000,
+		"maxSessionMinutes":        180,
+		"afkPromptIntervalSeconds": 300,
+		"afkGraceSeconds":          45,
+		"payoutMode":               "on_clockout",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}
+
+// TestUpdateDepartmentDetails_EmptyBodyIsNoop guarantees the handler still
+// accepts an empty patch (some legacy clients PATCH with no changes when
+// debouncing) without hitting the database.
+func TestUpdateDepartmentDetails_EmptyBodyIsNoop(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -4598,14 +4598,26 @@ func (u User) FetchPrioritizedCommunitiesHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(decodedCommunities))
+	for _, item := range decodedCommunities {
+		ids = append(ids, item.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, u.DB, ids)
+
 	// Format response
 	var responseData []map[string]interface{}
 	for _, item := range decodedCommunities {
+		membersCount := item.Community.MembersCount
+		if live, ok := liveCounts[item.ID.Hex()]; ok {
+			membersCount = live
+		}
 		responseData = append(responseData, map[string]interface{}{
 			"_id":                    item.ID,
 			"name":                   item.Community.Name,
 			"imageLink":              item.Community.ImageLink,
-			"membersCount":           item.Community.MembersCount,
+			"membersCount":           membersCount,
 			"tags":                   item.Community.Tags,
 			"promotionalText":        item.Community.PromotionalText,
 			"promotionalDescription": item.Community.PromotionalDescription,
@@ -4906,14 +4918,26 @@ func (u User) FetchUserCommunitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Self-heal stored membersCount with a live count from the users
+	// collection (see liveMemberCounts for why).
+	ids := make([]string, 0, len(decodedCommunities))
+	for _, item := range decodedCommunities {
+		ids = append(ids, item.ID.Hex())
+	}
+	liveCounts := liveMemberCounts(ctx, u.DB, ids)
+
 	// Transform into response format
 	var communities []map[string]interface{}
 	for _, item := range decodedCommunities {
+		membersCount := item.Community.MembersCount
+		if live, ok := liveCounts[item.ID.Hex()]; ok {
+			membersCount = live
+		}
 		communities = append(communities, map[string]interface{}{
 			"_id":             item.ID,
 			"name":            item.Community.Name,
 			"imageLink":       item.Community.ImageLink,
-			"membersCount":    item.Community.MembersCount,
+			"membersCount":    membersCount,
 			"subscription":    item.Community.Subscription.Active,
 			"promotionalText": item.Community.PromotionalText,
 		})

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -32,56 +32,67 @@ print("=== FIX CORRUPT ECONOMY NUMERICS ===");
 print(`DRY_RUN: ${DRY_RUN}`);
 print("");
 
-// Field specs: name -> { min, max, defaultIfBad }
-// Bounds are intentionally generous so we only clamp truly broken values.
-// int64 max is 9223372036854775807; we keep everything well under so the Go
-// `int` (architecture-dependent, but always at least 32-bit signed) decoder
-// is safe even on 32-bit targets.
+// Field spec: just the safe fallback we install when we find an unreadable
+// value. We ONLY repair values that the Go BSON decoder cannot read into the
+// int-typed model field — doubles that overflow int64, NaN, Infinity, or
+// doubles with a fractional part. We do NOT enforce conceptual minimums
+// (e.g. "afkPromptIntervalSeconds >= 30"). A value of 0 is the legitimate
+// zero-value for departments that never configured the economy; the Go
+// decoder handles it fine, and "repairing" it would touch 99%+ of the
+// population for no benefit.
 const DEPT_FIELDS = {
-  basePayPerHour:           { min: 0, max: 1_000_000_000, defaultIfBad: 0 },     // cents/hr, $10M/hr cap
-  maxSessionMinutes:        { min: 1, max: 24 * 60 * 7,   defaultIfBad: 120 },   // 1 min .. 1 week
-  afkPromptIntervalSeconds: { min: 30, max: 86400,         defaultIfBad: 600 },  // 30s .. 1 day
-  afkGraceSeconds:          { min: 10, max: 86400,         defaultIfBad: 60 },   // 10s .. 1 day
+  basePayPerHour:           { defaultIfBad: 0 },
+  maxSessionMinutes:        { defaultIfBad: 120 },
+  afkPromptIntervalSeconds: { defaultIfBad: 600 },
+  afkGraceSeconds:          { defaultIfBad: 60 },
 };
 
 const COMMUNITY_ECONOMY_FIELDS = {
-  defaultStartingBalance: { min: 0,                       max: 1_000_000_000_00, defaultIfBad: 0 },   // cents, $1B cap
-  defaultDueDays:         { min: 0,                       max: 365,              defaultIfBad: 14 },
-  contestExtensionDays:   { min: 0,                       max: 365,              defaultIfBad: 7 },
+  defaultStartingBalance: { defaultIfBad: 0 },
+  defaultDueDays:         { defaultIfBad: 14 },
+  contestExtensionDays:   { defaultIfBad: 7 },
 };
 
-const SAFE_INT_MAX = Number.MAX_SAFE_INTEGER; // 2^53 - 1, far below int64 max
-const SAFE_INT_MIN = Number.MIN_SAFE_INTEGER;
+// Anything past this point is unreadable by the Go decoder targeting int64.
+// (Real int64 max is 2^63-1 = 9223372036854775807, but JS can't represent it
+// exactly; MAX_SAFE_INTEGER = 2^53-1 is a safer guard.)
+const INT64_SAFE_MAX = Number.MAX_SAFE_INTEGER;
+const INT64_SAFE_MIN = Number.MIN_SAFE_INTEGER;
 
-function isSafeInt(v) {
-  return typeof v === "number"
-    && Number.isFinite(v)
-    && Math.floor(v) === v
-    && v <= SAFE_INT_MAX
-    && v >= SAFE_INT_MIN;
+// isMongoLong matches BSON Long, which mongosh surfaces as an object with
+// .low/.high/.unsigned. Long is the correct int64 wire type for these
+// fields, so it is always valid — including when the wrapped value is zero.
+function isMongoLong(v) {
+  return v !== null
+    && typeof v === "object"
+    && typeof v.low === "number"
+    && typeof v.high === "number"
+    && "unsigned" in v;
 }
 
-// Decide whether the stored value is acceptable. We're lenient about MISSING
-// fields (those are fine — the Go decoder treats them as zero) and only act
-// when the field is present-but-broken.
-function repair(value, spec) {
-  if (value === undefined || value === null) return { changed: false };
-  if (!isSafeInt(value)) {
-    return { changed: true, newValue: spec.defaultIfBad, reason: `not-safe-int (${String(value)})` };
+// detectBad returns null if the value is fine, or { newValue, reason } if it
+// needs repair. Conditions treated as fine:
+//   - field absent
+//   - field is a BSON Long (correct type, always valid)
+//   - field is a JS number that is finite, an integer, and in int64 range
+// Everything else (NaN, Infinity, non-integer double, overflowing double,
+// unexpected wrapper) is decoder-breaking and gets reset to the default.
+function detectBad(value, spec) {
+  if (value === undefined || value === null) return null;
+  if (isMongoLong(value)) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return { newValue: spec.defaultIfBad, reason: `non-finite (${String(value)})` };
+    }
+    if (!Number.isInteger(value)) {
+      return { newValue: spec.defaultIfBad, reason: `non-integer (${value})` };
+    }
+    if (value > INT64_SAFE_MAX || value < INT64_SAFE_MIN) {
+      return { newValue: spec.defaultIfBad, reason: `overflows int64 (${value})` };
+    }
+    return null; // ordinary in-range integer double — decoder handles it
   }
-  if (value < spec.min) {
-    return { changed: true, newValue: spec.min, reason: `below-min (${value} < ${spec.min})` };
-  }
-  if (value > spec.max) {
-    return { changed: true, newValue: spec.defaultIfBad, reason: `above-max (${value} > ${spec.max})` };
-  }
-  // Already an int but Mongo may have stored it as a double (NumberDouble) due
-  // to past JSON-decoded writes. We can detect this in mongosh: bsonsize()
-  // doesn't tell us the type but $type would on the server side. We can't
-  // cheaply detect double-vs-long here without an extra round trip, so we
-  // accept safe ints as-is. The Go BSON decoder converts NumberDouble to int
-  // fine *as long as* the value fits — which by definition a safe int does.
-  return { changed: false };
+  return { newValue: spec.defaultIfBad, reason: `unexpected type (${typeof value})` };
 }
 
 const cursor = db.communities.find(
@@ -105,10 +116,10 @@ while (cursor.hasNext()) {
   const econ = doc.community && doc.community.economy;
   if (econ && typeof econ === "object") {
     for (const [field, spec] of Object.entries(COMMUNITY_ECONOMY_FIELDS)) {
-      const result = repair(econ[field], spec);
-      if (result.changed) {
-        setOps[`community.economy.${field}`] = result.newValue;
-        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: result.newValue, reason: result.reason });
+      const bad = detectBad(econ[field], spec);
+      if (bad) {
+        setOps[`community.economy.${field}`] = bad.newValue;
+        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: bad.newValue, reason: bad.reason });
       }
     }
   }
@@ -118,16 +129,16 @@ while (cursor.hasNext()) {
   for (let i = 0; i < depts.length; i++) {
     const dept = depts[i] || {};
     for (const [field, spec] of Object.entries(DEPT_FIELDS)) {
-      const result = repair(dept[field], spec);
-      if (result.changed) {
-        setOps[`community.departments.${i}.${field}`] = result.newValue;
+      const bad = detectBad(dept[field], spec);
+      if (bad) {
+        setOps[`community.departments.${i}.${field}`] = bad.newValue;
         docFixes.push({
           path: `community.departments.${i}.${field}`,
           deptId: dept._id,
           deptName: dept.name,
           was: dept[field],
-          now: result.newValue,
-          reason: result.reason,
+          now: bad.newValue,
+          reason: bad.reason,
         });
       }
     }

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -1,0 +1,170 @@
+// Repair community/department economy numeric fields that have been corrupted
+// with out-of-range or non-integer values, which cause every community read to
+// 500 with "overflows int64" / "cannot decode ... into int" once the Go decoder
+// hits the bad field.
+//
+// Background: the PATCH /api/v1/community/{communityId}/departments/{departmentId}
+// handler used to accept an unvalidated map[string]interface{} and write each
+// field straight into MongoDB. If a client sent a JS Number that JSON-encoded as
+// scientific notation (e.g. 3e+22 from a long numeric typed into a number
+// input), it was stored as a BSON double and broke the document forever.
+//
+// This script:
+//   - scans every community
+//   - for each known economy numeric field (community-level + per-department),
+//     replaces values that are not safe int64 ints (NaN, Infinity, doubles,
+//     out-of-range, negative where not allowed) with a clamped/default int
+//   - logs every change with the community _id and the field path
+//   - is idempotent: running again is a no-op
+//
+// Usage (run from the police-cad-api scripts dir against a Mongo shell):
+//   DRY_RUN=true mongosh "$DB_URI" fix_corrupt_economy_numerics.js
+//   mongosh "$DB_URI" fix_corrupt_economy_numerics.js
+//
+// DRY_RUN defaults to true; set to "false" via shell env or by editing below
+// to actually apply writes. The script always prints a summary.
+
+const DRY_RUN = (typeof process !== "undefined" && process.env && process.env.DRY_RUN)
+  ? process.env.DRY_RUN !== "false"
+  : true;
+
+print("=== FIX CORRUPT ECONOMY NUMERICS ===");
+print(`DRY_RUN: ${DRY_RUN}`);
+print("");
+
+// Field specs: name -> { min, max, defaultIfBad }
+// Bounds are intentionally generous so we only clamp truly broken values.
+// int64 max is 9223372036854775807; we keep everything well under so the Go
+// `int` (architecture-dependent, but always at least 32-bit signed) decoder
+// is safe even on 32-bit targets.
+const DEPT_FIELDS = {
+  basePayPerHour:           { min: 0, max: 1_000_000_000, defaultIfBad: 0 },     // cents/hr, $10M/hr cap
+  maxSessionMinutes:        { min: 1, max: 24 * 60 * 7,   defaultIfBad: 120 },   // 1 min .. 1 week
+  afkPromptIntervalSeconds: { min: 30, max: 86400,         defaultIfBad: 600 },  // 30s .. 1 day
+  afkGraceSeconds:          { min: 10, max: 86400,         defaultIfBad: 60 },   // 10s .. 1 day
+};
+
+const COMMUNITY_ECONOMY_FIELDS = {
+  defaultStartingBalance: { min: 0,                       max: 1_000_000_000_00, defaultIfBad: 0 },   // cents, $1B cap
+  defaultDueDays:         { min: 0,                       max: 365,              defaultIfBad: 14 },
+  contestExtensionDays:   { min: 0,                       max: 365,              defaultIfBad: 7 },
+};
+
+const SAFE_INT_MAX = Number.MAX_SAFE_INTEGER; // 2^53 - 1, far below int64 max
+const SAFE_INT_MIN = Number.MIN_SAFE_INTEGER;
+
+function isSafeInt(v) {
+  return typeof v === "number"
+    && Number.isFinite(v)
+    && Math.floor(v) === v
+    && v <= SAFE_INT_MAX
+    && v >= SAFE_INT_MIN;
+}
+
+// Decide whether the stored value is acceptable. We're lenient about MISSING
+// fields (those are fine — the Go decoder treats them as zero) and only act
+// when the field is present-but-broken.
+function repair(value, spec) {
+  if (value === undefined || value === null) return { changed: false };
+  if (!isSafeInt(value)) {
+    return { changed: true, newValue: spec.defaultIfBad, reason: `not-safe-int (${String(value)})` };
+  }
+  if (value < spec.min) {
+    return { changed: true, newValue: spec.min, reason: `below-min (${value} < ${spec.min})` };
+  }
+  if (value > spec.max) {
+    return { changed: true, newValue: spec.defaultIfBad, reason: `above-max (${value} > ${spec.max})` };
+  }
+  // Already an int but Mongo may have stored it as a double (NumberDouble) due
+  // to past JSON-decoded writes. We can detect this in mongosh: bsonsize()
+  // doesn't tell us the type but $type would on the server side. We can't
+  // cheaply detect double-vs-long here without an extra round trip, so we
+  // accept safe ints as-is. The Go BSON decoder converts NumberDouble to int
+  // fine *as long as* the value fits — which by definition a safe int does.
+  return { changed: false };
+}
+
+const cursor = db.communities.find(
+  {},
+  { _id: 1, "community.economy": 1, "community.departments": 1 }
+);
+
+let scanned = 0;
+let communitiesUpdated = 0;
+let fieldsRepaired = 0;
+const examples = [];
+
+while (cursor.hasNext()) {
+  const doc = cursor.next();
+  scanned++;
+
+  const setOps = {};
+  const docFixes = [];
+
+  // Community-level economy fields
+  const econ = doc.community && doc.community.economy;
+  if (econ && typeof econ === "object") {
+    for (const [field, spec] of Object.entries(COMMUNITY_ECONOMY_FIELDS)) {
+      const result = repair(econ[field], spec);
+      if (result.changed) {
+        setOps[`community.economy.${field}`] = result.newValue;
+        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: result.newValue, reason: result.reason });
+      }
+    }
+  }
+
+  // Per-department economy fields
+  const depts = (doc.community && doc.community.departments) || [];
+  for (let i = 0; i < depts.length; i++) {
+    const dept = depts[i] || {};
+    for (const [field, spec] of Object.entries(DEPT_FIELDS)) {
+      const result = repair(dept[field], spec);
+      if (result.changed) {
+        setOps[`community.departments.${i}.${field}`] = result.newValue;
+        docFixes.push({
+          path: `community.departments.${i}.${field}`,
+          deptId: dept._id,
+          deptName: dept.name,
+          was: dept[field],
+          now: result.newValue,
+          reason: result.reason,
+        });
+      }
+    }
+  }
+
+  if (Object.keys(setOps).length === 0) continue;
+
+  communitiesUpdated++;
+  fieldsRepaired += Object.keys(setOps).length;
+  if (examples.length < 20) examples.push({ communityId: doc._id, fixes: docFixes });
+
+  if (!DRY_RUN) {
+    const res = db.communities.updateOne({ _id: doc._id }, { $set: setOps });
+    if (res.modifiedCount !== 1) {
+      print(`!! WARN: updateOne modifiedCount=${res.modifiedCount} for ${doc._id}`);
+    }
+  }
+}
+
+print("");
+print(`Scanned communities: ${scanned}`);
+print(`Communities needing repair: ${communitiesUpdated}`);
+print(`Total fields repaired: ${fieldsRepaired}`);
+print("");
+
+if (examples.length > 0) {
+  print(`First ${examples.length} affected communities:`);
+  for (const ex of examples) {
+    print(`  community ${ex.communityId}`);
+    for (const f of ex.fixes) {
+      const dept = f.deptId ? ` (dept ${f.deptId} "${f.deptName || ""}")` : "";
+      print(`    ${f.path}${dept}: ${JSON.stringify(f.was)} -> ${JSON.stringify(f.now)}  [${f.reason}]`);
+    }
+  }
+}
+
+if (DRY_RUN) {
+  print("");
+  print("DRY_RUN was true — no writes performed. Re-run with DRY_RUN=false to apply.");
+}

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -32,32 +32,37 @@ print("=== FIX CORRUPT ECONOMY NUMERICS ===");
 print(`DRY_RUN: ${DRY_RUN}`);
 print("");
 
-// Field spec: just the safe fallback we install when we find an unreadable
-// value. We ONLY repair values that the Go BSON decoder cannot read into the
-// int-typed model field — doubles that overflow int64, NaN, Infinity, or
-// doubles with a fractional part. We do NOT enforce conceptual minimums
-// (e.g. "afkPromptIntervalSeconds >= 30"). A value of 0 is the legitimate
-// zero-value for departments that never configured the economy; the Go
-// decoder handles it fine, and "repairing" it would touch 99%+ of the
-// population for no benefit.
+// Field spec:
+//   nonsenseFallback — value to install when the field is NaN/Infinity/
+//     non-integer or some unexpected wrapper type. No way to recover the
+//     user's intent in those cases, so we reset to the schema default.
+//   overflowCap       — value to install when the field is a finite integer
+//     that exceeds int64. Used in place of the nonsense fallback because the
+//     user clearly intended a very high number; clamping to the API's
+//     documented cap preserves intent rather than zeroing it out.
+//
+// We do NOT enforce conceptual minimums (e.g. afkPromptIntervalSeconds >= 30)
+// and we do NOT touch finite integers that fit in int64 — even if huge —
+// because the Go decoder reads those without complaint. Caps match what the
+// hardened UpdateDepartmentDetailsHandler now enforces on new writes.
 const DEPT_FIELDS = {
-  basePayPerHour:           { defaultIfBad: 0 },
-  maxSessionMinutes:        { defaultIfBad: 120 },
-  afkPromptIntervalSeconds: { defaultIfBad: 600 },
-  afkGraceSeconds:          { defaultIfBad: 60 },
+  basePayPerHour:           { nonsenseFallback: 0,   overflowCap: 1_000_000_000 }, // cents/hr ($10M/hr)
+  maxSessionMinutes:        { nonsenseFallback: 120, overflowCap: 24 * 60 * 7 },   // 1 week
+  afkPromptIntervalSeconds: { nonsenseFallback: 600, overflowCap: 86400 },         // 1 day
+  afkGraceSeconds:          { nonsenseFallback: 60,  overflowCap: 86400 },         // 1 day
 };
 
 const COMMUNITY_ECONOMY_FIELDS = {
-  defaultStartingBalance: { defaultIfBad: 0 },
-  defaultDueDays:         { defaultIfBad: 14 },
-  contestExtensionDays:   { defaultIfBad: 7 },
+  defaultStartingBalance: { nonsenseFallback: 0,  overflowCap: 1_000_000_000_000 }, // $10B in cents
+  defaultDueDays:         { nonsenseFallback: 14, overflowCap: 3650 },              // 10 years
+  contestExtensionDays:   { nonsenseFallback: 7,  overflowCap: 3650 },
 };
 
-// Anything past this point is unreadable by the Go decoder targeting int64.
-// (Real int64 max is 2^63-1 = 9223372036854775807, but JS can't represent it
-// exactly; MAX_SAFE_INTEGER = 2^53-1 is a safer guard.)
-const INT64_SAFE_MAX = Number.MAX_SAFE_INTEGER;
-const INT64_SAFE_MIN = Number.MIN_SAFE_INTEGER;
+// Actual int64 limits. JS can't represent 2^63-1 exactly (it rounds to
+// 9223372036854776000), but as a *threshold* that approximation is fine —
+// anything strictly greater is unambiguously over the int64 ceiling.
+const INT64_MAX = 9223372036854775807;
+const INT64_MIN = -9223372036854775808;
 
 // isMongoLong matches BSON Long, which mongosh surfaces as an object with
 // .low/.high/.unsigned. Long is the correct int64 wire type for these
@@ -70,29 +75,34 @@ function isMongoLong(v) {
     && "unsigned" in v;
 }
 
-// detectBad returns null if the value is fine, or { newValue, reason } if it
-// needs repair. Conditions treated as fine:
+// detectBad returns null if the value is fine, or { newValue, reason } if
+// it needs repair. Conditions treated as fine:
 //   - field absent
-//   - field is a BSON Long (correct type, always valid)
+//   - field is a BSON Long (correct int64 wire type)
 //   - field is a JS number that is finite, an integer, and in int64 range
-// Everything else (NaN, Infinity, non-integer double, overflowing double,
-// unexpected wrapper) is decoder-breaking and gets reset to the default.
+//     (even if huge — Go decodes it cleanly)
+// Repairs:
+//   - NaN / Infinity / non-integer / unexpected wrapper → nonsenseFallback
+//   - > int64 range → overflowCap (preserves "they wanted a very high value")
 function detectBad(value, spec) {
   if (value === undefined || value === null) return null;
   if (isMongoLong(value)) return null;
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      return { newValue: spec.defaultIfBad, reason: `non-finite (${String(value)})` };
+      return { newValue: spec.nonsenseFallback, reason: `non-finite (${String(value)})` };
     }
     if (!Number.isInteger(value)) {
-      return { newValue: spec.defaultIfBad, reason: `non-integer (${value})` };
+      return { newValue: spec.nonsenseFallback, reason: `non-integer (${value})` };
     }
-    if (value > INT64_SAFE_MAX || value < INT64_SAFE_MIN) {
-      return { newValue: spec.defaultIfBad, reason: `overflows int64 (${value})` };
+    if (value > INT64_MAX) {
+      return { newValue: spec.overflowCap, reason: `overflows int64, clamped (${value})` };
     }
-    return null; // ordinary in-range integer double — decoder handles it
+    if (value < INT64_MIN) {
+      return { newValue: spec.nonsenseFallback, reason: `underflows int64 (${value})` };
+    }
+    return null; // ordinary in-range integer (even if very large) — leave alone
   }
-  return { newValue: spec.defaultIfBad, reason: `unexpected type (${typeof value})` };
+  return { newValue: spec.nonsenseFallback, reason: `unexpected type (${typeof value})` };
 }
 
 const cursor = db.communities.find(


### PR DESCRIPTION
## Summary

`community.membersCount` is a denormalized counter maintained by `$inc` on join/approve/leave/ban. It drifts high over time — historical ban paths didn't decrement, account deletion never did. Observed gaps: Cedar Springs RP at stored=119/live=62, FCRP at stored=4348/live=308.

The single-community fetch already self-healed; this PR extends the same correctness to every other surface that uses `membersCount`.

### What changed

**Shared helper — [community_member_counts.go](api/handlers/community_member_counts.go):** `liveMemberCounts(ctx, udb, ids)` runs **one** aggregation over the users collection, keyed by the community IDs in the response page. Backed by the existing `{user.communities.communityId, user.communities.status}` compound index. Aggregation failures soft-fail and fall back to stored values, matching the single-community pattern.

**List handlers — self-healed `membersCount` in responses:**
- `FetchEliteCommunitiesHandler` (`/api/v2/communities/elite`)
- `FetchCommunitiesByTagHandlerV2` (`/api/v2/communities/tag/{tag}`)
- `FetchPrioritizedCommunitiesHandler` (`/api/v2/user/{id}/prioritized-communities`)
- `FetchUserCommunitiesHandler` (`/api/v2/user/{id}/communities`)
- `CommunitiesByOwnerIDHandler` (`/api/v1/communities/{owner_id}`)
- `SearchCommunityHandler` (`/api/v1/search/communities`)

**Leaderboard — rewritten to rank by LIVE count:** The members-stat fast path used to sort+filter by stored `community.membersCount`. With drift in the thousands, real top communities were buried under ghost rankings (FCRP dropped out of the top 10 entirely). New pipeline aggregates over users (`$match → $unwind → $group → $lookup → $facet`), filters communities to public+non-pending in the `$lookup` inner pipeline, sorts by live count. Single round trip, indexed lookups, hidden behind the existing 24h cache (cache resets on process restart). For activity/growth statTypes the sort key is unchanged (sorts by activity score, not members), but the displayed members column is now patched via the helper.

**Not touched:** stored `membersCount` field, `$inc` writes, backfill script. Field stays as a hint, just no longer the source of truth for display or ranking. No client or mobile changes needed.

## Test plan

- [x] Unit tests for `liveMemberCounts`: success path, aggregation-error soft-fail, empty-ID short-circuit.
- [x] Full handler test suite still green. `go vet` warnings are pre-existing in unrelated code.
- [ ] Deploy to a dev/staging API. Hit `/api/v2/communities/elite?limit=20` against a drifted DB — confirm Cedar Springs RP returns 62, not 119.
- [ ] Hit `/api/v1/communities/leaderboard?timeframe=weekly&statType=members` — confirm FCRP appears, ranked by live count (308), not stored (4348). Other entries should be real top communities, not ghosts.
- [ ] Visit `/communities` on the deployed website: Elite carousel, All tab, Recommended tab, Joined/Owned tabs all show corrected counts.
- [ ] Confirm leaderboard cache resets on deploy (Heroku restart wipes in-memory map).
- [ ] Confirm activity/growth leaderboards still render and their members column shows live numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)