### PR TITLE
fix(communities): validate department PATCH to stop BSON int overflow lockout

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -3246,13 +3246,58 @@ func (c Community) UpdateDepartmentImageLinkHandler(w http.ResponseWriter, r *ht
 	w.Write([]byte(`{"message": "Department image link updated successfully"}`))
 }
 
-// UpdateDepartmentDetailsHandler updates the details of a department
+// departmentPatchBounds are the per-field sanity limits applied to numeric
+// economy fields when updating a department. They guard against junk values
+// (NaN, Infinity, scientific-notation doubles, negative numbers) ever landing
+// on the document — those used to permanently break community reads because
+// the Go BSON decoder would overflow trying to coerce a Double back into the
+// int-typed model field. Bounds are intentionally generous; they only reject
+// values that are obviously wrong.
+var departmentPatchBounds = map[string]struct {
+	min int64
+	max int64
+}{
+	"basePayPerHour":           {0, 1_000_000_000},     // cents/hr (cap = $10M/hr)
+	"maxSessionMinutes":        {1, 24 * 60 * 7},       // 1 min .. 1 week
+	"afkPromptIntervalSeconds": {30, 86400},            // 30s .. 1 day
+	"afkGraceSeconds":          {10, 86400},            // 10s .. 1 day
+}
+
+// coerceJSONInt accepts any JSON number (decoded as float64 by encoding/json),
+// rejects NaN/Infinity/non-integer/out-of-range values, and returns the int64.
+// JSON booleans, strings, and other types are rejected — clients must send a
+// real number for numeric fields.
+func coerceJSONInt(raw interface{}, lo, hi int64) (int64, error) {
+	f, ok := raw.(float64)
+	if !ok {
+		return 0, fmt.Errorf("expected number, got %T", raw)
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("value is not finite")
+	}
+	if f != math.Trunc(f) {
+		return 0, fmt.Errorf("value must be an integer")
+	}
+	if f < float64(lo) || f > float64(hi) {
+		return 0, fmt.Errorf("value %v out of range [%d, %d]", f, lo, hi)
+	}
+	return int64(f), nil
+}
+
+// UpdateDepartmentDetailsHandler updates the details of a department.
+//
+// The body is a partial document — every field is optional. We allowlist the
+// fields that legitimate clients (web + mobile) actually send, validate types
+// and (for numeric fields) ranges, and write only those fields. Anything else
+// is rejected with 400 to keep the document well-formed and to close a
+// mass-assignment vector (callers could previously set _id, members, ranks,
+// etc. by simply naming the field in the JSON body).
 func (c Community) UpdateDepartmentDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	communityID := mux.Vars(r)["communityId"]
 	departmentID := mux.Vars(r)["departmentId"]
 
-	var updatedDetails map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&updatedDetails); err != nil {
+	var raw map[string]interface{}
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
 		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
 		return
 	}
@@ -3268,14 +3313,71 @@ func (c Community) UpdateDepartmentDetailsHandler(w http.ResponseWriter, r *http
 		return
 	}
 
+	update := bson.M{}
+	for key, value := range raw {
+		switch key {
+		// String fields
+		case "name", "description", "image", "toneSound":
+			s, ok := value.(string)
+			if !ok {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected string", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = s
+
+		// Constrained string enums
+		case "payoutMode":
+			s, ok := value.(string)
+			if !ok || (s != "on_heartbeat" && s != "on_clockout") {
+				config.ErrorStatus("invalid payoutMode: expected \"on_heartbeat\" or \"on_clockout\"", http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = s
+
+		// Bool fields
+		case "approvalRequired", "restrictCivilianRecordDeletion", "economyEnabled":
+			b, ok := value.(bool)
+			if !ok {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected boolean", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = b
+
+		// Range-checked numeric fields
+		case "basePayPerHour", "maxSessionMinutes", "afkPromptIntervalSeconds", "afkGraceSeconds":
+			bounds := departmentPatchBounds[key]
+			n, ierr := coerceJSONInt(value, bounds.min, bounds.max)
+			if ierr != nil {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: %s", key, ierr.Error()), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = n
+
+		// Opaque object fields — passed through as-is. These are too deeply
+		// structured to validate inline here; the model decoder will reject
+		// truly malformed shapes on the next read.
+		case "template", "templateRef":
+			if _, ok := value.(map[string]interface{}); !ok && value != nil {
+				config.ErrorStatus(fmt.Sprintf("invalid %s: expected object", key), http.StatusBadRequest, w, nil)
+				return
+			}
+			update["community.departments.$."+key] = value
+
+		default:
+			config.ErrorStatus(fmt.Sprintf("field %q is not updatable via this endpoint", key), http.StatusBadRequest, w, nil)
+			return
+		}
+	}
+
+	if len(update) == 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"message": "no fields to update"}`))
+		return
+	}
+
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
-
-	update := bson.M{}
-	for key, value := range updatedDetails {
-		update["community.departments.$."+key] = value
-	}
 
 	filter := bson.M{"_id": cID, "community.departments._id": dID}
 	err = c.DB.UpdateOne(ctx, filter, bson.M{"$set": update})

--- a/api/handlers/update_department_details_test.go
+++ b/api/handlers/update_department_details_test.go
@@ -1,0 +1,211 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+)
+
+// Shared IDs for these tests.
+const (
+	updateDeptCommunityID  = "507f1f77bcf86cd799439011"
+	updateDeptDepartmentID = "507f1f77bcf86cd799439022"
+)
+
+func newUpdateDeptHandler(cdb *mocks.CommunityDatabase, aldb *mocks.AuditLogDatabase) handlers.Community {
+	return handlers.Community{
+		DB:   cdb,
+		ALDB: aldb,
+	}
+}
+
+func newUpdateDeptRequest(t *testing.T, body interface{}) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"/api/v1/community/"+updateDeptCommunityID+"/departments/"+updateDeptDepartmentID,
+		bytes.NewReader(raw),
+	)
+	assert.NoError(t, err)
+	return mux.SetURLVars(req, map[string]string{
+		"communityId":  updateDeptCommunityID,
+		"departmentId": updateDeptDepartmentID,
+	})
+}
+
+// TestUpdateDepartmentDetails_RejectsOutOfRangeAfkPrompt is the regression
+// test for the original bug: a client sent afkPromptIntervalSeconds=3e22, the
+// handler accepted it blindly, MongoDB stored a BSON double, and every
+// community read afterwards 500'd with "overflows int64". The hardened
+// handler now refuses values outside the documented range.
+func TestUpdateDepartmentDetails_RejectsOutOfRangeAfkPrompt(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"afkPromptIntervalSeconds": 3e22,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsNonIntegerNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"maxSessionMinutes": 12.5,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsNegativeBasePay(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"basePayPerHour": -100,
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateDepartmentDetails_RejectsUnknownField closes the mass-assignment
+// vector: the old handler would happily write `_id` or `members` if a client
+// named those fields in the body.
+func TestUpdateDepartmentDetails_RejectsUnknownField(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"_id":     "deadbeefdeadbeefdeadbeef",
+		"members": []map[string]string{{"userID": "attacker"}},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateDepartmentDetails_RejectsInvalidPayoutMode(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"payoutMode": "instant_yacht",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestUpdateDepartmentDetails_AcceptsValidEconomyPatch is the happy path: a
+// realistic mixed payload the real economy-settings UI sends. It must persist
+// every field with the correct typed value (int64 for the numeric ones, so
+// the Go BSON decoder can round-trip without overflow).
+func TestUpdateDepartmentDetails_AcceptsValidEconomyPatch(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateDeptCommunityID)
+	dID, _ := primitive.ObjectIDFromHex(updateDeptDepartmentID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+
+	// audit log InsertOne fires on a goroutine — allow but do not require
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID, "community.departments._id": dID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			if !ok {
+				return false
+			}
+			// Every numeric field must be persisted as int64 (not float64), or
+			// the BSON encoder would write a NumberDouble and we'd be right
+			// back where we started.
+			checks := map[string]int64{
+				"community.departments.$.basePayPerHour":           5000,
+				"community.departments.$.maxSessionMinutes":        180,
+				"community.departments.$.afkPromptIntervalSeconds": 300,
+				"community.departments.$.afkGraceSeconds":          45,
+			}
+			for k, want := range checks {
+				got, ok := set[k].(int64)
+				if !ok || got != want {
+					return false
+				}
+			}
+			if set["community.departments.$.economyEnabled"] != true {
+				return false
+			}
+			if set["community.departments.$.payoutMode"] != "on_clockout" {
+				return false
+			}
+			return true
+		}),
+	).Return(nil)
+
+	c := newUpdateDeptHandler(cdb, aldb)
+	req := newUpdateDeptRequest(t, map[string]interface{}{
+		"economyEnabled":           true,
+		"basePayPerHour":           5000,
+		"maxSessionMinutes":        180,
+		"afkPromptIntervalSeconds": 300,
+		"afkGraceSeconds":          45,
+		"payoutMode":               "on_clockout",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}
+
+// TestUpdateDepartmentDetails_EmptyBodyIsNoop guarantees the handler still
+// accepts an empty patch (some legacy clients PATCH with no changes when
+// debouncing) without hitting the database.
+func TestUpdateDepartmentDetails_EmptyBodyIsNoop(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateDeptHandler(cdb, aldb)
+
+	req := newUpdateDeptRequest(t, map[string]interface{}{})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateDepartmentDetailsHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -32,56 +32,67 @@ print("=== FIX CORRUPT ECONOMY NUMERICS ===");
 print(`DRY_RUN: ${DRY_RUN}`);
 print("");
 
-// Field specs: name -> { min, max, defaultIfBad }
-// Bounds are intentionally generous so we only clamp truly broken values.
-// int64 max is 9223372036854775807; we keep everything well under so the Go
-// `int` (architecture-dependent, but always at least 32-bit signed) decoder
-// is safe even on 32-bit targets.
+// Field spec: just the safe fallback we install when we find an unreadable
+// value. We ONLY repair values that the Go BSON decoder cannot read into the
+// int-typed model field — doubles that overflow int64, NaN, Infinity, or
+// doubles with a fractional part. We do NOT enforce conceptual minimums
+// (e.g. "afkPromptIntervalSeconds >= 30"). A value of 0 is the legitimate
+// zero-value for departments that never configured the economy; the Go
+// decoder handles it fine, and "repairing" it would touch 99%+ of the
+// population for no benefit.
 const DEPT_FIELDS = {
-  basePayPerHour:           { min: 0, max: 1_000_000_000, defaultIfBad: 0 },     // cents/hr, $10M/hr cap
-  maxSessionMinutes:        { min: 1, max: 24 * 60 * 7,   defaultIfBad: 120 },   // 1 min .. 1 week
-  afkPromptIntervalSeconds: { min: 30, max: 86400,         defaultIfBad: 600 },  // 30s .. 1 day
-  afkGraceSeconds:          { min: 10, max: 86400,         defaultIfBad: 60 },   // 10s .. 1 day
+  basePayPerHour:           { defaultIfBad: 0 },
+  maxSessionMinutes:        { defaultIfBad: 120 },
+  afkPromptIntervalSeconds: { defaultIfBad: 600 },
+  afkGraceSeconds:          { defaultIfBad: 60 },
 };
 
 const COMMUNITY_ECONOMY_FIELDS = {
-  defaultStartingBalance: { min: 0,                       max: 1_000_000_000_00, defaultIfBad: 0 },   // cents, $1B cap
-  defaultDueDays:         { min: 0,                       max: 365,              defaultIfBad: 14 },
-  contestExtensionDays:   { min: 0,                       max: 365,              defaultIfBad: 7 },
+  defaultStartingBalance: { defaultIfBad: 0 },
+  defaultDueDays:         { defaultIfBad: 14 },
+  contestExtensionDays:   { defaultIfBad: 7 },
 };
 
-const SAFE_INT_MAX = Number.MAX_SAFE_INTEGER; // 2^53 - 1, far below int64 max
-const SAFE_INT_MIN = Number.MIN_SAFE_INTEGER;
+// Anything past this point is unreadable by the Go decoder targeting int64.
+// (Real int64 max is 2^63-1 = 9223372036854775807, but JS can't represent it
+// exactly; MAX_SAFE_INTEGER = 2^53-1 is a safer guard.)
+const INT64_SAFE_MAX = Number.MAX_SAFE_INTEGER;
+const INT64_SAFE_MIN = Number.MIN_SAFE_INTEGER;
 
-function isSafeInt(v) {
-  return typeof v === "number"
-    && Number.isFinite(v)
-    && Math.floor(v) === v
-    && v <= SAFE_INT_MAX
-    && v >= SAFE_INT_MIN;
+// isMongoLong matches BSON Long, which mongosh surfaces as an object with
+// .low/.high/.unsigned. Long is the correct int64 wire type for these
+// fields, so it is always valid — including when the wrapped value is zero.
+function isMongoLong(v) {
+  return v !== null
+    && typeof v === "object"
+    && typeof v.low === "number"
+    && typeof v.high === "number"
+    && "unsigned" in v;
 }
 
-// Decide whether the stored value is acceptable. We're lenient about MISSING
-// fields (those are fine — the Go decoder treats them as zero) and only act
-// when the field is present-but-broken.
-function repair(value, spec) {
-  if (value === undefined || value === null) return { changed: false };
-  if (!isSafeInt(value)) {
-    return { changed: true, newValue: spec.defaultIfBad, reason: `not-safe-int (${String(value)})` };
+// detectBad returns null if the value is fine, or { newValue, reason } if it
+// needs repair. Conditions treated as fine:
+//   - field absent
+//   - field is a BSON Long (correct type, always valid)
+//   - field is a JS number that is finite, an integer, and in int64 range
+// Everything else (NaN, Infinity, non-integer double, overflowing double,
+// unexpected wrapper) is decoder-breaking and gets reset to the default.
+function detectBad(value, spec) {
+  if (value === undefined || value === null) return null;
+  if (isMongoLong(value)) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      return { newValue: spec.defaultIfBad, reason: `non-finite (${String(value)})` };
+    }
+    if (!Number.isInteger(value)) {
+      return { newValue: spec.defaultIfBad, reason: `non-integer (${value})` };
+    }
+    if (value > INT64_SAFE_MAX || value < INT64_SAFE_MIN) {
+      return { newValue: spec.defaultIfBad, reason: `overflows int64 (${value})` };
+    }
+    return null; // ordinary in-range integer double — decoder handles it
   }
-  if (value < spec.min) {
-    return { changed: true, newValue: spec.min, reason: `below-min (${value} < ${spec.min})` };
-  }
-  if (value > spec.max) {
-    return { changed: true, newValue: spec.defaultIfBad, reason: `above-max (${value} > ${spec.max})` };
-  }
-  // Already an int but Mongo may have stored it as a double (NumberDouble) due
-  // to past JSON-decoded writes. We can detect this in mongosh: bsonsize()
-  // doesn't tell us the type but $type would on the server side. We can't
-  // cheaply detect double-vs-long here without an extra round trip, so we
-  // accept safe ints as-is. The Go BSON decoder converts NumberDouble to int
-  // fine *as long as* the value fits — which by definition a safe int does.
-  return { changed: false };
+  return { newValue: spec.defaultIfBad, reason: `unexpected type (${typeof value})` };
 }
 
 const cursor = db.communities.find(
@@ -105,10 +116,10 @@ while (cursor.hasNext()) {
   const econ = doc.community && doc.community.economy;
   if (econ && typeof econ === "object") {
     for (const [field, spec] of Object.entries(COMMUNITY_ECONOMY_FIELDS)) {
-      const result = repair(econ[field], spec);
-      if (result.changed) {
-        setOps[`community.economy.${field}`] = result.newValue;
-        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: result.newValue, reason: result.reason });
+      const bad = detectBad(econ[field], spec);
+      if (bad) {
+        setOps[`community.economy.${field}`] = bad.newValue;
+        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: bad.newValue, reason: bad.reason });
       }
     }
   }
@@ -118,16 +129,16 @@ while (cursor.hasNext()) {
   for (let i = 0; i < depts.length; i++) {
     const dept = depts[i] || {};
     for (const [field, spec] of Object.entries(DEPT_FIELDS)) {
-      const result = repair(dept[field], spec);
-      if (result.changed) {
-        setOps[`community.departments.${i}.${field}`] = result.newValue;
+      const bad = detectBad(dept[field], spec);
+      if (bad) {
+        setOps[`community.departments.${i}.${field}`] = bad.newValue;
         docFixes.push({
           path: `community.departments.${i}.${field}`,
           deptId: dept._id,
           deptName: dept.name,
           was: dept[field],
-          now: result.newValue,
-          reason: result.reason,
+          now: bad.newValue,
+          reason: bad.reason,
         });
       }
     }

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -1,0 +1,170 @@
+// Repair community/department economy numeric fields that have been corrupted
+// with out-of-range or non-integer values, which cause every community read to
+// 500 with "overflows int64" / "cannot decode ... into int" once the Go decoder
+// hits the bad field.
+//
+// Background: the PATCH /api/v1/community/{communityId}/departments/{departmentId}
+// handler used to accept an unvalidated map[string]interface{} and write each
+// field straight into MongoDB. If a client sent a JS Number that JSON-encoded as
+// scientific notation (e.g. 3e+22 from a long numeric typed into a number
+// input), it was stored as a BSON double and broke the document forever.
+//
+// This script:
+//   - scans every community
+//   - for each known economy numeric field (community-level + per-department),
+//     replaces values that are not safe int64 ints (NaN, Infinity, doubles,
+//     out-of-range, negative where not allowed) with a clamped/default int
+//   - logs every change with the community _id and the field path
+//   - is idempotent: running again is a no-op
+//
+// Usage (run from the police-cad-api scripts dir against a Mongo shell):
+//   DRY_RUN=true mongosh "$DB_URI" fix_corrupt_economy_numerics.js
+//   mongosh "$DB_URI" fix_corrupt_economy_numerics.js
+//
+// DRY_RUN defaults to true; set to "false" via shell env or by editing below
+// to actually apply writes. The script always prints a summary.
+
+const DRY_RUN = (typeof process !== "undefined" && process.env && process.env.DRY_RUN)
+  ? process.env.DRY_RUN !== "false"
+  : true;
+
+print("=== FIX CORRUPT ECONOMY NUMERICS ===");
+print(`DRY_RUN: ${DRY_RUN}`);
+print("");
+
+// Field specs: name -> { min, max, defaultIfBad }
+// Bounds are intentionally generous so we only clamp truly broken values.
+// int64 max is 9223372036854775807; we keep everything well under so the Go
+// `int` (architecture-dependent, but always at least 32-bit signed) decoder
+// is safe even on 32-bit targets.
+const DEPT_FIELDS = {
+  basePayPerHour:           { min: 0, max: 1_000_000_000, defaultIfBad: 0 },     // cents/hr, $10M/hr cap
+  maxSessionMinutes:        { min: 1, max: 24 * 60 * 7,   defaultIfBad: 120 },   // 1 min .. 1 week
+  afkPromptIntervalSeconds: { min: 30, max: 86400,         defaultIfBad: 600 },  // 30s .. 1 day
+  afkGraceSeconds:          { min: 10, max: 86400,         defaultIfBad: 60 },   // 10s .. 1 day
+};
+
+const COMMUNITY_ECONOMY_FIELDS = {
+  defaultStartingBalance: { min: 0,                       max: 1_000_000_000_00, defaultIfBad: 0 },   // cents, $1B cap
+  defaultDueDays:         { min: 0,                       max: 365,              defaultIfBad: 14 },
+  contestExtensionDays:   { min: 0,                       max: 365,              defaultIfBad: 7 },
+};
+
+const SAFE_INT_MAX = Number.MAX_SAFE_INTEGER; // 2^53 - 1, far below int64 max
+const SAFE_INT_MIN = Number.MIN_SAFE_INTEGER;
+
+function isSafeInt(v) {
+  return typeof v === "number"
+    && Number.isFinite(v)
+    && Math.floor(v) === v
+    && v <= SAFE_INT_MAX
+    && v >= SAFE_INT_MIN;
+}
+
+// Decide whether the stored value is acceptable. We're lenient about MISSING
+// fields (those are fine — the Go decoder treats them as zero) and only act
+// when the field is present-but-broken.
+function repair(value, spec) {
+  if (value === undefined || value === null) return { changed: false };
+  if (!isSafeInt(value)) {
+    return { changed: true, newValue: spec.defaultIfBad, reason: `not-safe-int (${String(value)})` };
+  }
+  if (value < spec.min) {
+    return { changed: true, newValue: spec.min, reason: `below-min (${value} < ${spec.min})` };
+  }
+  if (value > spec.max) {
+    return { changed: true, newValue: spec.defaultIfBad, reason: `above-max (${value} > ${spec.max})` };
+  }
+  // Already an int but Mongo may have stored it as a double (NumberDouble) due
+  // to past JSON-decoded writes. We can detect this in mongosh: bsonsize()
+  // doesn't tell us the type but $type would on the server side. We can't
+  // cheaply detect double-vs-long here without an extra round trip, so we
+  // accept safe ints as-is. The Go BSON decoder converts NumberDouble to int
+  // fine *as long as* the value fits — which by definition a safe int does.
+  return { changed: false };
+}
+
+const cursor = db.communities.find(
+  {},
+  { _id: 1, "community.economy": 1, "community.departments": 1 }
+);
+
+let scanned = 0;
+let communitiesUpdated = 0;
+let fieldsRepaired = 0;
+const examples = [];
+
+while (cursor.hasNext()) {
+  const doc = cursor.next();
+  scanned++;
+
+  const setOps = {};
+  const docFixes = [];
+
+  // Community-level economy fields
+  const econ = doc.community && doc.community.economy;
+  if (econ && typeof econ === "object") {
+    for (const [field, spec] of Object.entries(COMMUNITY_ECONOMY_FIELDS)) {
+      const result = repair(econ[field], spec);
+      if (result.changed) {
+        setOps[`community.economy.${field}`] = result.newValue;
+        docFixes.push({ path: `community.economy.${field}`, was: econ[field], now: result.newValue, reason: result.reason });
+      }
+    }
+  }
+
+  // Per-department economy fields
+  const depts = (doc.community && doc.community.departments) || [];
+  for (let i = 0; i < depts.length; i++) {
+    const dept = depts[i] || {};
+    for (const [field, spec] of Object.entries(DEPT_FIELDS)) {
+      const result = repair(dept[field], spec);
+      if (result.changed) {
+        setOps[`community.departments.${i}.${field}`] = result.newValue;
+        docFixes.push({
+          path: `community.departments.${i}.${field}`,
+          deptId: dept._id,
+          deptName: dept.name,
+          was: dept[field],
+          now: result.newValue,
+          reason: result.reason,
+        });
+      }
+    }
+  }
+
+  if (Object.keys(setOps).length === 0) continue;
+
+  communitiesUpdated++;
+  fieldsRepaired += Object.keys(setOps).length;
+  if (examples.length < 20) examples.push({ communityId: doc._id, fixes: docFixes });
+
+  if (!DRY_RUN) {
+    const res = db.communities.updateOne({ _id: doc._id }, { $set: setOps });
+    if (res.modifiedCount !== 1) {
+      print(`!! WARN: updateOne modifiedCount=${res.modifiedCount} for ${doc._id}`);
+    }
+  }
+}
+
+print("");
+print(`Scanned communities: ${scanned}`);
+print(`Communities needing repair: ${communitiesUpdated}`);
+print(`Total fields repaired: ${fieldsRepaired}`);
+print("");
+
+if (examples.length > 0) {
+  print(`First ${examples.length} affected communities:`);
+  for (const ex of examples) {
+    print(`  community ${ex.communityId}`);
+    for (const f of ex.fixes) {
+      const dept = f.deptId ? ` (dept ${f.deptId} "${f.deptName || ""}")` : "";
+      print(`    ${f.path}${dept}: ${JSON.stringify(f.was)} -> ${JSON.stringify(f.now)}  [${f.reason}]`);
+    }
+  }
+}
+
+if (DRY_RUN) {
+  print("");
+  print("DRY_RUN was true — no writes performed. Re-run with DRY_RUN=false to apply.");
+}


### PR DESCRIPTION
## Summary
- Lock down `PATCH /api/v1/community/{communityId}/departments/{departmentId}` so a client cannot persist a non-int / out-of-range / unknown field — root cause of the bug where one community sent `afkPromptIntervalSeconds=3e22` and every subsequent read of that community returned 500 (`3e+22 overflows int64`).
- Validate every numeric economy field (basePayPerHour, maxSessionMinutes, afkPromptIntervalSeconds, afkGraceSeconds) through `coerceJSONInt` — rejects NaN/Inf/non-int/out-of-range and writes `int64` so BSON never stores a `Double` that the Go decoder can't read back.
- Strict allowlist for the rest of the body. Unknown fields → 400. Closes a mass-assignment vector where `_id`, `members`, `ranks` etc. were writable.
- Adds `scripts/fix_corrupt_economy_numerics.js` to repair any already-corrupted documents in the field (idempotent, DRY_RUN default).
- 7 new handler tests including the literal regression: `afkPromptIntervalSeconds: 3e22` → 400, no DB call.

## Test plan
- [x] `go test ./api/handlers/...` — all new tests pass, no regressions in existing handler tests.
- [ ] Run `DRY_RUN=true mongosh "$DB_URI" scripts/fix_corrupt_economy_numerics.js` against police-cad-dev — confirm only expected docs flagged.
- [ ] Re-run with `DRY_RUN=false` on dev, then verify a previously-broken community now loads (no more 500).
- [ ] Repeat against prod once dev is clean.
- [ ] Post-deploy: smoke test economy-settings save path on web + mobile (happy values + try to send a giant number → expect 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)