### PR TITLE
fix: enforce authorization on community rank & role mutations

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -1139,6 +1139,15 @@ func (c Community) AddRoleToCommunityHandler(w http.ResponseWriter, r *http.Requ
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
+
 	// Update the community to add the new role
 	filter := bson.M{"_id": cID}
 	update := bson.M{"$push": bson.M{"community.roles": role}}
@@ -1189,6 +1198,15 @@ func (c Community) UpdateRoleMembersHandler(w http.ResponseWriter, r *http.Reque
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
+
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
 
 	filter := bson.M{"_id": cID, "community.roles._id": rID}
 	update := bson.M{
@@ -1242,6 +1260,15 @@ func (c Community) UpdateRoleNameHandler(w http.ResponseWriter, r *http.Request)
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
+
 	// Update the role name in the community
 	filter := bson.M{"_id": cID, "community.roles._id": rID}
 	update := bson.M{"$set": bson.M{"community.roles.$.name": requestBody.Name}}
@@ -1279,6 +1306,15 @@ func (c Community) DeleteRoleByIDHandler(w http.ResponseWriter, r *http.Request)
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
+
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
 
 	// Update the community to pull the role by ID
 	filter := bson.M{"_id": cID}
@@ -1331,6 +1367,10 @@ func (c Community) ReorderRolesHandler(w http.ResponseWriter, r *http.Request) {
 	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
 	if err != nil {
 		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
 		return
 	}
 
@@ -1431,6 +1471,15 @@ func (c Community) UpdateRolePermissionsHandler(w http.ResponseWriter, r *http.R
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
+
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
 
 	// Update the role permissions in the community
 	filter := bson.M{"_id": cID, "community.roles._id": rID}
@@ -2320,10 +2369,22 @@ func (c Community) DeleteRoleMemberHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+	if !authorizeCommunityAction(w, r, community, "manage roles") {
+		return
+	}
+
 	// Update the community to pull the member from the role
 	filter := bson.M{"_id": cID, "community.roles._id": rID}
 	update := bson.M{"$pull": bson.M{"community.roles.$.members": memberID}}
-	err = c.DB.UpdateOne(context.Background(), filter, update)
+	err = c.DB.UpdateOne(ctx, filter, update)
 	if err != nil {
 		config.ErrorStatus("failed to delete role member", http.StatusInternalServerError, w, err)
 		return
@@ -2981,6 +3042,23 @@ func (c Community) GetDepartmentCallSignsHandler(w http.ResponseWriter, r *http.
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"departmentCallSigns": callSigns,
 	})
+}
+
+// authorizeCommunityAction verifies the requester (resolved from the request) is the
+// community owner or holds one of the given permissions on the already-loaded community.
+// On failure it writes the appropriate error response (401 if the caller cannot be
+// identified, 403 if they lack permission) and returns false.
+func authorizeCommunityAction(w http.ResponseWriter, r *http.Request, community *models.Community, permissionNames ...string) bool {
+	actorID := resolveActorFromRequest(r)
+	if actorID == "" {
+		config.ErrorStatus("unauthorized", http.StatusUnauthorized, w, fmt.Errorf("no authenticated user"))
+		return false
+	}
+	if !userHasCommunityPermission(community, actorID, permissionNames...) {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, fmt.Errorf("user %s lacks required permission", actorID))
+		return false
+	}
+	return true
 }
 
 // userHasCommunityPermission checks if a user is the community owner or has a role

--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -122,6 +122,10 @@ func (c Community) CreateRankHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
+		return
+	}
+
 	deptIdx, dept := findDepartment(community, departmentID)
 	if dept == nil {
 		config.ErrorStatus("department not found", http.StatusNotFound, w, fmt.Errorf("department not found"))
@@ -202,6 +206,10 @@ func (c Community) UpdateRankHandler(w http.ResponseWriter, r *http.Request) {
 	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
 	if err != nil {
 		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
 		return
 	}
 
@@ -324,6 +332,10 @@ func (c Community) DeleteRankHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
+		return
+	}
+
 	_, dept := findDepartment(community, departmentID)
 	if dept == nil {
 		config.ErrorStatus("department not found", http.StatusNotFound, w, fmt.Errorf("department not found"))
@@ -412,6 +424,10 @@ func (c Community) ReorderRanksHandler(w http.ResponseWriter, r *http.Request) {
 	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
 	if err != nil {
 		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
 		return
 	}
 
@@ -1191,6 +1207,10 @@ func (c Community) AssignMemberRankHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
+		return
+	}
+
 	deptIdx, dept := findDepartment(community, departmentID)
 	if dept == nil {
 		config.ErrorStatus("department not found", http.StatusNotFound, w, fmt.Errorf("department not found"))
@@ -1442,6 +1462,10 @@ func (c Community) CheckAllPromotionsHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
+		return
+	}
+
 	deptIdx, dept := findDepartment(community, departmentID)
 	if dept == nil {
 		config.ErrorStatus("department not found", http.StatusNotFound, w, fmt.Errorf("department not found"))
@@ -1650,6 +1674,10 @@ func (c Community) ToggleCustomRequirementHandler(w http.ResponseWriter, r *http
 	community, err := c.DB.FindOne(ctx, bson.M{"_id": cID})
 	if err != nil {
 		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	if !authorizeCommunityAction(w, r, community, "manage departments") {
 		return
 	}
 


### PR DESCRIPTION
## Security fix

Community **rank** and **role** management endpoints performed writes **without any authorization check**. Any authenticated community member — or anyone able to supply a `userId` — could create/edit/delete/reorder/assign **ranks** and create/edit/delete **roles**, edit role permissions, and add/remove role members in **any** community. The handlers only resolved the caller for audit logging, never for access control.

Reported from the mobile app: a regular member could open a member's detail page, reach *Manage Ranks*, and actually delete ranks. Root cause was the backend, not just the hidden-button UI.

## What changed

New shared helper `authorizeCommunityAction(w, r, community, ...perms)` in `community.go` — mirrors the existing `userHasCommunityPermission` pattern used by the audit-log and call-sign handlers:
- 401 if the caller can't be resolved
- 403 if they lack the permission
- community **owner** and **"administrator"** always pass

Applied to every mutating handler:

| Area | Handlers | Permission |
|------|----------|------------|
| Ranks (`rank.go`) | Create, Update, Delete, Reorder, AssignMemberRank, ToggleCustomRequirement, CheckAllPromotions | `manage departments` |
| Roles (`community.go`) | AddRole, UpdateRoleMembers, UpdateRoleName, DeleteRoleByID, ReorderRoles, UpdateRolePermissions, DeleteRoleMember | `manage roles` |

Permission strings mirror how the website/mobile already gate these surfaces. Role handlers that didn't previously load the community now fetch it before the check.

## Base branch

Targets `feature/fix-firearm-stolen-status` (not `main`) so it deploys alongside that branch.

## Known limitation (pre-existing, not addressed here)

When the in-memory token cache misses (e.g. after an API restart) these endpoints fall back to a forgeable `?userId=` query param. That weakness is **systemic across the entire API** and predates this change; fixing it (mandatory/persistent tokens) is a separate, larger effort. This PR closes the actual reported exploit and matches the codebase's established security pattern.

## Testing
- `go build ./...` ✅
- `go test ./api/handlers/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)