### PR TITLE
fix(forms): 409 for duplicate slug + scrub DB internals from API errors

### DIFF
--- a/api/handlers/formTemplate.go
+++ b/api/handlers/formTemplate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/linesmerrill/police-cad-api/api"
@@ -86,6 +87,17 @@ func (h FormTemplate) CreateFormTemplateHandler(w http.ResponseWriter, r *http.R
 	defer cancel()
 
 	if _, err := h.DB.InsertOne(ctx, tpl); err != nil {
+		// The unique (communityID, slug) index rejects a slug already in use by
+		// this community. Surface that as a clean 409 the user can act on rather
+		// than a generic 500.
+		if mongo.IsDuplicateKeyError(err) {
+			config.ErrorStatus(
+				fmt.Sprintf("a form with slug %q already exists in this community", body.Slug),
+				http.StatusConflict, w,
+				fmt.Errorf("duplicate form template slug %q for community %q", body.Slug, body.CommunityID),
+			)
+			return
+		}
 		config.ErrorStatus("failed to create form template", http.StatusInternalServerError, w, err)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.uber.org/zap"
 
 	"github.com/linesmerrill/police-cad-api/models"
@@ -51,7 +53,7 @@ func InfoStatus(message string, httpStatusCode int, w http.ResponseWriter, err e
 	w.WriteHeader(httpStatusCode)
 	var errorMsg string
 	if err != nil {
-		errorMsg = err.Error()
+		errorMsg = safeClientError(err)
 	} else {
 		errorMsg = message
 	}
@@ -71,13 +73,36 @@ func ErrorStatus(message string, httpStatusCode int, w http.ResponseWriter, err 
 	w.WriteHeader(httpStatusCode)
 	var errorMsg string
 	if err != nil {
-		errorMsg = err.Error()
+		errorMsg = safeClientError(err)
 	} else {
 		errorMsg = message
 	}
 	b, _ := json.Marshal(models.ErrorMessageResponse{Response: models.MessageError{Message: message, Error: errorMsg}})
 	w.Write(b)
 	return
+}
+
+// safeClientError returns a client-safe representation of err. Raw MongoDB
+// driver errors embed server-side internals — the database name, collection,
+// index names, and document IDs — which must never reach an API client. Those
+// are scrubbed down to a generic string here; the full error is still logged
+// server-side by the caller (ErrorStatus/InfoStatus log via zap before calling
+// this). Application errors built with fmt.Errorf carry no internals and pass
+// through unchanged so callers keep their human-readable messages.
+func safeClientError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if mongo.IsDuplicateKeyError(err) {
+		return "resource already exists"
+	}
+	var writeErr mongo.WriteException
+	var cmdErr mongo.CommandError
+	var bulkErr mongo.BulkWriteException
+	if errors.As(err, &writeErr) || errors.As(err, &cmdErr) || errors.As(err, &bulkErr) {
+		return "a database error occurred"
+	}
+	return err.Error()
 }
 
 // setLogger is a helper function to set the logger based on the environment

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+
+	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -23,6 +26,43 @@ func TestErrorStatus(t *testing.T) {
 
 	ErrorStatus("error it borked", http.StatusBadRequest, httptest.NewRecorder(), errors.New("bad request"))
 	assert.True(t, true)
+}
+
+// rawMongoLeak mimics the server-side detail a real Mongo driver error carries:
+// the database name, collection, and index. None of it may reach a client.
+const rawMongoLeak = `heroku_jfpckj4d0.formTemplates index: formTemplate_community_slug_unique`
+
+func TestSafeClientErrorScrubsDuplicateKey(t *testing.T) {
+	dupErr := mongo.WriteException{
+		WriteErrors: mongo.WriteErrors{{
+			Code:    11000,
+			Message: "E11000 duplicate key error collection: " + rawMongoLeak,
+		}},
+	}
+
+	got := safeClientError(dupErr)
+
+	assert.Equal(t, "resource already exists", got)
+	assert.NotContains(t, got, "heroku_")
+	assert.NotContains(t, got, "formTemplates")
+}
+
+func TestSafeClientErrorScrubsGenericMongoError(t *testing.T) {
+	cmdErr := mongo.CommandError{Code: 26, Message: "ns not found: " + rawMongoLeak}
+
+	got := safeClientError(cmdErr)
+
+	assert.Equal(t, "a database error occurred", got)
+	assert.False(t, strings.Contains(got, "heroku_"))
+}
+
+func TestSafeClientErrorPassesThroughAppErrors(t *testing.T) {
+	got := safeClientError(fmt.Errorf("slug is required"))
+	assert.Equal(t, "slug is required", got)
+}
+
+func TestSafeClientErrorNil(t *testing.T) {
+	assert.Equal(t, "", safeClientError(nil))
 }
 
 func TestSetLoggerSetsDevelopmentLogger(t *testing.T) {


### PR DESCRIPTION
## Problem
Creating a form template whose slug is already used by the community failed with a raw **HTTP 500** whose body leaked the database name (`heroku_jfpckj4d0`), collection, and index name — the Mongo driver's `E11000` error echoed straight to the browser. This leak affected **every** API endpoint, not just forms.

## Fix
- **`CreateFormTemplateHandler`** now detects the duplicate-key error and returns a clean **409 Conflict** with a user-actionable message (`a form with slug "p" already exists in this community`).
- **`config.ErrorStatus` / `InfoStatus`** scrub Mongo driver internals (DB name, collection, index, doc IDs) from the client-facing `error` field globally. The full error is still logged server-side via zap. App errors built with `fmt.Errorf` pass through unchanged.
- Added `config_test.go` cases proving dup-key and generic Mongo errors are scrubbed and app messages survive.

## Verify
- `go test ./config/...` — green.
- POST a second `/api/v1/form-template` with an existing slug → 409, body contains no `heroku_`/collection/index text.

Paired frontend PR surfaces `response.message` instead of dumping the raw body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)