### PR TITLE
Self-heal legacy pre-permissions communities on load

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -4213,15 +4213,10 @@ func (h Admin) AdminSendEmailHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // isHeadAdminRole identifies the Head Admin role by its permission structure,
-// not by name (since users can rename roles). The Head Admin role has an
-// "administrator" permission with description "Head Admin".
+// not by name (since users can rename roles). Delegates to the canonical
+// implementation in the models package so detection logic lives in one place.
 func isHeadAdminRole(role models.Role) bool {
-	for _, perm := range role.Permissions {
-		if perm.Name == "administrator" && perm.Description == "Head Admin" && perm.Enabled {
-			return true
-		}
-	}
-	return false
+	return models.IsHeadAdminRole(role)
 }
 
 // getClientIP extracts the client IP from the request
@@ -4547,6 +4542,84 @@ func (h Admin) AdminGetCommunityRolesHandler(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"roles": roles,
+	})
+}
+
+// AdminSyncCommunitySchemaHandler brings a legacy community up to the current
+// schema: a Head Admin role granting the owner administrator power (so they can
+// delete/leave/manage their community), plus any default reference data and an
+// initialized members map that pre-permission-system communities never got. It
+// is idempotent and non-destructive — existing values are preserved and a
+// healthy community returns synced=false with no actions and no write.
+func (h Admin) AdminSyncCommunitySchemaHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	communityID := mux.Vars(r)["id"]
+	if communityID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "community ID is required"})
+		return
+	}
+
+	// Body is optional — currentUser drives the permission check when provided.
+	var req struct {
+		CurrentUser map[string]interface{} `json:"currentUser"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "insufficient permissions to sync community schema (requires owner or admin role)"})
+		return
+	}
+
+	cID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid community ID"})
+		return
+	}
+
+	// IncludingPending so a community can be repaired even while pending deletion
+	// (mirrors AdminCommunityDetailsHandler, which admins use for the same docs).
+	community, err := h.CDB.FindOneIncludingPending(r.Context(), bson.M{"_id": cID})
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "community not found"})
+		return
+	}
+
+	actions, err := applyCommunityBackfill(r.Context(), h.CDB, community)
+	if err != nil {
+		log.Printf("failed to sync community schema for %s: %v", communityID, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to sync community schema"})
+		return
+	}
+
+	if len(actions) > 0 {
+		adminEmail, _ := req.CurrentUser["email"].(string)
+		audit := models.AdminAudit{
+			AdminEmail:    adminEmail,
+			Action:        "community_schema_sync",
+			CommunityID:   communityID,
+			CommunityName: community.Details.Name,
+			After:         map[string]interface{}{"actions": actions},
+			Details:       fmt.Sprintf("Synced legacy community schema: %s", strings.Join(actions, ", ")),
+			Timestamp:     time.Now(),
+			IP:            getClientIP(r),
+		}
+		if _, err := h.AuditDB.InsertOne(r.Context(), audit); err != nil {
+			log.Printf("CRITICAL: failed to write audit log for schema sync: %v", err)
+		}
+		h.trackAdminAction(primitive.NilObjectID, "community_schema_sync", communityID, "community",
+			fmt.Sprintf("Synced legacy community %s: %s", community.Details.Name, strings.Join(actions, ", ")), r)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"synced":  len(actions) > 0,
+		"actions": actions,
 	})
 }
 

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -260,6 +260,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/communities/{id}/transfer-ownership", http.HandlerFunc(adminHandler.AdminTransferOwnershipHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/remove-member", http.HandlerFunc(adminHandler.AdminRemoveMemberHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{id}/roles", http.HandlerFunc(adminHandler.AdminGetCommunityRolesHandler)).Methods("GET")
+	apiCreate.Handle("/admin/communities/{id}/sync-schema", http.HandlerFunc(adminHandler.AdminSyncCommunitySchemaHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{community_id}/restore-pending-deletion", http.HandlerFunc(c.RestoreCommunityPendingDeletionHandler)).Methods("POST")
 	apiCreate.Handle("/admin/communities/{community_id}/force-delete", http.HandlerFunc(c.ForceDeleteCommunityHandler)).Methods("POST")
 	// Admin-only smoke test for the cron-alert Discord webhook. POST with

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -251,6 +251,21 @@ func (c Community) CommunityHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Self-healing: bring legacy pre-permissions communities up to the current
+	// schema (a Head Admin role for the owner, default reference data, an
+	// initialized members map) so the owner isn't locked out of their own
+	// community. Idempotent — writes only when something is actually missing,
+	// so healthy communities just read. Re-fetch on repair so this response
+	// reflects the healed document.
+	if actions, healErr := applyCommunityBackfill(ctx, c.DB, dbResp); healErr != nil {
+		zap.S().Warnw("failed to heal legacy community schema", "community_id", commID, "error", healErr)
+	} else if len(actions) > 0 {
+		zap.S().Infow("healed legacy community schema", "community_id", commID, "actions", actions)
+		if healed, refErr := c.DB.FindOneIncludingPending(ctx, filter); refErr == nil {
+			dbResp = healed
+		}
+	}
+
 	// Ensure no role has nil Permissions or Members — nil slices serialize as
 	// JSON null, which crashes mobile clients that call .some() on the array.
 	for i := range dbResp.Details.Roles {
@@ -294,6 +309,22 @@ func (c Community) CommunityHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Write(b)
+}
+
+// applyCommunityBackfill brings a community up to the current schema using the
+// canonical, non-destructive rules in models.BuildCommunityBackfill. It writes
+// only when there is something to repair and returns the list of actions taken
+// (nil when the community was already healthy). Shared by the owner-facing
+// community load path and the admin schema-sync endpoint.
+func applyCommunityBackfill(ctx context.Context, cdb databases.CommunityDatabase, community *models.Community) ([]string, error) {
+	set, actions := models.BuildCommunityBackfill(community)
+	if len(actions) == 0 {
+		return nil, nil
+	}
+	if err := cdb.UpdateOne(ctx, bson.M{"_id": community.ID}, bson.M{"$set": set}); err != nil {
+		return nil, err
+	}
+	return actions, nil
 }
 
 // CreateCommunityHandler creates a new community
@@ -354,65 +385,10 @@ func (c Community) CreateCommunityHandler(w http.ResponseWriter, r *http.Request
 		newCommunity.Details.Events = []models.Event{}
 	}
 
-	// Define the Head Admin role and permission
-	headAdminRole := models.Role{
-		ID:      primitive.NewObjectID(),
-		Name:    "Head Admin",
-		Members: []string{newCommunity.Details.OwnerID},
-		Permissions: []models.Permission{
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "administrator",
-				Description: "Head Admin",
-				Enabled:     true,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage community settings",
-				Description: "Allows managing community settings",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage community events",
-				Description: "Allows managing community events",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage departments",
-				Description: "Allows managing departments",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage roles",
-				Description: "Allows managing roles",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage members",
-				Description: "Allows managing members",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "manage bans",
-				Description: "Allows managing bans",
-				Enabled:     false,
-			},
-			{
-				ID:          primitive.NewObjectID(),
-				Name:        "administrator",
-				Description: "Members with this permission will have every permission and will also bypass all community specific permissions or restrictions (for example, these members would get access to all settings and pages). This is a dangerous permission to grant.",
-				Enabled:     false,
-			},
-		},
-	}
-
-	// Add the Head Admin role to the community
-	newCommunity.Details.Roles = append(newCommunity.Details.Roles, headAdminRole)
+	// Add the Head Admin role to the community. The canonical role lives in the
+	// models package so create-time and the legacy schema-sync stamp identical
+	// roles (see models/community_backfill.go).
+	newCommunity.Details.Roles = append(newCommunity.Details.Roles, models.BuildHeadAdminRole(newCommunity.Details.OwnerID))
 
 	// Use request context with timeout for all database operations
 	ctx, cancel := api.WithQueryTimeout(r.Context())

--- a/models/community_backfill.go
+++ b/models/community_backfill.go
@@ -1,0 +1,188 @@
+package models
+
+import (
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// This file is the single source of truth for "what a current community should
+// look like." Communities created before the permission/roles system are
+// missing fields that newer communities get at creation (a Head Admin role,
+// ten-codes, penal codes, an initialized members map, etc.), which leaves the
+// owner locked out of their own community. CreateCommunityHandler, the
+// admin schema-sync endpoint, the owner-facing community load path, and the
+// batch backfill script all build the same canonical objects from here so a
+// remediated community is indistinguishable from a freshly-created one.
+
+// IsHeadAdminRole identifies the Head Admin role by its permission structure,
+// not by name (owners can rename roles). The Head Admin role has an enabled
+// "administrator" permission whose description is "Head Admin".
+func IsHeadAdminRole(role Role) bool {
+	for _, perm := range role.Permissions {
+		if perm.Name == "administrator" && perm.Description == "Head Admin" && perm.Enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// OwnerHasAdmin reports whether the owner is a member of any role that has an
+// enabled "administrator" permission — i.e. the owner is NOT locked out. This
+// is broader than IsHeadAdminRole on purpose: an owner who holds admin through
+// any role does not need a Head Admin role stamped on them.
+func OwnerHasAdmin(roles []Role, ownerID string) bool {
+	if ownerID == "" {
+		return false
+	}
+	for _, r := range roles {
+		hasOwner := false
+		for _, m := range r.Members {
+			if m == ownerID {
+				hasOwner = true
+				break
+			}
+		}
+		if !hasOwner {
+			continue
+		}
+		for _, p := range r.Permissions {
+			if p.Enabled && strings.EqualFold(p.Name, "administrator") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// BuildHeadAdminRole returns the canonical Head Admin role stamped onto every
+// new community: only the first "administrator"/"Head Admin" permission is
+// enabled; the rest are present-but-disabled so the owner can toggle them.
+func BuildHeadAdminRole(ownerID string) Role {
+	return Role{
+		ID:      primitive.NewObjectID(),
+		Name:    "Head Admin",
+		Members: []string{ownerID},
+		Permissions: []Permission{
+			{ID: primitive.NewObjectID(), Name: "administrator", Description: "Head Admin", Enabled: true},
+			{ID: primitive.NewObjectID(), Name: "manage community settings", Description: "Allows managing community settings", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "manage community events", Description: "Allows managing community events", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "manage departments", Description: "Allows managing departments", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "manage roles", Description: "Allows managing roles", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "manage members", Description: "Allows managing members", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "manage bans", Description: "Allows managing bans", Enabled: false},
+			{ID: primitive.NewObjectID(), Name: "administrator", Description: "Members with this permission will have every permission and will also bypass all community specific permissions or restrictions (for example, these members would get access to all settings and pages). This is a dangerous permission to grant.", Enabled: false},
+		},
+	}
+}
+
+// BuildCommunityBackfill computes a non-destructive, idempotent set of repairs
+// that bring a legacy community up to the current schema. It returns a $set map
+// (keyed by bson path) and a human-readable list of the actions taken. It only
+// fills fields that are missing/empty — existing non-empty values are never
+// overwritten — so re-running on an already-healthy community returns no
+// actions and an empty set (the caller should skip the write in that case).
+//
+// updatedAt is stamped only when at least one repair is made, so a no-op sync
+// does not bump the timestamp.
+func BuildCommunityBackfill(c *Community) (bson.M, []string) {
+	set := bson.M{}
+	var actions []string
+
+	owner := strings.TrimSpace(c.Details.OwnerID)
+
+	// "Owner locked out" — the owner holds admin through no role — is the
+	// defining signal of a pre-permissions legacy community, and the exact set
+	// the batch backfill targets. We gate ALL repairs on it so that any healthy
+	// community (whose owner already has admin) is never written on the hot read
+	// path. There is no realistic way for a non-legacy community to be missing
+	// these fields, so nothing is lost by scoping the repair this way.
+	if owner == "" || OwnerHasAdmin(c.Details.Roles, owner) {
+		return set, actions
+	}
+
+	// Head Admin: prefer attaching the owner to an existing Head Admin role;
+	// otherwise stamp a fresh one. Setting the whole roles array keeps the write
+	// atomic and avoids positional-path pitfalls.
+	headAdminIdx := -1
+	for i := range c.Details.Roles {
+		if IsHeadAdminRole(c.Details.Roles[i]) {
+			headAdminIdx = i
+			break
+		}
+	}
+	newRoles := append([]Role{}, c.Details.Roles...)
+	if headAdminIdx >= 0 {
+		newRoles[headAdminIdx].Members = append(append([]string{}, newRoles[headAdminIdx].Members...), owner)
+		actions = append(actions, "add owner to Head Admin role")
+	} else {
+		newRoles = append(newRoles, BuildHeadAdminRole(owner))
+		actions = append(actions, "add Head Admin role")
+	}
+	set["community.roles"] = newRoles
+
+	// Seed the reference data every current community ships with at creation.
+	// Guards match the create-time defaults: seed only when genuinely empty.
+	if len(c.Details.TenCodes) == 0 {
+		set["community.tenCodes"] = DefaultTenCodes()
+		actions = append(actions, "seed tenCodes")
+	}
+	if c.Details.Fines.Currency == "" && len(c.Details.Fines.Categories) == 0 {
+		set["community.fines"] = DefaultCommunityFines()
+		actions = append(actions, "seed fines")
+	}
+	if len(c.Details.PenalCodes.Categories) == 0 {
+		set["community.penalCodes"] = DefaultCommunityPenalCodes()
+		actions = append(actions, "seed penalCodes")
+	}
+	if c.Details.InviteCodeIds == nil {
+		set["community.inviteCodeIds"] = []string{}
+		actions = append(actions, "init inviteCodeIds")
+	}
+	if c.Details.BanList == nil {
+		set["community.banList"] = []string{}
+		actions = append(actions, "init banList")
+	}
+	if c.Details.Departments == nil {
+		set["community.departments"] = []Department{}
+		actions = append(actions, "init departments")
+	}
+	if c.Details.Events == nil {
+		set["community.events"] = []Event{}
+		actions = append(actions, "init events")
+	}
+	if c.Details.Visibility == "" {
+		set["community.visibility"] = "public"
+		actions = append(actions, "default visibility=public")
+	}
+
+	// Members map + denormalized count: ensure the owner is a member, then make
+	// membersCount agree with the map.
+	_, hasOwnerMember := c.Details.Members[owner]
+	if c.Details.Members == nil {
+		set["community.members"] = map[string]MemberDetail{owner: {}}
+		actions = append(actions, "init members{owner}")
+	} else if !hasOwnerMember {
+		set["community.members."+owner] = MemberDetail{}
+		actions = append(actions, "add owner to members")
+	}
+	expected := len(c.Details.Members)
+	if !hasOwnerMember {
+		expected++
+	}
+	if expected == 0 {
+		expected = 1
+	}
+	if c.Details.MembersCount != expected {
+		set["community.membersCount"] = expected
+		actions = append(actions, "fix membersCount")
+	}
+
+	if len(actions) > 0 {
+		set["community.updatedAt"] = primitive.NewDateTimeFromTime(time.Now())
+	}
+
+	return set, actions
+}

--- a/models/community_backfill_test.go
+++ b/models/community_backfill_test.go
@@ -1,0 +1,121 @@
+package models
+
+import "testing"
+
+func actionsContain(actions []string, want string) bool {
+	for _, a := range actions {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A legacy community (owner set, but no roles array at all) must be brought up
+// to the current schema: a Head Admin role for the owner plus the default
+// reference data and an initialized members map.
+func TestBuildCommunityBackfill_LegacyCommunity(t *testing.T) {
+	c := &Community{Details: CommunityDetails{OwnerID: "owner1"}}
+
+	set, actions := BuildCommunityBackfill(c)
+
+	if len(actions) == 0 {
+		t.Fatal("expected repairs for a legacy community, got none")
+	}
+	if !actionsContain(actions, "add Head Admin role") {
+		t.Errorf("expected a Head Admin role to be added, actions=%v", actions)
+	}
+	for _, key := range []string{
+		"community.roles", "community.tenCodes", "community.fines", "community.penalCodes",
+		"community.inviteCodeIds", "community.banList", "community.departments", "community.events",
+		"community.visibility", "community.members", "community.membersCount", "community.updatedAt",
+	} {
+		if _, ok := set[key]; !ok {
+			t.Errorf("expected $set to include %q, set=%v", key, set)
+		}
+	}
+
+	// The stamped Head Admin role must actually grant the owner admin power.
+	roles, ok := set["community.roles"].([]Role)
+	if !ok {
+		t.Fatalf("community.roles should be []Role, got %T", set["community.roles"])
+	}
+	if !OwnerHasAdmin(roles, "owner1") {
+		t.Error("owner should hold admin after the Head Admin role is stamped")
+	}
+}
+
+// A healthy community whose owner already holds admin must be left completely
+// untouched (no write on the hot read path), even if other fields look sparse.
+func TestBuildCommunityBackfill_HealthyNoop(t *testing.T) {
+	c := &Community{Details: CommunityDetails{
+		OwnerID: "owner1",
+		Roles:   []Role{BuildHeadAdminRole("owner1")},
+	}}
+
+	set, actions := BuildCommunityBackfill(c)
+
+	if len(actions) != 0 {
+		t.Errorf("expected no repairs for a healthy community, got %v", actions)
+	}
+	if len(set) != 0 {
+		t.Errorf("expected an empty $set for a healthy community, got %v", set)
+	}
+}
+
+// Re-running on the already-healed output must be a no-op (idempotency).
+func TestBuildCommunityBackfill_Idempotent(t *testing.T) {
+	c := &Community{Details: CommunityDetails{OwnerID: "owner1"}}
+	set, _ := BuildCommunityBackfill(c)
+
+	healed := &Community{Details: CommunityDetails{
+		OwnerID: "owner1",
+		Roles:   set["community.roles"].([]Role),
+	}}
+	if _, actions := BuildCommunityBackfill(healed); len(actions) != 0 {
+		t.Errorf("second pass should be a no-op for the owner-admin gate, got %v", actions)
+	}
+}
+
+// When a Head Admin role exists but the owner is not in it (and holds admin
+// nowhere else), the owner is added to the existing role rather than a second
+// Head Admin role being created.
+func TestBuildCommunityBackfill_AddOwnerToExistingHeadAdmin(t *testing.T) {
+	existing := BuildHeadAdminRole("someoneElse") // enabled admin, owner not a member
+	c := &Community{Details: CommunityDetails{
+		OwnerID: "owner1",
+		Roles:   []Role{existing},
+	}}
+
+	set, actions := BuildCommunityBackfill(c)
+
+	if !actionsContain(actions, "add owner to Head Admin role") {
+		t.Errorf("expected the owner to be added to the existing Head Admin role, actions=%v", actions)
+	}
+	roles := set["community.roles"].([]Role)
+	if len(roles) != 1 {
+		t.Errorf("expected no duplicate Head Admin role, got %d roles", len(roles))
+	}
+	if !OwnerHasAdmin(roles, "owner1") {
+		t.Error("owner should hold admin after being added to the existing Head Admin role")
+	}
+}
+
+// An empty owner ID cannot be repaired and must be a no-op.
+func TestBuildCommunityBackfill_NoOwner(t *testing.T) {
+	c := &Community{Details: CommunityDetails{OwnerID: ""}}
+	if _, actions := BuildCommunityBackfill(c); len(actions) != 0 {
+		t.Errorf("expected no-op when ownerID is empty, got %v", actions)
+	}
+}
+
+func TestIsHeadAdminRole(t *testing.T) {
+	if !IsHeadAdminRole(BuildHeadAdminRole("o")) {
+		t.Error("BuildHeadAdminRole output should be detected as the Head Admin role")
+	}
+	// Disabled admin permission must NOT count as Head Admin.
+	disabled := Role{Permissions: []Permission{{Name: "administrator", Description: "Head Admin", Enabled: false}}}
+	if IsHeadAdminRole(disabled) {
+		t.Error("a disabled administrator permission should not be a Head Admin role")
+	}
+}

--- a/scripts/backfill_legacy_community_permissions/main.go
+++ b/scripts/backfill_legacy_community_permissions/main.go
@@ -195,7 +195,7 @@ func main() {
 			skippedDecode++
 			continue
 		}
-		if ownerHasAdmin(doc.Details.Roles, owner) {
+		if models.OwnerHasAdmin(doc.Details.Roles, owner) {
 			alreadyFine++
 			continue
 		}
@@ -245,7 +245,7 @@ func main() {
 		actions := []string{}
 
 		newRoles := append([]models.Role{}, doc.Details.Roles...)
-		newRoles = append(newRoles, headAdminRole(owner))
+		newRoles = append(newRoles, models.BuildHeadAdminRole(owner))
 		set["community.roles"] = newRoles
 		actions = append(actions, "add Head Admin role")
 
@@ -377,32 +377,6 @@ func main() {
 	}
 }
 
-// ownerHasAdmin reports whether any role contains ownerID AND has an enabled
-// permission named "administrator".
-func ownerHasAdmin(roles []models.Role, ownerID string) bool {
-	if ownerID == "" {
-		return false
-	}
-	for _, r := range roles {
-		hasOwner := false
-		for _, m := range r.Members {
-			if m == ownerID {
-				hasOwner = true
-				break
-			}
-		}
-		if !hasOwner {
-			continue
-		}
-		for _, p := range r.Permissions {
-			if p.Enabled && strings.EqualFold(p.Name, "administrator") {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // ownerHasAdminOnAnotherCommunity returns true if the owner has administrator
 // in any community whose _id is NOT excludeID. Indicates the user migrated
 // successfully and this candidate is likely the abandoned legacy leftover.
@@ -432,28 +406,9 @@ func ownerHasAdminOnAnotherCommunity(ctx context.Context, communities *mongo.Col
 		if err := cur.Decode(&doc); err != nil {
 			continue
 		}
-		if ownerHasAdmin(doc.Details.Roles, ownerID) {
+		if models.OwnerHasAdmin(doc.Details.Roles, ownerID) {
 			return true, nil
 		}
 	}
 	return false, cur.Err()
-}
-
-// headAdminRole mirrors the role stamped by CreateCommunityHandler.
-func headAdminRole(ownerID string) models.Role {
-	return models.Role{
-		ID:      primitive.NewObjectID(),
-		Name:    "Head Admin",
-		Members: []string{ownerID},
-		Permissions: []models.Permission{
-			{ID: primitive.NewObjectID(), Name: "administrator", Description: "Head Admin", Enabled: true},
-			{ID: primitive.NewObjectID(), Name: "manage community settings", Description: "Allows managing community settings", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "manage community events", Description: "Allows managing community events", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "manage departments", Description: "Allows managing departments", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "manage roles", Description: "Allows managing roles", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "manage members", Description: "Allows managing members", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "manage bans", Description: "Allows managing bans", Enabled: false},
-			{ID: primitive.NewObjectID(), Name: "administrator", Description: "Members with this permission will have every permission and will also bypass all community specific permissions or restrictions (for example, these members would get access to all settings and pages). This is a dangerous permission to grant.", Enabled: false},
-		},
-	}
 }


### PR DESCRIPTION
## Problem

Communities created before the roles/permissions system (e.g. "ventura county", created 2023-10-16) have **no `community.roles` array at all** — and often lack tenCodes, penalCodes, fines, departments, and a complete members map. With no Head Admin role, the **owner has no administrator permission and is locked out of their own community** (can't delete, leave, or manage it). The admin Cases · Head Admin step surfaced this as "`<owner>` is NOT in the Head Admin role" with no way to fix it.

## Approach

An **idempotent, non-destructive schema sync** that runs when a community is loaded and brings legacy communities up to the current create-time schema. It acts **only when the owner is locked out** (holds admin through no role) — the exact set the batch backfill targets — so healthy communities are **never written** on the hot read path.

## Changes

- **`models/community_backfill.go`** (new, unit-tested) — single source of truth: `IsHeadAdminRole`, `OwnerHasAdmin`, `BuildHeadAdminRole`, and `BuildCommunityBackfill` (returns a `$set` map + human-readable action list; empty when nothing to repair).
- **Dedup**: `CreateCommunityHandler`, `admin.isHeadAdminRole`, and `scripts/backfill_legacy_community_permissions` now reuse these shared helpers — removes 3 duplicate copies of the canonical Head Admin role / detection logic.
- **`CommunityHandler`** heals on the owner-facing load path (silent, `zap` log).
- **`POST /admin/communities/{id}/sync-schema`** (`AdminSyncCommunitySchemaHandler`, audited) lets the admin Cases workflow repair-before-render and report what changed.

## Safety / idempotency

- Strictly additive — existing non-empty values are never overwritten.
- Re-running on a healthy/healed community returns no actions and performs no write (verified by unit tests).
- `updatedAt` is bumped only when a repair is actually made.

## Tests

- `go build ./...` ✅ · `go test ./models/` ✅ (legacy heal, healthy no-op, idempotency, add-owner-to-existing-head-admin, empty-owner, IsHeadAdminRole).

Pairs with the police-cad PR (admin-console calls the new sync endpoint on case open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)