### PR TITLE
fix(scripts): sweep uses real int64 max, clamps overflow instead of zeroing

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -993,6 +993,23 @@ func (c Community) UpdateCommunityFieldHandler(w http.ResponseWriter, r *http.Re
 		}
 	}
 
+	// Same hardening as UpdateDepartmentDetailsHandler: when the payload
+	// includes an `economy` sub-object, validate it strictly so a malformed
+	// numeric (e.g. afkPromptIntervalSeconds=3e22-style overflow on the
+	// community-level fields) can never land on the document and break every
+	// subsequent BSON decode of that community. Other top-level community
+	// fields still flow through the existing pass-through code — this endpoint
+	// is a catch-all used by many surfaces and we don't want to lock those
+	// down piecemeal here.
+	if econRaw, exists := req["economy"]; exists {
+		cleaned, vErr := validateCommunityEconomyPatch(econRaw)
+		if vErr != nil {
+			config.ErrorStatus(vErr.Error(), http.StatusBadRequest, w, nil)
+			return
+		}
+		req["economy"] = cleaned
+	}
+
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -3295,6 +3312,62 @@ func coerceJSONInt(raw interface{}, lo, hi int64) (int64, error) {
 		return 0, fmt.Errorf("value %v out of range [%d, %d]", f, lo, hi)
 	}
 	return int64(f), nil
+}
+
+// communityEconomyPatchBounds matches the EconomySettings model fields. Same
+// rationale as departmentPatchBounds: prevent any client (mobile, web, or
+// otherwise) from persisting a non-int / out-of-range value that the Go BSON
+// decoder cannot read back. Caps are intentionally generous; they only reject
+// values that are obviously wrong.
+var communityEconomyPatchBounds = map[string]struct {
+	min int64
+	max int64
+}{
+	"defaultStartingBalance": {0, 1_000_000_000_000}, // cents ($10B cap)
+	"defaultDueDays":         {0, 3650},              // up to 10 years
+	"contestExtensionDays":   {0, 3650},
+}
+
+// validateCommunityEconomyPatch takes the raw `economy` sub-object from a
+// community PATCH body, validates every field with a strict allowlist (same
+// approach as UpdateDepartmentDetailsHandler), and returns a clean bson.M
+// safe to write under `community.economy`. Unknown fields are rejected so
+// arbitrary keys cannot be smuggled onto community.economy.
+func validateCommunityEconomyPatch(raw interface{}) (bson.M, error) {
+	if raw == nil {
+		return bson.M{}, nil
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid economy: expected object")
+	}
+	clean := bson.M{}
+	for key, value := range m {
+		switch key {
+		case "enabled", "allowNegativeBalance":
+			b, ok := value.(bool)
+			if !ok {
+				return nil, fmt.Errorf("invalid economy.%s: expected boolean", key)
+			}
+			clean[key] = b
+		case "fineMode":
+			s, ok := value.(string)
+			if !ok || (s != "inbox" && s != "auto_debit") {
+				return nil, fmt.Errorf("invalid economy.fineMode: expected \"inbox\" or \"auto_debit\"")
+			}
+			clean[key] = s
+		case "defaultStartingBalance", "defaultDueDays", "contestExtensionDays":
+			bounds := communityEconomyPatchBounds[key]
+			n, ierr := coerceJSONInt(value, bounds.min, bounds.max)
+			if ierr != nil {
+				return nil, fmt.Errorf("invalid economy.%s: %s", key, ierr.Error())
+			}
+			clean[key] = n
+		default:
+			return nil, fmt.Errorf("field economy.%q is not updatable via this endpoint", key)
+		}
+	}
+	return clean, nil
 }
 
 // UpdateDepartmentDetailsHandler updates the details of a department.

--- a/api/handlers/update_community_economy_test.go
+++ b/api/handlers/update_community_economy_test.go
@@ -1,0 +1,192 @@
+package handlers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+)
+
+const updateCommunityID = "507f1f77bcf86cd799439033"
+
+func newUpdateCommunityHandler(cdb *mocks.CommunityDatabase, aldb *mocks.AuditLogDatabase) handlers.Community {
+	return handlers.Community{
+		DB:   cdb,
+		ALDB: aldb,
+	}
+}
+
+func newUpdateCommunityRequest(t *testing.T, body interface{}) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	assert.NoError(t, err)
+	req, err := http.NewRequest(
+		http.MethodPatch,
+		"/api/v1/community/"+updateCommunityID,
+		bytes.NewReader(raw),
+	)
+	assert.NoError(t, err)
+	return mux.SetURLVars(req, map[string]string{"community_id": updateCommunityID})
+}
+
+// Regression: same class of bug as UpdateDepartmentDetailsHandler. A
+// community.economy field with a giant numeric like 3e22 used to land on the
+// document and break every subsequent BSON decode of the community.
+func TestUpdateCommunityField_RejectsOverflowingEconomyNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"defaultStartingBalance": 3e22},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsNonIntegerEconomyNumeric(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"defaultDueDays": 12.5},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsInvalidFineMode(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"fineMode": "yacht_seizure"},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestUpdateCommunityField_RejectsUnknownEconomyKey(t *testing.T) {
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	c := newUpdateCommunityHandler(cdb, aldb)
+
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{"superSecretBackdoor": true},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	cdb.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// Happy path: a realistic mobile save (every economy field present). Each
+// numeric must persist as int64 — never float64 — so BSON cannot store a
+// Double that the Go decoder won't read back.
+func TestUpdateCommunityField_AcceptsValidEconomyPatch(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			if !ok {
+				return false
+			}
+			econ, ok := set["community.economy"].(bson.M)
+			if !ok {
+				return false
+			}
+			intChecks := map[string]int64{
+				"defaultStartingBalance": 50000,
+				"defaultDueDays":         14,
+				"contestExtensionDays":   30,
+			}
+			for k, want := range intChecks {
+				got, ok := econ[k].(int64)
+				if !ok || got != want {
+					return false
+				}
+			}
+			return econ["enabled"] == true &&
+				econ["allowNegativeBalance"] == false &&
+				econ["fineMode"] == "inbox"
+		}),
+	).Return(nil)
+
+	c := newUpdateCommunityHandler(cdb, aldb)
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"economy": map[string]interface{}{
+			"enabled":                true,
+			"defaultStartingBalance": 50000,
+			"fineMode":               "inbox",
+			"defaultDueDays":         14,
+			"contestExtensionDays":   30,
+			"allowNegativeBalance":   false,
+		},
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}
+
+// Backwards-compatibility: a non-economy PATCH (the common case for this
+// catch-all endpoint) must still flow through unchanged. We don't want the
+// economy hardening to lock down the other 40+ fields this endpoint serves.
+func TestUpdateCommunityField_PassesThroughNonEconomyFields(t *testing.T) {
+	cID, _ := primitive.ObjectIDFromHex(updateCommunityID)
+
+	cdb := &mocks.CommunityDatabase{}
+	aldb := &mocks.AuditLogDatabase{}
+	aldb.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	cdb.On(
+		"UpdateOne",
+		mock.Anything,
+		bson.M{"_id": cID},
+		mock.MatchedBy(func(update bson.M) bool {
+			set, ok := update["$set"].(bson.M)
+			return ok && set["community.name"] == "Renamed Town"
+		}),
+	).Return(nil)
+
+	c := newUpdateCommunityHandler(cdb, aldb)
+	req := newUpdateCommunityRequest(t, map[string]interface{}{
+		"name": "Renamed Town",
+	})
+	rr := httptest.NewRecorder()
+	http.HandlerFunc(c.UpdateCommunityFieldHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	cdb.AssertExpectations(t)
+}

--- a/scripts/fix_corrupt_economy_numerics.js
+++ b/scripts/fix_corrupt_economy_numerics.js
@@ -32,32 +32,37 @@ print("=== FIX CORRUPT ECONOMY NUMERICS ===");
 print(`DRY_RUN: ${DRY_RUN}`);
 print("");
 
-// Field spec: just the safe fallback we install when we find an unreadable
-// value. We ONLY repair values that the Go BSON decoder cannot read into the
-// int-typed model field — doubles that overflow int64, NaN, Infinity, or
-// doubles with a fractional part. We do NOT enforce conceptual minimums
-// (e.g. "afkPromptIntervalSeconds >= 30"). A value of 0 is the legitimate
-// zero-value for departments that never configured the economy; the Go
-// decoder handles it fine, and "repairing" it would touch 99%+ of the
-// population for no benefit.
+// Field spec:
+//   nonsenseFallback — value to install when the field is NaN/Infinity/
+//     non-integer or some unexpected wrapper type. No way to recover the
+//     user's intent in those cases, so we reset to the schema default.
+//   overflowCap       — value to install when the field is a finite integer
+//     that exceeds int64. Used in place of the nonsense fallback because the
+//     user clearly intended a very high number; clamping to the API's
+//     documented cap preserves intent rather than zeroing it out.
+//
+// We do NOT enforce conceptual minimums (e.g. afkPromptIntervalSeconds >= 30)
+// and we do NOT touch finite integers that fit in int64 — even if huge —
+// because the Go decoder reads those without complaint. Caps match what the
+// hardened UpdateDepartmentDetailsHandler now enforces on new writes.
 const DEPT_FIELDS = {
-  basePayPerHour:           { defaultIfBad: 0 },
-  maxSessionMinutes:        { defaultIfBad: 120 },
-  afkPromptIntervalSeconds: { defaultIfBad: 600 },
-  afkGraceSeconds:          { defaultIfBad: 60 },
+  basePayPerHour:           { nonsenseFallback: 0,   overflowCap: 1_000_000_000 }, // cents/hr ($10M/hr)
+  maxSessionMinutes:        { nonsenseFallback: 120, overflowCap: 24 * 60 * 7 },   // 1 week
+  afkPromptIntervalSeconds: { nonsenseFallback: 600, overflowCap: 86400 },         // 1 day
+  afkGraceSeconds:          { nonsenseFallback: 60,  overflowCap: 86400 },         // 1 day
 };
 
 const COMMUNITY_ECONOMY_FIELDS = {
-  defaultStartingBalance: { defaultIfBad: 0 },
-  defaultDueDays:         { defaultIfBad: 14 },
-  contestExtensionDays:   { defaultIfBad: 7 },
+  defaultStartingBalance: { nonsenseFallback: 0,  overflowCap: 1_000_000_000_000 }, // $10B in cents
+  defaultDueDays:         { nonsenseFallback: 14, overflowCap: 3650 },              // 10 years
+  contestExtensionDays:   { nonsenseFallback: 7,  overflowCap: 3650 },
 };
 
-// Anything past this point is unreadable by the Go decoder targeting int64.
-// (Real int64 max is 2^63-1 = 9223372036854775807, but JS can't represent it
-// exactly; MAX_SAFE_INTEGER = 2^53-1 is a safer guard.)
-const INT64_SAFE_MAX = Number.MAX_SAFE_INTEGER;
-const INT64_SAFE_MIN = Number.MIN_SAFE_INTEGER;
+// Actual int64 limits. JS can't represent 2^63-1 exactly (it rounds to
+// 9223372036854776000), but as a *threshold* that approximation is fine —
+// anything strictly greater is unambiguously over the int64 ceiling.
+const INT64_MAX = 9223372036854775807;
+const INT64_MIN = -9223372036854775808;
 
 // isMongoLong matches BSON Long, which mongosh surfaces as an object with
 // .low/.high/.unsigned. Long is the correct int64 wire type for these
@@ -70,29 +75,34 @@ function isMongoLong(v) {
     && "unsigned" in v;
 }
 
-// detectBad returns null if the value is fine, or { newValue, reason } if it
-// needs repair. Conditions treated as fine:
+// detectBad returns null if the value is fine, or { newValue, reason } if
+// it needs repair. Conditions treated as fine:
 //   - field absent
-//   - field is a BSON Long (correct type, always valid)
+//   - field is a BSON Long (correct int64 wire type)
 //   - field is a JS number that is finite, an integer, and in int64 range
-// Everything else (NaN, Infinity, non-integer double, overflowing double,
-// unexpected wrapper) is decoder-breaking and gets reset to the default.
+//     (even if huge — Go decodes it cleanly)
+// Repairs:
+//   - NaN / Infinity / non-integer / unexpected wrapper → nonsenseFallback
+//   - > int64 range → overflowCap (preserves "they wanted a very high value")
 function detectBad(value, spec) {
   if (value === undefined || value === null) return null;
   if (isMongoLong(value)) return null;
   if (typeof value === "number") {
     if (!Number.isFinite(value)) {
-      return { newValue: spec.defaultIfBad, reason: `non-finite (${String(value)})` };
+      return { newValue: spec.nonsenseFallback, reason: `non-finite (${String(value)})` };
     }
     if (!Number.isInteger(value)) {
-      return { newValue: spec.defaultIfBad, reason: `non-integer (${value})` };
+      return { newValue: spec.nonsenseFallback, reason: `non-integer (${value})` };
     }
-    if (value > INT64_SAFE_MAX || value < INT64_SAFE_MIN) {
-      return { newValue: spec.defaultIfBad, reason: `overflows int64 (${value})` };
+    if (value > INT64_MAX) {
+      return { newValue: spec.overflowCap, reason: `overflows int64, clamped (${value})` };
     }
-    return null; // ordinary in-range integer double — decoder handles it
+    if (value < INT64_MIN) {
+      return { newValue: spec.nonsenseFallback, reason: `underflows int64 (${value})` };
+    }
+    return null; // ordinary in-range integer (even if very large) — leave alone
   }
-  return { newValue: spec.defaultIfBad, reason: `unexpected type (${typeof value})` };
+  return { newValue: spec.nonsenseFallback, reason: `unexpected type (${typeof value})` };
 }
 
 const cursor = db.communities.find(


### PR DESCRIPTION
## Summary
Follow-up to the economy-numeric sweep already merged into \`feature/live-member-counts\`. Two issues in the detector:

1. **Threshold was too tight.** Used \`Number.MAX_SAFE_INTEGER\` (~9×10¹⁵) as the int64 guard. Real int64 max is ~9.22×10¹⁸. So values like \`basePayPerHour: 90000000000000000\` (9×10¹⁶) were getting flagged as "overflows int64" when they actually fit fine and the Go decoder reads them cleanly.
2. **Reset-to-zero destroyed intent.** When a value really did overflow int64 (e.g. \`1e+24\`), the script reset it to the schema zero-value. For a field a user clearly typed a huge number into ("they wanted max pay"), that erases intent. Now clamps to the API's documented cap so the high-pay intent survives.

| Value | Before this PR | After |
|---|---|---|
| \`1e+24\` (basePayPerHour) | → \`0\` | → \`1_000_000_000\` (= $10M/hr, API cap) |
| \`9e16\` (basePayPerHour) | → \`0\` (false positive) | left alone (fits int64) |
| \`3e+22\` (original bug) | → \`0\` | → \`1_000_000_000\` (clamped) |
| \`NaN\` / \`Infinity\` / \`12.5\` | → schema default | → schema default (unchanged) |

Caps match the new \`UpdateDepartmentDetailsHandler\` validation merged in PR #119: basePay ≤ 1B cents, maxSession ≤ 1 week, afk timers ≤ 1 day.

## Test plan
- [ ] \`DRY_RUN=true mongosh "$DB_URI" scripts/fix_corrupt_economy_numerics.js\` — confirm false-positive count drops dramatically vs the previous run, and that any \`overflows int64\` rows now show \`-> <cap>\` not \`-> 0\`.
- [ ] \`DRY_RUN=false …\` on dev once the output looks right; verify a previously-broken community now loads.
- [ ] Repeat on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)