### PR TITLE
fix(rp-promotion): reject Discord channel deep-links as invite URL

### DIFF
--- a/api/handlers/rp_promotion.go
+++ b/api/handlers/rp_promotion.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -413,10 +414,12 @@ func sanitizeRpPromotionData(data *models.RpPromotionData, tier rpTierConfig) er
 		return fmt.Errorf("description must be %d characters or fewer on the %s tier", tier.DescMax, tier.Label)
 	}
 
-	// Invite URL must be an https Discord link.
-	lowerURL := strings.ToLower(data.InviteURL)
-	if !strings.HasPrefix(lowerURL, "https://") || !strings.Contains(lowerURL, "discord") {
-		return fmt.Errorf("a valid https Discord invite link is required")
+	// Invite URL must be a real Discord *invite* link — not a channel deep-link
+	// (discord.com/channels/...), profile, settings page, etc. Channel links
+	// look superficially valid but Discord can't unfurl them for non-members,
+	// so the post shows up as "Unknown" in the rp-servers channel.
+	if !isDiscordInviteURL(data.InviteURL) {
+		return fmt.Errorf("enter a Discord invite link (discord.gg/… or discord.com/invite/…) — channel links can't be used to join")
 	}
 
 	data.Consoles = cleanStringSlice(data.Consoles, 8)
@@ -464,6 +467,38 @@ func sanitizeRpPromotionData(data *models.RpPromotionData, tier rpTierConfig) er
 	}
 
 	return nil
+}
+
+// isDiscordInviteURL reports whether s is a real Discord *invite* link that
+// Discord will unfurl into an invite card. Accepts:
+//   - https://discord.gg/<code>
+//   - https://(www.|ptb.|canary.)?discord(app)?.com/invite/<code>
+//
+// Rejects channel deep-links (discord.com/channels/<guild>/<channel>), profile
+// URLs, settings pages, etc. — those superficially contain "discord" and pass
+// the old loose check but render as "Unknown" in the destination channel.
+func isDiscordInviteURL(s string) bool {
+	u, err := url.Parse(strings.TrimSpace(s))
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return false
+	}
+	host := strings.ToLower(u.Host)
+	host = strings.TrimPrefix(host, "www.")
+	host = strings.TrimPrefix(host, "ptb.")
+	host = strings.TrimPrefix(host, "canary.")
+	path := strings.Trim(u.Path, "/")
+	switch host {
+	case "discord.gg":
+		return path != "" && !strings.Contains(path, "/")
+	case "discord.com", "discordapp.com":
+		const prefix = "invite/"
+		if !strings.HasPrefix(path, prefix) {
+			return false
+		}
+		code := strings.TrimPrefix(path, prefix)
+		return code != "" && !strings.Contains(code, "/")
+	}
+	return false
 }
 
 // cleanURLSlice trims each entry, drops blanks, and limits the slice to max

--- a/api/handlers/rp_promotion_test.go
+++ b/api/handlers/rp_promotion_test.go
@@ -30,6 +30,26 @@ func TestSanitizeRpPromotionData_Valid(t *testing.T) {
 	}
 }
 
+func TestSanitizeRpPromotionData_AcceptsInviteVariants(t *testing.T) {
+	cases := []string{
+		"https://discord.gg/abc123",
+		"https://discord.com/invite/abc123",
+		"https://discordapp.com/invite/abc123",
+		"https://www.discord.com/invite/abc123",
+		"https://ptb.discord.com/invite/abc123",
+		"https://canary.discord.com/invite/abc123",
+	}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			data := validRpData()
+			data.InviteURL = u
+			if err := sanitizeRpPromotionData(&data, rpTiers["free"]); err != nil {
+				t.Errorf("expected %q to be accepted, got: %v", u, err)
+			}
+		})
+	}
+}
+
 func TestSanitizeRpPromotionData_RequiredFields(t *testing.T) {
 	cases := map[string]func(*models.RpPromotionData){
 		"missing server name": func(d *models.RpPromotionData) { d.ServerName = "  " },
@@ -38,6 +58,13 @@ func TestSanitizeRpPromotionData_RequiredFields(t *testing.T) {
 		"no consoles":         func(d *models.RpPromotionData) { d.Consoles = nil },
 		"non-discord invite":  func(d *models.RpPromotionData) { d.InviteURL = "https://example.com/x" },
 		"non-https invite":    func(d *models.RpPromotionData) { d.InviteURL = "http://discord.gg/x" },
+		"channel deep-link": func(d *models.RpPromotionData) {
+			d.InviteURL = "https://discord.com/channels/1508945617169285264/1508948755867635823"
+		},
+		"discord profile URL": func(d *models.RpPromotionData) {
+			d.InviteURL = "https://discord.com/users/123456789"
+		},
+		"discord.gg with no code": func(d *models.RpPromotionData) { d.InviteURL = "https://discord.gg/" },
 	}
 	for name, mutate := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Tighten the RP server promotion invite-URL validator to only accept real Discord *invite* links (`discord.gg/<code>` or `(www|ptb|canary).discord(app).com/invite/<code>`).
- Channel deep-links (`https://discord.com/channels/<guild>/<channel>`) passed the old loose `https + contains "discord"` check but render as **Unknown** in the rp-servers channel — Discord can't unfurl a channel link for non-members.
- Updated the user-facing error message to point users at the right link shape.

## Why
A real user pasted `https://discord.com/channels/<guild>/<channel>` as their invite link. It was accepted, posted, and showed up as "Unknown" in the promos channel — burning their cooldown for a useless post.

## Test plan
- [x] `go test ./api/handlers/ -run TestSanitizeRpPromotion` — all variants pass, including new rejection cases for channel deep-link, profile URL, and empty `discord.gg/`.
- [ ] Manual: submit a channel link in the promotion modal → see the actionable error.
- [ ] Manual: submit `discord.gg/<code>` and `discord.com/invite/<code>` → both accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)