### PR TITLE
fix(admin): avoid timeout on user-search lookup for large accounts

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -490,30 +490,54 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 	isEmailQuery := strings.Contains(query, "@") // Detect if query looks like an email
 	var filter bson.M
 	var findOpts *options.FindOptions
+	var countOpts *options.CountOptions
 
 	// Use request context with timeout
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-	
+
 	var err error
 
+	// Projection: only pull fields needed for AdminUserResult. Some user docs
+	// are very large (huge communities/notifications arrays); without this the
+	// driver decodes the whole document just to extract ~8 fields, which can
+	// blow past the query timeout for affected accounts.
+	resultProjection := bson.M{
+		"_id":                       1,
+		"user.email":                1,
+		"user.username":             1,
+		"user.profilePicture":       1,
+		"user.isDeactivated":        1,
+		"user.createdAt":            1,
+		"user.deactivatedAt":        1,
+		"user.deactivationReason":   1,
+		"user.deactivatedByAdminId": 1,
+	}
+
 	if isEmailQuery {
-		// For email queries, use direct lookup only (fastest - uses user_email_idx index)
-		filter = bson.M{"user.email": query} // Direct lookup uses user_email_idx (case-insensitive collation)
+		// For email queries, use direct lookup only (fastest - uses user_email_idx index).
+		// The index is defined with collation {locale:"en", strength:2}; the query
+		// must specify the same collation or Mongo will fall back to a COLLSCAN.
+		filter = bson.M{"user.email": query}
+		emailCollation := &options.Collation{Locale: "en", Strength: 2}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"user.email": 1},
+			Projection: resultProjection,
+			Collation:  emailCollation,
 		}
+		countOpts = options.Count().SetCollation(emailCollation)
 	} else if queryLen >= 3 {
 		// Use $text search for name/username queries
 		filter = bson.M{
 			"$text": bson.M{"$search": query}, // Uses user_search_text_idx for name/username
 		}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"score": bson.M{"$meta": "textScore"}, "user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"score": bson.M{"$meta": "textScore"}, "user.email": 1},
+			Projection: resultProjection,
 		}
 	} else {
 		// For very short queries, use regex but limit aggressively
@@ -525,16 +549,21 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		findOpts = &options.FindOptions{
-			Skip:  &skip,
-			Limit: &limit64,
-			Sort:  bson.M{"user.email": 1},
+			Skip:       &skip,
+			Limit:      &limit64,
+			Sort:       bson.M{"user.email": 1},
+			Projection: resultProjection,
 		}
 	}
-	
+
 	// Get total count for pagination metadata (skip for very short queries to avoid slow count)
 	var totalCount int64
 	if isEmailQuery || queryLen >= 3 {
-		totalCount, err = h.UDB.CountDocuments(ctx, filter)
+		if countOpts != nil {
+			totalCount, err = h.UDB.CountDocuments(ctx, filter, countOpts)
+		} else {
+			totalCount, err = h.UDB.CountDocuments(ctx, filter)
+		}
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "search count failed"})
@@ -544,7 +573,7 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 		// For short queries, estimate count based on results (faster)
 		totalCount = 0 // Will be estimated from results
 	}
-	
+
 	// Use existing user database to search with pagination
 	cursor, err := h.UDB.Find(ctx, filter, findOpts)
 	if err != nil {
@@ -560,9 +589,10 @@ func (h Admin) AdminUserSearchHandler(w http.ResponseWriter, r *http.Request) {
 				},
 			}
 			findOpts = &options.FindOptions{
-				Skip:  &skip,
-				Limit: &limit64,
-				Sort:  bson.M{"user.email": 1},
+				Skip:       &skip,
+				Limit:      &limit64,
+				Sort:       bson.M{"user.email": 1},
+				Projection: resultProjection,
 			}
 			// Retry count with new filter
 			totalCount, err = h.UDB.CountDocuments(ctx, filter)


### PR DESCRIPTION
## Summary
- The admin console "Look Up User" call in the case workflow (transfer ownership / remove bad actor) could hang indefinitely against accounts with very large user documents (huge `communities` / `notifications` arrays). Reported live: an open case where lookup-by-email for the old owner spun forever.
- Two compounding problems in `AdminUserSearchHandler` ([admin.go:454](https://github.com/Linesmerrill/police-cad-api/blob/feature/admin-user-search-perf/api/handlers/admin.go#L454)):
  1. **No projection** — driver loaded and BSON-decoded the entire `User` document to populate only ~8 fields of `AdminUserResult`. With a 9000+ line doc this can exceed the 10s query timeout during the decode step (decode isn't ctx-cancellable).
  2. **Missing collation on email branch** — `user_email_idx` is built with `{locale:"en", strength:2}`. Without that collation on the query, MongoDB can fall back to a COLLSCAN rather than using the index.
- Fix: add a field projection to all three search branches (email/text/regex) and pass the case-insensitive collation on both the find and count for the email branch.

## Test plan
- [ ] On `police-cad-dev`, hit `/admin/console#cases/<id>` → step 4, look up an existing user by email → returns under 1s.
- [ ] Repeat for an account known to have a large user document — confirms it no longer times out.
- [ ] Lookup with mixed-case email (e.g. `Foo@Bar.com` vs `foo@bar.com` in DB) returns the user — confirms collation is applied.
- [ ] Search by username (non-email) still returns matches — confirms the projection didn't drop any field used by the result page.