### PR TITLE
RP server promo moderation: admin endpoints, escalating bans, enforcement

### DIFF
--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -35,10 +35,10 @@ import (
 //	POST /api/v1/admin/rp-promos/offenses            — list offenses (banned-users view)
 //	POST /api/v1/admin/rp-promos/offenses/{id}/reverse — overturn an offense on appeal
 //
-// All are owner-only, authorized via checkAdminPermissions against the
-// self-asserted currentUser in the body — the same pattern every other admin
-// console endpoint uses (the console is only rendered to a session-
-// authenticated admin).
+// All require staff (admin or owner), authorized via
+// checkAdminOrOwnerPermissions against the self-asserted currentUser in the
+// body — the same pattern every other admin console endpoint uses (the console
+// is only rendered to a session-authenticated admin).
 
 const (
 	rpPromoModerationToSURL     = "https://www.linespolice-cad.com/terms-and-conditions"
@@ -171,6 +171,18 @@ func rpPromoNormalizeName(s string) string {
 	return rpPromoNonAlnum.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")
 }
 
+// rpPromoIgnoredOwners are internal test accounts (by username, lowercased)
+// whose promotions are excluded from duplicate detection so they never produce
+// false-positive flags.
+var rpPromoIgnoredOwners = map[string]bool{
+	"thecandyman": true,
+	"lpswebsite":  true,
+}
+
+func rpPromoIsIgnoredOwner(username string) bool {
+	return rpPromoIgnoredOwners[strings.ToLower(strings.TrimSpace(username))]
+}
+
 // rpPromoNormalizeInvite canonicalizes a Discord invite for duplicate matching:
 // lowercased, trimmed, scheme/host-prefix removed, and trailing slash dropped,
 // so "https://discord.gg/abc" and "discord.gg/abc/" match.
@@ -248,7 +260,7 @@ type rpPromoAggRow struct {
 
 // AdminListRpPromosHandler returns every promotion across all communities,
 // newest first, annotated with advisory duplicate flags and the owner's current
-// ban status. Owner-only.
+// ban status. Staff (admin or owner).
 func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -263,7 +275,7 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
@@ -294,6 +306,20 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	banned := c.inForceBannedUserSet(ctx)
+	nameCache := map[string]string{}
+	resolveName := func(id string) string {
+		if id == "" {
+			return ""
+		}
+		if v, ok := nameCache[id]; ok {
+			return v
+		}
+		v := resolveActorName(c.UDB, id)
+		nameCache[id] = v
+		return v
+	}
+
 	// First pass: tally the set of DISTINCT communities behind each invite and
 	// each name. Only cross-community reuse is suspicious — one community
 	// re-promoting on different days (respecting the cooldown) is fine.
@@ -303,10 +329,14 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 	// (key = name + ownerID): generic names like "San Andreas State Roleplay"
 	// collide across unrelated communities constantly, so a name match only
 	// signals evasion when the SAME owner is behind both communities (the
-	// "spin up a near-identical community" pattern).
+	// "spin up a near-identical community" pattern). Internal test accounts are
+	// skipped entirely so they never produce flags.
 	inviteCommunities := map[string]map[string]bool{} // invite -> set of communityIds
 	nameCommunities := map[string]map[string]bool{}   // name+ownerID -> set of communityIds
 	for _, row := range rows {
+		if rpPromoIsIgnoredOwner(resolveName(row.OwnerID)) {
+			continue
+		}
 		cid := row.CommunityID.Hex()
 		if inv := rpPromoNormalizeInvite(row.Post.Data.InviteURL); inv != "" {
 			if inviteCommunities[inv] == nil {
@@ -323,20 +353,6 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	banned := c.inForceBannedUserSet(ctx)
-	nameCache := map[string]string{}
-	resolveName := func(id string) string {
-		if id == "" {
-			return ""
-		}
-		if v, ok := nameCache[id]; ok {
-			return v
-		}
-		v := resolveActorName(c.UDB, id)
-		nameCache[id] = v
-		return v
-	}
-
 	// Second pass: build items, assigning each a duplicate group when its invite
 	// or name is shared across communities. Invite match takes precedence (a
 	// reused invite is the strongest "same server" signal); name is the
@@ -345,14 +361,16 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 	items := make([]adminRpPromoItem, 0, len(rows))
 	for _, row := range rows {
 		p := row.Post
+		ownerName := resolveName(row.OwnerID)
+		ignored := rpPromoIsIgnoredOwner(ownerName)
 		inv := rpPromoNormalizeInvite(p.Data.InviteURL)
 		nm := rpPromoNormalizeName(p.Data.ServerName)
 		nameKey := ""
 		if nm != "" {
 			nameKey = nm + "\x00" + row.OwnerID
 		}
-		dupInvite := inv != "" && len(inviteCommunities[inv]) > 1
-		dupName := nameKey != "" && len(nameCommunities[nameKey]) > 1
+		dupInvite := !ignored && inv != "" && len(inviteCommunities[inv]) > 1
+		dupName := !ignored && nameKey != "" && len(nameCommunities[nameKey]) > 1
 
 		postedByName := p.PostedByName
 		if postedByName == "" {
@@ -362,7 +380,7 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			CommunityID:   row.CommunityID.Hex(),
 			CommunityName: row.CommunityName,
 			OwnerID:       row.OwnerID,
-			OwnerName:     resolveName(row.OwnerID),
+			OwnerName:     ownerName,
 			PostID:        p.ID,
 			PostedBy:      p.PostedBy,
 			PostedByName:  postedByName,
@@ -456,7 +474,7 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 }
 
 // AdminDeleteRpPromoHandler removes a single promotion from the Discord channel
-// and marks its history entry removed (retained as evidence). Owner-only.
+// and marks its history entry removed (retained as evidence). Staff (admin or owner).
 func (c Community) AdminDeleteRpPromoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -470,7 +488,7 @@ func (c Community) AdminDeleteRpPromoHandler(w http.ResponseWriter, r *http.Requ
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
@@ -580,7 +598,7 @@ func evidenceEmailLines(ev []models.RpPromoEvidence) []templates.RpPromoOffenseE
 }
 
 // AdminRpPromoBanPreviewHandler computes the penalty that would apply and
-// renders the evidence email, without writing anything. Owner-only.
+// renders the evidence email, without writing anything. Staff (admin or owner).
 func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -594,7 +612,7 @@ func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
@@ -653,7 +671,7 @@ func renderOffenseEmail(username string, offenseNumber int, expiresAt *primitive
 
 // AdminRpPromoBanHandler issues an escalating ban against a user, optionally
 // removes their live promos from Discord, and sends the evidence email.
-// Owner-only.
+// Staff (admin or owner).
 func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -669,7 +687,7 @@ func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
@@ -816,7 +834,7 @@ func (e *sendgridStatusError) Error() string {
 }
 
 // AdminListRpPromoOffensesHandler lists offenses for the banned-users view,
-// optionally filtered to one user or to currently in-force bans. Owner-only.
+// optionally filtered to one user or to currently in-force bans. Staff (admin or owner).
 func (c Community) AdminListRpPromoOffensesHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -829,7 +847,7 @@ func (c Community) AdminListRpPromoOffensesHandler(w http.ResponseWriter, r *htt
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
@@ -892,7 +910,7 @@ func (c Community) AdminListRpPromoOffensesHandler(w http.ResponseWriter, r *htt
 }
 
 // AdminReverseRpPromoOffenseHandler overturns an offense on appeal — it stops
-// counting toward escalation and lifts the ban. Owner-only.
+// counting toward escalation and lifts the ban. Staff (admin or owner).
 func (c Community) AdminReverseRpPromoOffenseHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -911,7 +929,7 @@ func (c Community) AdminReverseRpPromoOffenseHandler(w http.ResponseWriter, r *h
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
 	}
-	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -435,10 +435,16 @@ func (c Community) computeRpPromoItems(ctx context.Context) ([]adminRpPromoItem,
 	// collide across unrelated communities constantly, so a name match only
 	// signals evasion when the SAME owner is behind both communities. Internal
 	// test accounts are skipped entirely so they never produce flags.
+	//
+	// Removed posts are excluded from the tally: a "duplicate" is two or more
+	// LIVE posts sharing an invite/name. Once staff remove the offending posts
+	// (or remove-with-ban), the set drops below two live members and stops being
+	// flagged — so a set never lingers in "possible duplicates" after it's been
+	// actioned. This mirrors the sidebar badge, which also counts live members.
 	inviteCommunities := map[string]map[string]bool{} // invite -> set of communityIds
 	nameCommunities := map[string]map[string]bool{}   // name+ownerID -> set of communityIds
 	for _, row := range rows {
-		if rpPromoIsIgnoredOwner(resolveName(row.OwnerID)) {
+		if rpPromoIsIgnoredOwner(resolveName(row.OwnerID)) || row.Post.RemovedAt != nil {
 			continue
 		}
 		cid := row.CommunityID.Hex()
@@ -470,8 +476,9 @@ func (c Community) computeRpPromoItems(ctx context.Context) ([]adminRpPromoItem,
 		if nm != "" {
 			nameKey = nm + "\x00" + row.OwnerID
 		}
-		dupInvite := !ignored && inv != "" && len(inviteCommunities[inv]) > 1
-		dupName := !ignored && nameKey != "" && len(nameCommunities[nameKey]) > 1
+		removed := p.RemovedAt != nil
+		dupInvite := !ignored && !removed && inv != "" && len(inviteCommunities[inv]) > 1
+		dupName := !ignored && !removed && nameKey != "" && len(nameCommunities[nameKey]) > 1
 
 		postedByName := p.PostedByName
 		if postedByName == "" {
@@ -830,6 +837,14 @@ type rpPromoBanPlan struct {
 	UserOffense      *models.RpPromoOffense
 	CommunityOffense *models.RpPromoOffense
 	Notifications    []rpPromoNotification
+
+	// A scope already under an in-force ban is NOT re-issued — re-banning would
+	// stack a second offense and over-escalate. We surface the existing ban
+	// instead so the UI can disable that scope and the handler can skip it.
+	UserAlreadyInForce      bool
+	UserInForceUntil        string // RFC3339, or "permanent"
+	CommunityAlreadyInForce bool
+	CommunityInForceUntil   string
 }
 
 // resolveCommunityOwnerContact returns the owner email/username and the
@@ -871,32 +886,44 @@ func (c Community) buildRpPromoBanPlan(ctx context.Context, req adminRpPromoBanR
 	}
 
 	if req.BanUser {
-		prior, _ := c.countActiveRpPromoOffenses(ctx, req.UserID)
-		n := int(prior) + 1
-		exp := rpPromoOffenseExpiry(n, now)
-		email, username := resolveUserContact(c.UDB, req.UserID)
-		plan.UserOffense = &models.RpPromoOffense{
-			Scope: models.RpPromoOffenseScopeUser, UserID: req.UserID, Username: username, Email: email,
-			OffenseNumber: n, Reason: reason, Evidence: evidence, IssuedBy: adminEmail,
-			IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
+		if existing := c.activeRpPromoBan(ctx, "", req.UserID); existing != nil {
+			// Already restricted — don't stack another offense.
+			plan.UserAlreadyInForce = true
+			plan.UserInForceUntil = offenseExpiresStr(existing)
+		} else {
+			prior, _ := c.countActiveRpPromoOffenses(ctx, req.UserID)
+			n := int(prior) + 1
+			exp := rpPromoOffenseExpiry(n, now)
+			email, username := resolveUserContact(c.UDB, req.UserID)
+			plan.UserOffense = &models.RpPromoOffense{
+				Scope: models.RpPromoOffenseScopeUser, UserID: req.UserID, Username: username, Email: email,
+				OffenseNumber: n, Reason: reason, Evidence: evidence, IssuedBy: adminEmail,
+				IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
+			}
+			add(email, username, rpPromoRestrictionLine{Scope: "user", Label: "your account", OffenseNumber: n, ExpiresAt: exp})
 		}
-		add(email, username, rpPromoRestrictionLine{Scope: "user", Label: "your account", OffenseNumber: n, ExpiresAt: exp})
 	}
 
 	if req.BanCommunity {
-		prior, _ := c.countActiveRpPromoCommunityOffenses(ctx, req.CommunityID)
-		n := int(prior) + 1
-		exp := rpPromoOffenseExpiry(n, now)
-		ownerEmail, ownerName, commName := c.resolveCommunityOwnerContact(ctx, req.CommunityID)
-		if commName == "" {
-			commName = req.CommunityName
+		if existing := c.activeRpPromoBan(ctx, req.CommunityID); existing != nil {
+			// Already restricted — don't stack another offense.
+			plan.CommunityAlreadyInForce = true
+			plan.CommunityInForceUntil = offenseExpiresStr(existing)
+		} else {
+			prior, _ := c.countActiveRpPromoCommunityOffenses(ctx, req.CommunityID)
+			n := int(prior) + 1
+			exp := rpPromoOffenseExpiry(n, now)
+			ownerEmail, ownerName, commName := c.resolveCommunityOwnerContact(ctx, req.CommunityID)
+			if commName == "" {
+				commName = req.CommunityName
+			}
+			plan.CommunityOffense = &models.RpPromoOffense{
+				Scope: models.RpPromoOffenseScopeCommunity, CommunityID: req.CommunityID, CommunityName: commName,
+				Username: ownerName, Email: ownerEmail, OffenseNumber: n, Reason: reason, Evidence: evidence,
+				IssuedBy: adminEmail, IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
+			}
+			add(ownerEmail, ownerName, rpPromoRestrictionLine{Scope: "community", Label: `the community "` + commName + `"`, OffenseNumber: n, ExpiresAt: exp})
 		}
-		plan.CommunityOffense = &models.RpPromoOffense{
-			Scope: models.RpPromoOffenseScopeCommunity, CommunityID: req.CommunityID, CommunityName: commName,
-			Username: ownerName, Email: ownerEmail, OffenseNumber: n, Reason: reason, Evidence: evidence,
-			IssuedBy: adminEmail, IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
-		}
-		add(ownerEmail, ownerName, rpPromoRestrictionLine{Scope: "community", Label: `the community "` + commName + `"`, OffenseNumber: n, ExpiresAt: exp})
 	}
 
 	// Stable order (by email) so previews and tests are deterministic.
@@ -999,6 +1026,15 @@ func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.
 			"ownerEmail":    plan.CommunityOffense.Email,
 			"ownerUsername": plan.CommunityOffense.Username,
 		}
+	}
+	// Scopes already under an in-force ban can't be re-banned (would over-escalate).
+	if plan.UserAlreadyInForce {
+		resp["userAlreadyInForce"] = true
+		resp["userInForceUntil"] = plan.UserInForceUntil
+	}
+	if plan.CommunityAlreadyInForce {
+		resp["communityAlreadyInForce"] = true
+		resp["communityInForceUntil"] = plan.CommunityInForceUntil
 	}
 	_ = json.NewEncoder(w).Encode(resp)
 }
@@ -1119,6 +1155,19 @@ func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request
 		"message":      "ban issued",
 		"emailsSent":   emailsSent,
 		"removedPosts": removed,
+	}
+	// Scopes already under an in-force ban are reported back (not re-issued) so
+	// the UI can explain why no new offense was recorded for them.
+	if plan.UserAlreadyInForce {
+		resp["userAlreadyInForce"] = true
+		resp["userInForceUntil"] = plan.UserInForceUntil
+	}
+	if plan.CommunityAlreadyInForce {
+		resp["communityAlreadyInForce"] = true
+		resp["communityInForceUntil"] = plan.CommunityInForceUntil
+	}
+	if plan.UserOffense == nil && plan.CommunityOffense == nil {
+		resp["message"] = "already restricted — no new offense issued"
 	}
 
 	insert := func(o *models.RpPromoOffense, key, scope, targetID, targetName string) {

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	rpPromoModerationToSURL     = "https://www.linespolice-cad.com/terms-and-conditions"
-	rpPromoModerationAppealInfo = "If you believe this is a mistake, open a ticket in the assistance channel of the Lines Police CAD Discord server. An admin will review it and can reverse the restriction."
+	rpPromoModerationAppealInfo = "If you believe this is a mistake, you can appeal by opening a ticket in our Discord assistance channel: https://discord.gg/Y9ytW2ZMp4 — an admin will review it and can reverse the restriction."
 
 	rpPromoModerationDefaultLimit = 25
 	rpPromoModerationMaxLimit     = 100
@@ -69,7 +69,8 @@ func rpPromoOffenseExpiry(offenseNumber int, now time.Time) *primitive.DateTime 
 	return &dt
 }
 
-// rpPromoPenaltyLabel is the human label for an offense's restriction length.
+// rpPromoPenaltyLabel is the compact label for an offense's restriction length,
+// used in the admin UI (e.g. "7-day restriction").
 func rpPromoPenaltyLabel(offenseNumber int) string {
 	switch offenseNumber {
 	case 1:
@@ -78,6 +79,21 @@ func rpPromoPenaltyLabel(offenseNumber int) string {
 		return "30-day"
 	case 3:
 		return "1-year"
+	default:
+		return "permanent"
+	}
+}
+
+// rpPromoDurationPhrase is the grammatical duration used in email sentences
+// (e.g. "restricted ... for 7 days").
+func rpPromoDurationPhrase(offenseNumber int) string {
+	switch offenseNumber {
+	case 1:
+		return "7 days"
+	case 2:
+		return "30 days"
+	case 3:
+		return "1 year"
 	default:
 		return "permanent"
 	}
@@ -234,6 +250,77 @@ func rpPromoNormalizeInvite(s string) string {
 	return v
 }
 
+// alertIfRpPromoFlagged checks whether a just-posted promotion is a possible
+// cross-community duplicate (same invite under another community, or same name
+// under another community owned by the same person) and, if so, posts a single
+// review nudge to the staff alerts channel. Best-effort; runs in its own
+// goroutine with a detached context.
+func (c Community) alertIfRpPromoFlagged(communityID, communityName, ownerID string, data models.RpPromotionData) {
+	ownerName := resolveActorName(c.UDB, ownerID)
+	if rpPromoIsIgnoredOwner(ownerName) {
+		return
+	}
+	objID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	matchKind := ""
+	matched := []string{}
+
+	// Same invite under a DIFFERENT community = literally the same server.
+	if strings.TrimSpace(data.InviteURL) != "" {
+		if other, oErr := c.DB.FindOneIncludingPending(ctx, bson.M{
+			"_id":                                       bson.M{"$ne": objID},
+			"community.rpPromotion.history.data.inviteUrl": data.InviteURL,
+		}); oErr == nil && other != nil {
+			matchKind = "same invite"
+			matched = append(matched, other.Details.Name)
+		}
+	}
+
+	// Same normalized name under another community owned by the same person.
+	if matchKind == "" {
+		nm := rpPromoNormalizeName(data.ServerName)
+		if nm != "" {
+			cur, fErr := c.DB.FindIncludingPending(ctx, bson.M{
+				"_id":                            bson.M{"$ne": objID},
+				"community.ownerID":              ownerID,
+				"community.rpPromotion.history.0": bson.M{"$exists": true},
+			})
+			if fErr == nil {
+				var comms []models.Community
+				if cur.All(ctx, &comms) == nil {
+					for _, oc := range comms {
+						if oc.Details.RpPromotion == nil {
+							continue
+						}
+						for _, h := range oc.Details.RpPromotion.History {
+							if rpPromoNormalizeName(h.Data.ServerName) == nm {
+								matchKind = "same name"
+								matched = append(matched, oc.Details.Name)
+								break
+							}
+						}
+						if matchKind != "" {
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if matchKind == "" {
+		return
+	}
+	allNames := append([]string{communityName}, matched...)
+	sendRpPromoFlaggedAlert(data.ServerName, ownerName, matchKind, allNames, data.InviteURL, communityID+"|"+matchKind)
+}
+
 // resolveUserContact returns a user's email and username from their ID.
 func resolveUserContact(udb databases.UserDatabase, userID string) (email, username string) {
 	if userID == "" {
@@ -298,31 +385,11 @@ type rpPromoAggRow struct {
 	Post          models.RpPromotionPost `bson:"post"`
 }
 
-// AdminListRpPromosHandler returns every promotion across all communities,
-// newest first, annotated with advisory duplicate flags and the owner's current
-// ban status. Staff (admin or owner).
-func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
-	var req struct {
-		adminCurrentUserBody
-		Search         string `json:"search"`
-		DuplicatesOnly bool   `json:"duplicatesOnly"`
-		Page           int    `json:"page"`
-		Limit          int    `json:"limit"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
-		return
-	}
-	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
-		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
-		return
-	}
-
-	ctx, cancel := api.WithQueryTimeout(r.Context())
-	defer cancel()
-
+// computeRpPromoItems loads every promotion across all communities (newest
+// first), annotates each with advisory duplicate flags + ban status, and groups
+// duplicate-set members adjacently. Shared by the list endpoint and the
+// flagged-count badge so both apply identical rules.
+func (c Community) computeRpPromoItems(ctx context.Context) ([]adminRpPromoItem, error) {
 	pipeline := mongo.Pipeline{
 		{{Key: "$match", Value: bson.M{"community.rpPromotion.history.0": bson.M{"$exists": true}}}},
 		{{Key: "$unwind", Value: "$community.rpPromotion.history"}},
@@ -337,13 +404,11 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 
 	cur, err := c.DB.AggregateIncludingPending(ctx, pipeline)
 	if err != nil {
-		config.ErrorStatus("failed to load promotions", http.StatusInternalServerError, w, err)
-		return
+		return nil, err
 	}
 	var rows []rpPromoAggRow
 	if err := cur.All(ctx, &rows); err != nil {
-		config.ErrorStatus("failed to decode promotions", http.StatusInternalServerError, w, err)
-		return
+		return nil, err
 	}
 
 	bannedUsers, bannedCommunities := c.inForceBannedSets(ctx)
@@ -368,9 +433,8 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 	// literally the same server, whoever owns it. Name is scoped per OWNER
 	// (key = name + ownerID): generic names like "San Andreas State Roleplay"
 	// collide across unrelated communities constantly, so a name match only
-	// signals evasion when the SAME owner is behind both communities (the
-	// "spin up a near-identical community" pattern). Internal test accounts are
-	// skipped entirely so they never produce flags.
+	// signals evasion when the SAME owner is behind both communities. Internal
+	// test accounts are skipped entirely so they never produce flags.
 	inviteCommunities := map[string]map[string]bool{} // invite -> set of communityIds
 	nameCommunities := map[string]map[string]bool{}   // name+ownerID -> set of communityIds
 	for _, row := range rows {
@@ -394,10 +458,7 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Second pass: build items, assigning each a duplicate group when its invite
-	// or name is shared across communities. Invite match takes precedence (a
-	// reused invite is the strongest "same server" signal); name is the
-	// fallback. A row records the secondary signal too, so the UI header can say
-	// "same invite & name".
+	// or name is shared across communities (invite preferred, name fallback).
 	items := make([]adminRpPromoItem, 0, len(rows))
 	for _, row := range rows {
 		p := row.Post
@@ -417,20 +478,20 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			postedByName = resolveName(p.PostedBy)
 		}
 		it := adminRpPromoItem{
-			CommunityID:   row.CommunityID.Hex(),
-			CommunityName: row.CommunityName,
-			OwnerID:       row.OwnerID,
-			OwnerName:     ownerName,
-			PostID:        p.ID,
-			PostedBy:      p.PostedBy,
-			PostedByName:  postedByName,
-			PostedAt:      p.PostedAt.Time().UTC().Format(time.RFC3339),
-			Tier:          p.Tier,
-			ServerName:    p.Data.ServerName,
-			Game:          p.Data.Game,
-			Consoles:      p.Data.Consoles,
-			InviteURL:     p.Data.InviteURL,
-			MessageID:     p.MessageID,
+			CommunityID:     row.CommunityID.Hex(),
+			CommunityName:   row.CommunityName,
+			OwnerID:         row.OwnerID,
+			OwnerName:       ownerName,
+			PostID:          p.ID,
+			PostedBy:        p.PostedBy,
+			PostedByName:    postedByName,
+			PostedAt:        p.PostedAt.Time().UTC().Format(time.RFC3339),
+			Tier:            p.Tier,
+			ServerName:      p.Data.ServerName,
+			Game:            p.Data.Game,
+			Consoles:        p.Data.Consoles,
+			InviteURL:       p.Data.InviteURL,
+			MessageID:       p.MessageID,
 			MessageLink:     rpPromotionMessageLink(p.ChannelID, p.MessageID),
 			Removed:         p.RemovedAt != nil,
 			OwnerBanned:     bannedUsers[row.OwnerID],
@@ -465,6 +526,39 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		}
 		return items[i].PostedAt > items[j].PostedAt // newest first
 	})
+	return items, nil
+}
+
+// AdminListRpPromosHandler returns every promotion across all communities,
+// newest first, annotated with advisory duplicate flags and the owner's current
+// ban status. Staff (admin or owner).
+func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		Search         string `json:"search"`
+		DuplicatesOnly bool   `json:"duplicatesOnly"`
+		Page           int    `json:"page"`
+		Limit          int    `json:"limit"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	items, err := c.computeRpPromoItems(ctx)
+	if err != nil {
+		config.ErrorStatus("failed to load promotions", http.StatusInternalServerError, w, err)
+		return
+	}
 
 	// Filters (applied in memory so duplicate grouping reflects the global set).
 	search := strings.ToLower(strings.TrimSpace(req.Search))
@@ -511,6 +605,53 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		"totalCount": total,
 		"page":       page,
 		"limit":      limit,
+	})
+}
+
+// AdminRpPromoFlaggedCountHandler returns how many promotions are currently
+// flagged as possible duplicates and how many distinct sets they form — used
+// for the sidebar review badge. Staff (admin or owner).
+func (c Community) AdminRpPromoFlaggedCountHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req adminCurrentUserBody
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	items, err := c.computeRpPromoItems(ctx)
+	if err != nil {
+		config.ErrorStatus("failed to load promotions", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	// Count only sets that still have 2+ LIVE (not removed) members — once an
+	// admin removes the duplicate posts, the set stops counting and the badge
+	// clears, so it reflects what still needs review.
+	liveByGroup := map[string]int{}
+	for _, it := range items {
+		if it.DupGroupID != "" && !it.Removed {
+			liveByGroup[it.DupGroupID]++
+		}
+	}
+	flaggedSets, flaggedPromos := 0, 0
+	for _, n := range liveByGroup {
+		if n >= 2 {
+			flaggedSets++
+			flaggedPromos += n
+		}
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"flaggedPromos": flaggedPromos,
+		"flaggedSets":   flaggedSets,
 	})
 }
 
@@ -780,7 +921,7 @@ func renderNotificationEmail(n rpPromoNotification, reason string, ev []models.R
 		}
 		restrictions = append(restrictions, templates.RpPromoOffenseRestriction{
 			Label:         l.Label,
-			PenaltyLabel:  rpPromoPenaltyLabel(l.OffenseNumber),
+			PenaltyLabel:  rpPromoDurationPhrase(l.OffenseNumber),
 			LiftsAt:       liftsAt,
 			OffenseNumber: l.OffenseNumber,
 		})

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -1,0 +1,870 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
+
+	"github.com/linesmerrill/police-cad-api/api"
+	"github.com/linesmerrill/police-cad-api/config"
+	"github.com/linesmerrill/police-cad-api/databases"
+	"github.com/linesmerrill/police-cad-api/models"
+	templates "github.com/linesmerrill/police-cad-api/templates/html"
+)
+
+// Admin RP server promotion moderation.
+//
+//	POST /api/v1/admin/rp-promos                     — list all promos (+ duplicate flags)
+//	POST /api/v1/admin/rp-promos/delete              — remove a promo from Discord
+//	POST /api/v1/admin/rp-promos/ban/preview         — compute penalty + render evidence email
+//	POST /api/v1/admin/rp-promos/ban                 — issue an escalating ban + send email
+//	POST /api/v1/admin/rp-promos/offenses            — list offenses (banned-users view)
+//	POST /api/v1/admin/rp-promos/offenses/{id}/reverse — overturn an offense on appeal
+//
+// All are owner-only, authorized via checkAdminPermissions against the
+// self-asserted currentUser in the body — the same pattern every other admin
+// console endpoint uses (the console is only rendered to a session-
+// authenticated admin).
+
+const (
+	rpPromoModerationToSURL     = "https://www.linespolice-cad.com/terms-and-conditions"
+	rpPromoModerationAppealInfo = "If you believe this is a mistake, open a ticket in the assistance channel of the Lines Police CAD Discord server. An admin will review it and can reverse the restriction."
+
+	rpPromoModerationDefaultLimit = 25
+	rpPromoModerationMaxLimit     = 100
+)
+
+// rpPromoOffenseExpiry returns when an offense's restriction lifts, given its
+// 1-based number on the escalation ladder. A nil result means permanent.
+//
+//	1st → 7 days, 2nd → 30 days, 3rd → 1 year, 4th+ → permanent.
+func rpPromoOffenseExpiry(offenseNumber int, now time.Time) *primitive.DateTime {
+	var until time.Time
+	switch offenseNumber {
+	case 1:
+		until = now.Add(7 * 24 * time.Hour)
+	case 2:
+		until = now.Add(30 * 24 * time.Hour)
+	case 3:
+		until = now.Add(365 * 24 * time.Hour)
+	default:
+		return nil // permanent
+	}
+	dt := primitive.NewDateTimeFromTime(until)
+	return &dt
+}
+
+// rpPromoPenaltyLabel is the human label for an offense's restriction length.
+func rpPromoPenaltyLabel(offenseNumber int) string {
+	switch offenseNumber {
+	case 1:
+		return "7-day"
+	case 2:
+		return "30-day"
+	case 3:
+		return "1-year"
+	default:
+		return "permanent"
+	}
+}
+
+// activeRpPromoInForceFilter matches offenses that are active AND not past their
+// expiry (a permanent ban has no expiresAt). Used for the enforcement gate.
+func activeRpPromoInForceFilter(now time.Time) bson.M {
+	nowDT := primitive.NewDateTimeFromTime(now)
+	return bson.M{
+		"status": models.RpPromoOffenseStatusActive,
+		"$or": []bson.M{
+			{"expiresAt": bson.M{"$exists": false}},
+			{"expiresAt": nil},
+			{"expiresAt": bson.M{"$gt": nowDT}},
+		},
+	}
+}
+
+// activeRpPromoBan returns the in-force ban covering any of the given user IDs,
+// or nil if none are restricted. When multiple apply it returns the most
+// restrictive (a permanent ban, else the one expiring latest).
+func (c Community) activeRpPromoBan(ctx context.Context, userIDs ...string) *models.RpPromoOffense {
+	if c.OffDB == nil || len(userIDs) == 0 {
+		return nil
+	}
+	filter := activeRpPromoInForceFilter(time.Now())
+	filter["userId"] = bson.M{"$in": userIDs}
+
+	cur, err := c.OffDB.Find(ctx, filter)
+	if err != nil {
+		zap.S().Errorw("rp promo moderation: ban lookup failed", "error", err)
+		return nil
+	}
+	var offenses []models.RpPromoOffense
+	if err := cur.All(ctx, &offenses); err != nil || len(offenses) == 0 {
+		return nil
+	}
+
+	best := offenses[0]
+	for _, o := range offenses[1:] {
+		if best.ExpiresAt == nil {
+			break // already permanent — nothing is more restrictive
+		}
+		if o.ExpiresAt == nil || o.ExpiresAt.Time().After(best.ExpiresAt.Time()) {
+			best = o
+		}
+	}
+	return &best
+}
+
+// inForceBannedUserSet returns the set of user IDs currently under an in-force
+// ban, for annotating the promos list in one query rather than per row.
+func (c Community) inForceBannedUserSet(ctx context.Context) map[string]bool {
+	set := map[string]bool{}
+	if c.OffDB == nil {
+		return set
+	}
+	cur, err := c.OffDB.Find(ctx, activeRpPromoInForceFilter(time.Now()))
+	if err != nil {
+		return set
+	}
+	var offenses []models.RpPromoOffense
+	if err := cur.All(ctx, &offenses); err != nil {
+		return set
+	}
+	for _, o := range offenses {
+		set[o.UserID] = true
+	}
+	return set
+}
+
+// countActiveRpPromoOffenses counts a user's upheld (non-reversed) offenses.
+// Expired-by-time offenses still count — escalation is cumulative — so the
+// next offense number is this count + 1.
+func (c Community) countActiveRpPromoOffenses(ctx context.Context, userID string) (int64, error) {
+	if c.OffDB == nil {
+		return 0, nil
+	}
+	return c.OffDB.CountDocuments(ctx, bson.M{
+		"userId": userID,
+		"status": models.RpPromoOffenseStatusActive,
+	})
+}
+
+var rpPromoNonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// rpPromoNormalizeName lowercases and strips non-alphanumerics so "Vice City
+// Rejects" and "ViceCity Rejects" collapse to the same key for the advisory
+// name-duplicate flag.
+func rpPromoNormalizeName(s string) string {
+	return rpPromoNonAlnum.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")
+}
+
+// resolveUserContact returns a user's email and username from their ID.
+func resolveUserContact(udb databases.UserDatabase, userID string) (email, username string) {
+	if userID == "" {
+		return "", ""
+	}
+	objID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return "", ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var user models.User
+	if err := udb.FindOne(ctx, bson.M{"_id": objID}).Decode(&user); err != nil {
+		return "", ""
+	}
+	return user.Details.Email, user.Details.Username
+}
+
+// ---- request/response shapes ----
+
+type adminCurrentUserBody struct {
+	CurrentUser map[string]interface{} `json:"currentUser"`
+}
+
+type adminRpPromoItem struct {
+	CommunityID   string   `json:"communityId"`
+	CommunityName string   `json:"communityName"`
+	OwnerID       string   `json:"ownerId"`
+	OwnerName     string   `json:"ownerName"`
+	PostID        string   `json:"postId"`
+	PostedBy      string   `json:"postedBy"`
+	PostedByName  string   `json:"postedByName"`
+	PostedAt      string   `json:"postedAt"`
+	Tier          string   `json:"tier"`
+	ServerName    string   `json:"serverName"`
+	Game          string   `json:"game"`
+	Consoles      []string `json:"consoles"`
+	InviteURL     string   `json:"inviteUrl"`
+	MessageID     string   `json:"messageId"`
+	MessageLink   string   `json:"messageLink"`
+	Removed       bool     `json:"removed"`
+	OwnerDup      bool     `json:"ownerDup"`
+	NameDup       bool     `json:"nameDup"`
+	InviteDup     bool     `json:"inviteDup"`
+	OwnerBanned   bool     `json:"ownerBanned"`
+}
+
+type rpPromoAggRow struct {
+	CommunityID   primitive.ObjectID     `bson:"communityId"`
+	CommunityName string                 `bson:"communityName"`
+	OwnerID       string                 `bson:"ownerId"`
+	Post          models.RpPromotionPost `bson:"post"`
+}
+
+// AdminListRpPromosHandler returns every promotion across all communities,
+// newest first, annotated with advisory duplicate flags and the owner's current
+// ban status. Owner-only.
+func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		Search         string `json:"search"`
+		DuplicatesOnly bool   `json:"duplicatesOnly"`
+		Page           int    `json:"page"`
+		Limit          int    `json:"limit"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"community.rpPromotion.history.0": bson.M{"$exists": true}}}},
+		{{Key: "$unwind", Value: "$community.rpPromotion.history"}},
+		{{Key: "$project", Value: bson.M{
+			"communityId":   "$_id",
+			"communityName": "$community.name",
+			"ownerId":       "$community.ownerID",
+			"post":          "$community.rpPromotion.history",
+		}}},
+		{{Key: "$sort", Value: bson.D{{Key: "post.postedAt", Value: -1}}}},
+	}
+
+	cur, err := c.DB.AggregateIncludingPending(ctx, pipeline)
+	if err != nil {
+		config.ErrorStatus("failed to load promotions", http.StatusInternalServerError, w, err)
+		return
+	}
+	var rows []rpPromoAggRow
+	if err := cur.All(ctx, &rows); err != nil {
+		config.ErrorStatus("failed to decode promotions", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	// First pass: tally duplicate keys across the whole set.
+	ownerCount := map[string]int{}
+	inviteCount := map[string]int{}
+	nameCommunities := map[string]map[string]bool{} // normName -> set of communityIds
+	for _, row := range rows {
+		ownerCount[row.OwnerID]++
+		if inv := strings.ToLower(strings.TrimSpace(row.Post.Data.InviteURL)); inv != "" {
+			inviteCount[inv]++
+		}
+		if nm := rpPromoNormalizeName(row.Post.Data.ServerName); nm != "" {
+			if nameCommunities[nm] == nil {
+				nameCommunities[nm] = map[string]bool{}
+			}
+			nameCommunities[nm][row.CommunityID.Hex()] = true
+		}
+	}
+
+	banned := c.inForceBannedUserSet(ctx)
+	nameCache := map[string]string{}
+	resolveName := func(id string) string {
+		if id == "" {
+			return ""
+		}
+		if v, ok := nameCache[id]; ok {
+			return v
+		}
+		v := resolveActorName(c.UDB, id)
+		nameCache[id] = v
+		return v
+	}
+
+	// Second pass: build items with flags applied.
+	items := make([]adminRpPromoItem, 0, len(rows))
+	for _, row := range rows {
+		p := row.Post
+		inv := strings.ToLower(strings.TrimSpace(p.Data.InviteURL))
+		nm := rpPromoNormalizeName(p.Data.ServerName)
+		postedByName := p.PostedByName
+		if postedByName == "" {
+			postedByName = resolveName(p.PostedBy)
+		}
+		items = append(items, adminRpPromoItem{
+			CommunityID:   row.CommunityID.Hex(),
+			CommunityName: row.CommunityName,
+			OwnerID:       row.OwnerID,
+			OwnerName:     resolveName(row.OwnerID),
+			PostID:        p.ID,
+			PostedBy:      p.PostedBy,
+			PostedByName:  postedByName,
+			PostedAt:      p.PostedAt.Time().UTC().Format(time.RFC3339),
+			Tier:          p.Tier,
+			ServerName:    p.Data.ServerName,
+			Game:          p.Data.Game,
+			Consoles:      p.Data.Consoles,
+			InviteURL:     p.Data.InviteURL,
+			MessageID:     p.MessageID,
+			MessageLink:   rpPromotionMessageLink(p.ChannelID, p.MessageID),
+			Removed:       p.RemovedAt != nil,
+			OwnerDup:      ownerCount[row.OwnerID] > 1,
+			NameDup:       nm != "" && len(nameCommunities[nm]) > 1,
+			InviteDup:     inv != "" && inviteCount[inv] > 1,
+			OwnerBanned:   banned[row.OwnerID],
+		})
+	}
+
+	// Filters (applied in memory so duplicate flags reflect the global set).
+	search := strings.ToLower(strings.TrimSpace(req.Search))
+	filtered := items[:0]
+	for _, it := range items {
+		if req.DuplicatesOnly && !(it.OwnerDup || it.NameDup || it.InviteDup) {
+			continue
+		}
+		if search != "" {
+			hay := strings.ToLower(strings.Join([]string{
+				it.CommunityName, it.ServerName, it.OwnerName, it.PostedByName, it.InviteURL,
+			}, " "))
+			if !strings.Contains(hay, search) {
+				continue
+			}
+		}
+		filtered = append(filtered, it)
+	}
+
+	// Pagination.
+	limit := req.Limit
+	if limit <= 0 {
+		limit = rpPromoModerationDefaultLimit
+	}
+	if limit > rpPromoModerationMaxLimit {
+		limit = rpPromoModerationMaxLimit
+	}
+	page := req.Page
+	if page < 1 {
+		page = 1
+	}
+	total := len(filtered)
+	start := (page - 1) * limit
+	if start > total {
+		start = total
+	}
+	end := start + limit
+	if end > total {
+		end = total
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"data":       filtered[start:end],
+		"totalCount": total,
+		"page":       page,
+		"limit":      limit,
+	})
+}
+
+// AdminDeleteRpPromoHandler removes a single promotion from the Discord channel
+// and marks its history entry removed (retained as evidence). Owner-only.
+func (c Community) AdminDeleteRpPromoHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		CommunityID string `json:"communityId"`
+		PostID      string `json:"postId"`
+		Reason      string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+	adminEmail, _ := req.CurrentUser["email"].(string)
+
+	communityObjID, err := primitive.ObjectIDFromHex(req.CommunityID)
+	if err != nil {
+		config.ErrorStatus("invalid communityId", http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	community, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": communityObjID})
+	if err != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, err)
+		return
+	}
+
+	// Locate the post in history to recover its Discord message ID.
+	var target *models.RpPromotionPost
+	if community.Details.RpPromotion != nil {
+		for i := range community.Details.RpPromotion.History {
+			if community.Details.RpPromotion.History[i].ID == req.PostID {
+				target = &community.Details.RpPromotion.History[i]
+				break
+			}
+		}
+	}
+	if target == nil {
+		config.ErrorStatus("promotion not found", http.StatusNotFound, w, nil)
+		return
+	}
+
+	// Best-effort Discord removal. A missing message ID or already-deleted
+	// message is not an error — the goal is "not live", which is then true.
+	webhookURL := os.Getenv(rpPromoWebhookEnv)
+	if target.MessageID != "" {
+		if err := deleteRpPromotionWebhookMessage(webhookURL, target.MessageID); err != nil {
+			config.ErrorStatus("failed to remove the Discord message", http.StatusBadGateway, w, err)
+			return
+		}
+	}
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	update := bson.M{"$set": bson.M{
+		"community.rpPromotion.history.$[elem].removedAt":    now,
+		"community.rpPromotion.history.$[elem].removedBy":    adminEmail,
+		"community.rpPromotion.history.$[elem].removeReason": strings.TrimSpace(req.Reason),
+	}}
+	opts := options.Update().SetArrayFilters(options.ArrayFilters{
+		Filters: []interface{}{bson.M{"elem.id": req.PostID}},
+	})
+	if err := c.DB.UpdateOne(ctx, bson.M{"_id": communityObjID}, update, opts); err != nil {
+		config.ErrorStatus("removed from Discord but failed to update record", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	logAudit(c.ALDB, communityObjID, "rp_promotion.removed", "community", "", adminEmail, req.PostID, "",
+		map[string]interface{}{"serverName": target.Data.ServerName, "reason": req.Reason})
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"message": "promotion removed"})
+}
+
+// adminRpPromoEvidenceInput is the wire shape for an evidence promo.
+type adminRpPromoEvidenceInput struct {
+	CommunityID   string `json:"communityId"`
+	CommunityName string `json:"communityName"`
+	ServerName    string `json:"serverName"`
+	InviteURL     string `json:"inviteUrl"`
+	MessageID     string `json:"messageId"`
+	PostID        string `json:"postId"`
+	PostedAt      string `json:"postedAt"`
+}
+
+func parseEvidence(in []adminRpPromoEvidenceInput) []models.RpPromoEvidence {
+	out := make([]models.RpPromoEvidence, 0, len(in))
+	for _, e := range in {
+		postedAt := primitive.NewDateTimeFromTime(time.Now())
+		if t, err := time.Parse(time.RFC3339, e.PostedAt); err == nil {
+			postedAt = primitive.NewDateTimeFromTime(t)
+		}
+		out = append(out, models.RpPromoEvidence{
+			CommunityID:   e.CommunityID,
+			CommunityName: e.CommunityName,
+			ServerName:    e.ServerName,
+			InviteURL:     e.InviteURL,
+			MessageID:     e.MessageID,
+			PostedAt:      postedAt,
+		})
+	}
+	return out
+}
+
+func evidenceEmailLines(ev []models.RpPromoEvidence) []templates.RpPromoOffenseEvidenceLine {
+	lines := make([]templates.RpPromoOffenseEvidenceLine, 0, len(ev))
+	for _, e := range ev {
+		lines = append(lines, templates.RpPromoOffenseEvidenceLine{
+			CommunityName: e.CommunityName,
+			ServerName:    e.ServerName,
+			InviteURL:     e.InviteURL,
+			PostedAt:      e.PostedAt.Time().UTC().Format("Jan 2, 2006 15:04 UTC"),
+		})
+	}
+	return lines
+}
+
+// AdminRpPromoBanPreviewHandler computes the penalty that would apply and
+// renders the evidence email, without writing anything. Owner-only.
+func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		UserID   string                      `json:"userId"`
+		Reason   string                      `json:"reason"`
+		Evidence []adminRpPromoEvidenceInput `json:"evidence"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+	if strings.TrimSpace(req.UserID) == "" {
+		config.ErrorStatus("userId is required", http.StatusBadRequest, w, nil)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	prior, err := c.countActiveRpPromoOffenses(ctx, req.UserID)
+	if err != nil {
+		config.ErrorStatus("failed to compute offense history", http.StatusInternalServerError, w, err)
+		return
+	}
+	offenseNumber := int(prior) + 1
+	now := time.Now()
+	expiresAt := rpPromoOffenseExpiry(offenseNumber, now)
+
+	email, username := resolveUserContact(c.UDB, req.UserID)
+	htmlBody, textBody := renderOffenseEmail(username, offenseNumber, expiresAt, req.Reason, parseEvidence(req.Evidence))
+
+	expiresStr := ""
+	if expiresAt != nil {
+		expiresStr = expiresAt.Time().UTC().Format(time.RFC3339)
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"offenseNumber":  offenseNumber,
+		"penaltyLabel":   rpPromoPenaltyLabel(offenseNumber),
+		"expiresAt":      expiresStr,
+		"recipientEmail": email,
+		"username":       username,
+		"emailHtml":      htmlBody,
+		"emailText":      textBody,
+	})
+}
+
+// renderOffenseEmail builds the offense email bodies for both preview and send.
+func renderOffenseEmail(username string, offenseNumber int, expiresAt *primitive.DateTime, reason string, ev []models.RpPromoEvidence) (htmlBody, textBody string) {
+	liftsAt := ""
+	if expiresAt != nil {
+		liftsAt = expiresAt.Time().UTC().Format("Jan 2, 2006")
+	}
+	return templates.RenderRpPromoOffenseEmail(templates.RpPromoOffenseEmailParams{
+		Username:      username,
+		OffenseNumber: offenseNumber,
+		PenaltyLabel:  rpPromoPenaltyLabel(offenseNumber),
+		LiftsAt:       liftsAt,
+		Reason:        reason,
+		Evidence:      evidenceEmailLines(ev),
+		ToSURL:        rpPromoModerationToSURL,
+		AppealInfo:    rpPromoModerationAppealInfo,
+	})
+}
+
+// AdminRpPromoBanHandler issues an escalating ban against a user, optionally
+// removes their live promos from Discord, and sends the evidence email.
+// Owner-only.
+func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		UserID         string                      `json:"userId"`
+		Reason         string                      `json:"reason"`
+		Evidence       []adminRpPromoEvidenceInput `json:"evidence"`
+		RemoveLivePosts bool                       `json:"removeLivePosts"`
+		SendEmail      *bool                       `json:"sendEmail"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+	if strings.TrimSpace(req.UserID) == "" {
+		config.ErrorStatus("userId is required", http.StatusBadRequest, w, nil)
+		return
+	}
+	adminEmail, _ := req.CurrentUser["email"].(string)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	prior, err := c.countActiveRpPromoOffenses(ctx, req.UserID)
+	if err != nil {
+		config.ErrorStatus("failed to compute offense history", http.StatusInternalServerError, w, err)
+		return
+	}
+	offenseNumber := int(prior) + 1
+	now := time.Now()
+	nowDT := primitive.NewDateTimeFromTime(now)
+	expiresAt := rpPromoOffenseExpiry(offenseNumber, now)
+	evidence := parseEvidence(req.Evidence)
+
+	email, username := resolveUserContact(c.UDB, req.UserID)
+
+	offense := models.RpPromoOffense{
+		UserID:        req.UserID,
+		Username:      username,
+		Email:         email,
+		OffenseNumber: offenseNumber,
+		Reason:        strings.TrimSpace(req.Reason),
+		Evidence:      evidence,
+		IssuedBy:      adminEmail,
+		IssuedAt:      nowDT,
+		ExpiresAt:     expiresAt,
+		Status:        models.RpPromoOffenseStatusActive,
+	}
+
+	// Optionally remove the user's live promos from Discord first, so a partial
+	// failure here surfaces before we record the ban.
+	removed := 0
+	if req.RemoveLivePosts {
+		removed = c.removeEvidencePosts(ctx, evidence, adminEmail)
+	}
+
+	// Send the evidence email (default on). A send failure does not block the
+	// ban — the restriction still applies; we just report emailSent=false.
+	emailSent := false
+	if req.SendEmail == nil || *req.SendEmail {
+		if email != "" {
+			if err := sendOffenseEmail(email, username, offenseNumber, expiresAt, req.Reason, evidence); err != nil {
+				zap.S().Errorw("rp promo moderation: offense email failed", "userId", req.UserID, "error", err)
+			} else {
+				emailSent = true
+				offense.EmailSentAt = &nowDT
+			}
+		}
+	}
+
+	res, err := c.OffDB.InsertOne(ctx, offense)
+	if err != nil {
+		config.ErrorStatus("failed to record the ban", http.StatusInternalServerError, w, err)
+		return
+	}
+	offenseID := ""
+	if oid, ok := res.Decode().(primitive.ObjectID); ok {
+		offenseID = oid.Hex()
+	}
+
+	logAudit(c.ALDB, primitive.NilObjectID, "rp_promotion.banned", "user", "", adminEmail, req.UserID, email,
+		map[string]interface{}{"offenseNumber": offenseNumber, "reason": req.Reason, "removedPosts": removed})
+
+	expiresStr := "permanent"
+	if expiresAt != nil {
+		expiresStr = expiresAt.Time().UTC().Format(time.RFC3339)
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"message":       "ban issued",
+		"offenseId":     offenseID,
+		"offenseNumber": offenseNumber,
+		"expiresAt":     expiresStr,
+		"emailSent":     emailSent,
+		"removedPosts":  removed,
+	})
+}
+
+// removeEvidencePosts removes from Discord, and marks removed, each evidence
+// promo that is still live. Returns how many were removed. Best-effort: a
+// single failure is logged and skipped so one bad message can't block a ban.
+func (c Community) removeEvidencePosts(ctx context.Context, evidence []models.RpPromoEvidence, adminEmail string) int {
+	webhookURL := os.Getenv(rpPromoWebhookEnv)
+	removed := 0
+	for _, e := range evidence {
+		if e.MessageID == "" || e.CommunityID == "" {
+			continue
+		}
+		communityObjID, err := primitive.ObjectIDFromHex(e.CommunityID)
+		if err != nil {
+			continue
+		}
+		if err := deleteRpPromotionWebhookMessage(webhookURL, e.MessageID); err != nil {
+			zap.S().Warnw("rp promo moderation: failed to delete evidence post", "messageId", e.MessageID, "error", err)
+			continue
+		}
+		now := primitive.NewDateTimeFromTime(time.Now())
+		update := bson.M{"$set": bson.M{
+			"community.rpPromotion.history.$[elem].removedAt":    now,
+			"community.rpPromotion.history.$[elem].removedBy":    adminEmail,
+			"community.rpPromotion.history.$[elem].removeReason": "removed with ban",
+		}}
+		opts := options.Update().SetArrayFilters(options.ArrayFilters{
+			Filters: []interface{}{bson.M{"elem.messageId": e.MessageID}},
+		})
+		if err := c.DB.UpdateOne(ctx, bson.M{"_id": communityObjID}, update, opts); err != nil {
+			zap.S().Warnw("rp promo moderation: deleted from discord but failed to mark removed", "messageId", e.MessageID, "error", err)
+		}
+		removed++
+	}
+	return removed
+}
+
+// sendOffenseEmail renders and sends the offense email via SendGrid.
+func sendOffenseEmail(toEmail, username string, offenseNumber int, expiresAt *primitive.DateTime, reason string, ev []models.RpPromoEvidence) error {
+	htmlBody, textBody := renderOffenseEmail(username, offenseNumber, expiresAt, reason, ev)
+	subject := "Action taken on your Lines Police CAD server promotions"
+	from := mail.NewEmail("Lines Police CAD", "no-reply@linespolice-cad.com")
+	to := mail.NewEmail(username, toEmail)
+	message := mail.NewSingleEmail(from, subject, to, textBody, htmlBody)
+	client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
+	resp, err := client.Send(message)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode >= 400 {
+		return &sendgridStatusError{status: resp.StatusCode}
+	}
+	return nil
+}
+
+type sendgridStatusError struct{ status int }
+
+func (e *sendgridStatusError) Error() string {
+	return "sendgrid returned status " + http.StatusText(e.status)
+}
+
+// AdminListRpPromoOffensesHandler lists offenses for the banned-users view,
+// optionally filtered to one user or to currently in-force bans. Owner-only.
+func (c Community) AdminListRpPromoOffensesHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req struct {
+		adminCurrentUserBody
+		UserID    string `json:"userId"`
+		ActiveOnly bool  `json:"activeOnly"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	filter := bson.M{}
+	if strings.TrimSpace(req.UserID) != "" {
+		filter["userId"] = req.UserID
+	}
+	if req.ActiveOnly {
+		for k, v := range activeRpPromoInForceFilter(time.Now()) {
+			filter[k] = v
+		}
+	}
+
+	cur, err := c.OffDB.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "issuedAt", Value: -1}}))
+	if err != nil {
+		config.ErrorStatus("failed to load offenses", http.StatusInternalServerError, w, err)
+		return
+	}
+	var offenses []models.RpPromoOffense
+	if err := cur.All(ctx, &offenses); err != nil {
+		config.ErrorStatus("failed to decode offenses", http.StatusInternalServerError, w, err)
+		return
+	}
+	// Newest-first is already applied by the sort; keep stable on equal times.
+	sort.SliceStable(offenses, func(i, j int) bool {
+		return offenses[i].IssuedAt.Time().After(offenses[j].IssuedAt.Time())
+	})
+
+	now := time.Now()
+	out := make([]map[string]interface{}, 0, len(offenses))
+	for _, o := range offenses {
+		inForce := o.Status == models.RpPromoOffenseStatusActive && (o.ExpiresAt == nil || o.ExpiresAt.Time().After(now))
+		expiresStr := "permanent"
+		if o.ExpiresAt != nil {
+			expiresStr = o.ExpiresAt.Time().UTC().Format(time.RFC3339)
+		}
+		out = append(out, map[string]interface{}{
+			"id":            o.ID.Hex(),
+			"userId":        o.UserID,
+			"username":      o.Username,
+			"email":         o.Email,
+			"offenseNumber": o.OffenseNumber,
+			"reason":        o.Reason,
+			"evidence":      o.Evidence,
+			"issuedBy":      o.IssuedBy,
+			"issuedAt":      o.IssuedAt.Time().UTC().Format(time.RFC3339),
+			"expiresAt":     expiresStr,
+			"status":        o.Status,
+			"inForce":       inForce,
+			"reversedBy":    o.ReversedBy,
+			"reversalReason": o.ReversalReason,
+		})
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": out, "totalCount": len(out)})
+}
+
+// AdminReverseRpPromoOffenseHandler overturns an offense on appeal — it stops
+// counting toward escalation and lifts the ban. Owner-only.
+func (c Community) AdminReverseRpPromoOffenseHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	offenseID := mux.Vars(r)["id"]
+	offenseObjID, err := primitive.ObjectIDFromHex(offenseID)
+	if err != nil {
+		config.ErrorStatus("invalid offense id", http.StatusBadRequest, w, err)
+		return
+	}
+
+	var req struct {
+		adminCurrentUserBody
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+	adminEmail, _ := req.CurrentUser["email"].(string)
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	now := primitive.NewDateTimeFromTime(time.Now())
+	update := bson.M{"$set": bson.M{
+		"status":         models.RpPromoOffenseStatusReversed,
+		"reversedBy":     adminEmail,
+		"reversedAt":     now,
+		"reversalReason": strings.TrimSpace(req.Reason),
+	}}
+	if err := c.OffDB.UpdateOne(ctx, bson.M{"_id": offenseObjID}, update); err != nil {
+		config.ErrorStatus("failed to reverse offense", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	logAudit(c.ALDB, primitive.NilObjectID, "rp_promotion.ban_reversed", "user", "", adminEmail, offenseID, "",
+		map[string]interface{}{"reason": req.Reason})
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"message": "offense reversed"})
+}

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -171,6 +171,18 @@ func rpPromoNormalizeName(s string) string {
 	return rpPromoNonAlnum.ReplaceAllString(strings.ToLower(strings.TrimSpace(s)), "")
 }
 
+// rpPromoNormalizeInvite canonicalizes a Discord invite for duplicate matching:
+// lowercased, trimmed, scheme/host-prefix removed, and trailing slash dropped,
+// so "https://discord.gg/abc" and "discord.gg/abc/" match.
+func rpPromoNormalizeInvite(s string) string {
+	v := strings.ToLower(strings.TrimSpace(s))
+	v = strings.TrimSuffix(v, "/")
+	for _, prefix := range []string{"https://", "http://", "www.", "discord.gg/", "discord.com/invite/"} {
+		v = strings.TrimPrefix(v, prefix)
+	}
+	return v
+}
+
 // resolveUserContact returns a user's email and username from their ID.
 func resolveUserContact(udb databases.UserDatabase, userID string) (email, username string) {
 	if userID == "" {
@@ -212,10 +224,19 @@ type adminRpPromoItem struct {
 	MessageID     string   `json:"messageId"`
 	MessageLink   string   `json:"messageLink"`
 	Removed       bool     `json:"removed"`
-	OwnerDup      bool     `json:"ownerDup"`
-	NameDup       bool     `json:"nameDup"`
-	InviteDup     bool     `json:"inviteDup"`
 	OwnerBanned   bool     `json:"ownerBanned"`
+
+	// Duplicate grouping. A promo is only flagged when its invite or normalized
+	// server name is shared across 2+ DISTINCT communities — a single community
+	// re-promoting on different days (respecting the cooldown) is legitimate and
+	// never flagged. Members of the same set share DupGroupID so the UI can
+	// group/pair them under one header.
+	DupGroupID        string `json:"dupGroupId,omitempty"`        // stable key, e.g. "inv:<url>" or "name:<norm>"
+	DupGroupType      string `json:"dupGroupType,omitempty"`      // "invite" | "name"
+	DupGroupValue     string `json:"dupGroupValue,omitempty"`     // the shared invite URL or server name, for display
+	DupCommunityCount int    `json:"dupCommunityCount,omitempty"` // distinct communities sharing the key
+	DupAlsoName       bool   `json:"dupAlsoName,omitempty"`       // invite-grouped row that ALSO shares its name cross-community
+	DupAlsoInvite     bool   `json:"dupAlsoInvite,omitempty"`     // name-grouped row that ALSO shares its invite cross-community
 }
 
 type rpPromoAggRow struct {
@@ -273,20 +294,24 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// First pass: tally duplicate keys across the whole set.
-	ownerCount := map[string]int{}
-	inviteCount := map[string]int{}
-	nameCommunities := map[string]map[string]bool{} // normName -> set of communityIds
+	// First pass: tally, per invite and per normalized name, the set of DISTINCT
+	// communities using it. Only cross-community reuse is suspicious — one
+	// community re-promoting on different days (respecting the cooldown) is fine.
+	inviteCommunities := map[string]map[string]bool{} // invite -> set of communityIds
+	nameCommunities := map[string]map[string]bool{}   // normName -> set of communityIds
 	for _, row := range rows {
-		ownerCount[row.OwnerID]++
-		if inv := strings.ToLower(strings.TrimSpace(row.Post.Data.InviteURL)); inv != "" {
-			inviteCount[inv]++
+		cid := row.CommunityID.Hex()
+		if inv := rpPromoNormalizeInvite(row.Post.Data.InviteURL); inv != "" {
+			if inviteCommunities[inv] == nil {
+				inviteCommunities[inv] = map[string]bool{}
+			}
+			inviteCommunities[inv][cid] = true
 		}
 		if nm := rpPromoNormalizeName(row.Post.Data.ServerName); nm != "" {
 			if nameCommunities[nm] == nil {
 				nameCommunities[nm] = map[string]bool{}
 			}
-			nameCommunities[nm][row.CommunityID.Hex()] = true
+			nameCommunities[nm][cid] = true
 		}
 	}
 
@@ -304,17 +329,24 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		return v
 	}
 
-	// Second pass: build items with flags applied.
+	// Second pass: build items, assigning each a duplicate group when its invite
+	// or name is shared across communities. Invite match takes precedence (a
+	// reused invite is the strongest "same server" signal); name is the
+	// fallback. A row records the secondary signal too, so the UI header can say
+	// "same invite & name".
 	items := make([]adminRpPromoItem, 0, len(rows))
 	for _, row := range rows {
 		p := row.Post
-		inv := strings.ToLower(strings.TrimSpace(p.Data.InviteURL))
+		inv := rpPromoNormalizeInvite(p.Data.InviteURL)
 		nm := rpPromoNormalizeName(p.Data.ServerName)
+		dupInvite := inv != "" && len(inviteCommunities[inv]) > 1
+		dupName := nm != "" && len(nameCommunities[nm]) > 1
+
 		postedByName := p.PostedByName
 		if postedByName == "" {
 			postedByName = resolveName(p.PostedBy)
 		}
-		items = append(items, adminRpPromoItem{
+		it := adminRpPromoItem{
 			CommunityID:   row.CommunityID.Hex(),
 			CommunityName: row.CommunityName,
 			OwnerID:       row.OwnerID,
@@ -331,18 +363,43 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			MessageID:     p.MessageID,
 			MessageLink:   rpPromotionMessageLink(p.ChannelID, p.MessageID),
 			Removed:       p.RemovedAt != nil,
-			OwnerDup:      ownerCount[row.OwnerID] > 1,
-			NameDup:       nm != "" && len(nameCommunities[nm]) > 1,
-			InviteDup:     inv != "" && inviteCount[inv] > 1,
 			OwnerBanned:   banned[row.OwnerID],
-		})
+		}
+		switch {
+		case dupInvite:
+			it.DupGroupID = "inv:" + inv
+			it.DupGroupType = "invite"
+			it.DupGroupValue = p.Data.InviteURL
+			it.DupCommunityCount = len(inviteCommunities[inv])
+			it.DupAlsoName = dupName
+		case dupName:
+			it.DupGroupID = "name:" + nm
+			it.DupGroupType = "name"
+			it.DupGroupValue = p.Data.ServerName
+			it.DupCommunityCount = len(nameCommunities[nm])
+		}
+		items = append(items, it)
 	}
 
-	// Filters (applied in memory so duplicate flags reflect the global set).
+	// Group duplicate-set members adjacently (grouped sets first, newest first
+	// within a set), then the rest newest first. PostedAt is RFC3339 so string
+	// comparison is chronological.
+	sort.SliceStable(items, func(i, j int) bool {
+		gi, gj := items[i].DupGroupID, items[j].DupGroupID
+		if (gi == "") != (gj == "") {
+			return gi != "" // grouped rows first
+		}
+		if gi != gj {
+			return gi < gj // keep a set together
+		}
+		return items[i].PostedAt > items[j].PostedAt // newest first
+	})
+
+	// Filters (applied in memory so duplicate grouping reflects the global set).
 	search := strings.ToLower(strings.TrimSpace(req.Search))
 	filtered := items[:0]
 	for _, it := range items {
-		if req.DuplicatesOnly && !(it.OwnerDup || it.NameDup || it.InviteDup) {
+		if req.DuplicatesOnly && it.DupGroupID == "" {
 			continue
 		}
 		if search != "" {

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"regexp"
@@ -82,29 +83,50 @@ func rpPromoPenaltyLabel(offenseNumber int) string {
 	}
 }
 
-// activeRpPromoInForceFilter matches offenses that are active AND not past their
-// expiry (a permanent ban has no expiresAt). Used for the enforcement gate.
-func activeRpPromoInForceFilter(now time.Time) bson.M {
+// rpPromoInForceExpiryOr returns the expiry clauses for an in-force ban (active
+// and not past expiry; a permanent ban has no expiresAt).
+func rpPromoInForceExpiryOr(now time.Time) []bson.M {
 	nowDT := primitive.NewDateTimeFromTime(now)
-	return bson.M{
-		"status": models.RpPromoOffenseStatusActive,
-		"$or": []bson.M{
-			{"expiresAt": bson.M{"$exists": false}},
-			{"expiresAt": nil},
-			{"expiresAt": bson.M{"$gt": nowDT}},
-		},
+	return []bson.M{
+		{"expiresAt": bson.M{"$exists": false}},
+		{"expiresAt": nil},
+		{"expiresAt": bson.M{"$gt": nowDT}},
 	}
 }
 
-// activeRpPromoBan returns the in-force ban covering any of the given user IDs,
-// or nil if none are restricted. When multiple apply it returns the most
-// restrictive (a permanent ban, else the one expiring latest).
-func (c Community) activeRpPromoBan(ctx context.Context, userIDs ...string) *models.RpPromoOffense {
-	if c.OffDB == nil || len(userIDs) == 0 {
+// activeRpPromoInForceFilter matches offenses that are active AND not past their
+// expiry. Used for list annotation.
+func activeRpPromoInForceFilter(now time.Time) bson.M {
+	return bson.M{
+		"status": models.RpPromoOffenseStatusActive,
+		"$or":    rpPromoInForceExpiryOr(now),
+	}
+}
+
+// activeRpPromoBan returns the in-force ban covering any of the given user IDs
+// OR the given community, or nil if none are restricted. When multiple apply it
+// returns the most restrictive (a permanent ban, else the one expiring latest).
+func (c Community) activeRpPromoBan(ctx context.Context, communityID string, userIDs ...string) *models.RpPromoOffense {
+	if c.OffDB == nil {
 		return nil
 	}
-	filter := activeRpPromoInForceFilter(time.Now())
-	filter["userId"] = bson.M{"$in": userIDs}
+	subject := []bson.M{}
+	if len(userIDs) > 0 {
+		subject = append(subject, bson.M{"userId": bson.M{"$in": userIDs}})
+	}
+	if communityID != "" {
+		subject = append(subject, bson.M{"communityId": communityID})
+	}
+	if len(subject) == 0 {
+		return nil
+	}
+	filter := bson.M{
+		"status": models.RpPromoOffenseStatusActive,
+		"$and": []bson.M{
+			{"$or": rpPromoInForceExpiryOr(time.Now())},
+			{"$or": subject},
+		},
+	}
 
 	cur, err := c.OffDB.Find(ctx, filter)
 	if err != nil {
@@ -128,25 +150,30 @@ func (c Community) activeRpPromoBan(ctx context.Context, userIDs ...string) *mod
 	return &best
 }
 
-// inForceBannedUserSet returns the set of user IDs currently under an in-force
-// ban, for annotating the promos list in one query rather than per row.
-func (c Community) inForceBannedUserSet(ctx context.Context) map[string]bool {
-	set := map[string]bool{}
+// inForceBannedSets returns the sets of user IDs and community IDs currently
+// under an in-force ban, for annotating the promos list in one query.
+func (c Community) inForceBannedSets(ctx context.Context) (users, communities map[string]bool) {
+	users, communities = map[string]bool{}, map[string]bool{}
 	if c.OffDB == nil {
-		return set
+		return
 	}
 	cur, err := c.OffDB.Find(ctx, activeRpPromoInForceFilter(time.Now()))
 	if err != nil {
-		return set
+		return
 	}
 	var offenses []models.RpPromoOffense
 	if err := cur.All(ctx, &offenses); err != nil {
-		return set
+		return
 	}
 	for _, o := range offenses {
-		set[o.UserID] = true
+		if o.UserID != "" {
+			users[o.UserID] = true
+		}
+		if o.CommunityID != "" {
+			communities[o.CommunityID] = true
+		}
 	}
-	return set
+	return
 }
 
 // countActiveRpPromoOffenses counts a user's upheld (non-reversed) offenses.
@@ -159,6 +186,18 @@ func (c Community) countActiveRpPromoOffenses(ctx context.Context, userID string
 	return c.OffDB.CountDocuments(ctx, bson.M{
 		"userId": userID,
 		"status": models.RpPromoOffenseStatusActive,
+	})
+}
+
+// countActiveRpPromoCommunityOffenses counts a community's upheld offenses, for
+// the community ban escalation ladder.
+func (c Community) countActiveRpPromoCommunityOffenses(ctx context.Context, communityID string) (int64, error) {
+	if c.OffDB == nil {
+		return 0, nil
+	}
+	return c.OffDB.CountDocuments(ctx, bson.M{
+		"communityId": communityID,
+		"status":      models.RpPromoOffenseStatusActive,
 	})
 }
 
@@ -235,8 +274,9 @@ type adminRpPromoItem struct {
 	InviteURL     string   `json:"inviteUrl"`
 	MessageID     string   `json:"messageId"`
 	MessageLink   string   `json:"messageLink"`
-	Removed       bool     `json:"removed"`
-	OwnerBanned   bool     `json:"ownerBanned"`
+	Removed         bool   `json:"removed"`
+	OwnerBanned     bool   `json:"ownerBanned"`
+	CommunityBanned bool   `json:"communityBanned"`
 
 	// Duplicate grouping. A promo is only flagged when its invite or normalized
 	// server name is shared across 2+ DISTINCT communities — a single community
@@ -306,7 +346,7 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	banned := c.inForceBannedUserSet(ctx)
+	bannedUsers, bannedCommunities := c.inForceBannedSets(ctx)
 	nameCache := map[string]string{}
 	resolveName := func(id string) string {
 		if id == "" {
@@ -391,9 +431,10 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			Consoles:      p.Data.Consoles,
 			InviteURL:     p.Data.InviteURL,
 			MessageID:     p.MessageID,
-			MessageLink:   rpPromotionMessageLink(p.ChannelID, p.MessageID),
-			Removed:       p.RemovedAt != nil,
-			OwnerBanned:   banned[row.OwnerID],
+			MessageLink:     rpPromotionMessageLink(p.ChannelID, p.MessageID),
+			Removed:         p.RemovedAt != nil,
+			OwnerBanned:     bannedUsers[row.OwnerID],
+			CommunityBanned: bannedCommunities[row.CommunityID.Hex()],
 		}
 		switch {
 		case dupInvite:
@@ -597,17 +638,177 @@ func evidenceEmailLines(ev []models.RpPromoEvidence) []templates.RpPromoOffenseE
 	return lines
 }
 
-// AdminRpPromoBanPreviewHandler computes the penalty that would apply and
-// renders the evidence email, without writing anything. Staff (admin or owner).
+// adminRpPromoBanRequest is the shared body for preview / ban / test-email. A
+// ban can target the poster (banUser), the community (banCommunity), or both.
+type adminRpPromoBanRequest struct {
+	adminCurrentUserBody
+	BanUser         bool                        `json:"banUser"`
+	BanCommunity    bool                        `json:"banCommunity"`
+	UserID          string                      `json:"userId"`        // the poster, when banUser
+	CommunityID     string                      `json:"communityId"`   // when banCommunity
+	CommunityName   string                      `json:"communityName"` // hint; resolved server-side too
+	Reason          string                      `json:"reason"`
+	Evidence        []adminRpPromoEvidenceInput `json:"evidence"`
+	RemoveLivePosts bool                        `json:"removeLivePosts"`
+	SendEmail       *bool                       `json:"sendEmail"`
+	TestEmail       string                      `json:"testEmail"` // test-email override recipient
+}
+
+func (r adminRpPromoBanRequest) validate() error {
+	if !r.BanUser && !r.BanCommunity {
+		return fmt.Errorf("select a user and/or a community to ban")
+	}
+	if r.BanUser && strings.TrimSpace(r.UserID) == "" {
+		return fmt.Errorf("userId is required to ban a user")
+	}
+	if r.BanCommunity && strings.TrimSpace(r.CommunityID) == "" {
+		return fmt.Errorf("communityId is required to ban a community")
+	}
+	return nil
+}
+
+// rpPromoRestrictionLine is one restriction applied to a single recipient.
+type rpPromoRestrictionLine struct {
+	Scope         string
+	Label         string
+	OffenseNumber int
+	ExpiresAt     *primitive.DateTime
+}
+
+// rpPromoNotification is the set of restrictions for one email recipient. When
+// the poster also owns the banned community they collapse into one notification.
+type rpPromoNotification struct {
+	Email        string
+	Username     string
+	Restrictions []rpPromoRestrictionLine
+}
+
+// rpPromoBanPlan is the computed outcome of a ban request: the offense
+// document(s) to insert and the deduped per-recipient email notifications.
+type rpPromoBanPlan struct {
+	UserOffense      *models.RpPromoOffense
+	CommunityOffense *models.RpPromoOffense
+	Notifications    []rpPromoNotification
+}
+
+// resolveCommunityOwnerContact returns the owner email/username and the
+// community name for a community, used to notify the owner of a community ban.
+func (c Community) resolveCommunityOwnerContact(ctx context.Context, communityID string) (email, username, communityName string) {
+	objID, err := primitive.ObjectIDFromHex(communityID)
+	if err != nil {
+		return "", "", ""
+	}
+	community, err := c.DB.FindOneIncludingPending(ctx, bson.M{"_id": objID})
+	if err != nil {
+		return "", "", ""
+	}
+	email, username = resolveUserContact(c.UDB, community.Details.OwnerID)
+	return email, username, community.Details.Name
+}
+
+// buildRpPromoBanPlan computes the offense(s) and grouped recipient
+// notifications for a ban request without writing anything.
+func (c Community) buildRpPromoBanPlan(ctx context.Context, req adminRpPromoBanRequest, adminEmail string) *rpPromoBanPlan {
+	now := time.Now()
+	nowDT := primitive.NewDateTimeFromTime(now)
+	evidence := parseEvidence(req.Evidence)
+	reason := strings.TrimSpace(req.Reason)
+	plan := &rpPromoBanPlan{}
+
+	// Group restrictions by recipient email so one person never gets two emails.
+	byEmail := map[string]*rpPromoNotification{}
+	add := func(email, username string, line rpPromoRestrictionLine) {
+		if email == "" {
+			return
+		}
+		n := byEmail[email]
+		if n == nil {
+			n = &rpPromoNotification{Email: email, Username: username}
+			byEmail[email] = n
+		}
+		n.Restrictions = append(n.Restrictions, line)
+	}
+
+	if req.BanUser {
+		prior, _ := c.countActiveRpPromoOffenses(ctx, req.UserID)
+		n := int(prior) + 1
+		exp := rpPromoOffenseExpiry(n, now)
+		email, username := resolveUserContact(c.UDB, req.UserID)
+		plan.UserOffense = &models.RpPromoOffense{
+			Scope: models.RpPromoOffenseScopeUser, UserID: req.UserID, Username: username, Email: email,
+			OffenseNumber: n, Reason: reason, Evidence: evidence, IssuedBy: adminEmail,
+			IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
+		}
+		add(email, username, rpPromoRestrictionLine{Scope: "user", Label: "your account", OffenseNumber: n, ExpiresAt: exp})
+	}
+
+	if req.BanCommunity {
+		prior, _ := c.countActiveRpPromoCommunityOffenses(ctx, req.CommunityID)
+		n := int(prior) + 1
+		exp := rpPromoOffenseExpiry(n, now)
+		ownerEmail, ownerName, commName := c.resolveCommunityOwnerContact(ctx, req.CommunityID)
+		if commName == "" {
+			commName = req.CommunityName
+		}
+		plan.CommunityOffense = &models.RpPromoOffense{
+			Scope: models.RpPromoOffenseScopeCommunity, CommunityID: req.CommunityID, CommunityName: commName,
+			Username: ownerName, Email: ownerEmail, OffenseNumber: n, Reason: reason, Evidence: evidence,
+			IssuedBy: adminEmail, IssuedAt: nowDT, ExpiresAt: exp, Status: models.RpPromoOffenseStatusActive,
+		}
+		add(ownerEmail, ownerName, rpPromoRestrictionLine{Scope: "community", Label: `the community "` + commName + `"`, OffenseNumber: n, ExpiresAt: exp})
+	}
+
+	// Stable order (by email) so previews and tests are deterministic.
+	emails := make([]string, 0, len(byEmail))
+	for e := range byEmail {
+		emails = append(emails, e)
+	}
+	sort.Strings(emails)
+	for _, e := range emails {
+		plan.Notifications = append(plan.Notifications, *byEmail[e])
+	}
+	return plan
+}
+
+// renderNotificationEmail builds the email bodies for one recipient notification.
+func renderNotificationEmail(n rpPromoNotification, reason string, ev []models.RpPromoEvidence, testBanner string) (htmlBody, textBody string) {
+	restrictions := make([]templates.RpPromoOffenseRestriction, 0, len(n.Restrictions))
+	for _, l := range n.Restrictions {
+		liftsAt := ""
+		if l.ExpiresAt != nil {
+			liftsAt = l.ExpiresAt.Time().UTC().Format("Jan 2, 2006")
+		}
+		restrictions = append(restrictions, templates.RpPromoOffenseRestriction{
+			Label:         l.Label,
+			PenaltyLabel:  rpPromoPenaltyLabel(l.OffenseNumber),
+			LiftsAt:       liftsAt,
+			OffenseNumber: l.OffenseNumber,
+		})
+	}
+	return templates.RenderRpPromoOffenseEmail(templates.RpPromoOffenseEmailParams{
+		Username:     n.Username,
+		Restrictions: restrictions,
+		Reason:       reason,
+		Evidence:     evidenceEmailLines(ev),
+		ToSURL:       rpPromoModerationToSURL,
+		AppealInfo:   rpPromoModerationAppealInfo,
+		TestBanner:   testBanner,
+	})
+}
+
+func offenseExpiresStr(o *models.RpPromoOffense) string {
+	if o == nil || o.ExpiresAt == nil {
+		return "permanent"
+	}
+	return o.ExpiresAt.Time().UTC().Format(time.RFC3339)
+}
+
+// AdminRpPromoBanPreviewHandler computes the penalty(ies) that would apply and
+// renders the recipient email(s), without writing anything. Staff (admin/owner).
 func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	var req struct {
-		adminCurrentUserBody
-		UserID   string                      `json:"userId"`
-		Reason   string                      `json:"reason"`
-		Evidence []adminRpPromoEvidenceInput `json:"evidence"`
-	}
+	var req adminRpPromoBanRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
@@ -616,73 +817,59 @@ func (c Community) AdminRpPromoBanPreviewHandler(w http.ResponseWriter, r *http.
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
-	if strings.TrimSpace(req.UserID) == "" {
-		config.ErrorStatus("userId is required", http.StatusBadRequest, w, nil)
+	if err := req.validate(); err != nil {
+		config.ErrorStatus(err.Error(), http.StatusBadRequest, w, err)
 		return
 	}
 
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
+	adminEmail, _ := req.CurrentUser["email"].(string)
 
-	prior, err := c.countActiveRpPromoOffenses(ctx, req.UserID)
-	if err != nil {
-		config.ErrorStatus("failed to compute offense history", http.StatusInternalServerError, w, err)
-		return
+	plan := c.buildRpPromoBanPlan(ctx, req, adminEmail)
+	evidence := parseEvidence(req.Evidence)
+
+	notifications := make([]map[string]interface{}, 0, len(plan.Notifications))
+	for _, n := range plan.Notifications {
+		_, textBody := renderNotificationEmail(n, req.Reason, evidence, "")
+		notifications = append(notifications, map[string]interface{}{
+			"email":     n.Email,
+			"username":  n.Username,
+			"emailText": textBody,
+		})
 	}
-	offenseNumber := int(prior) + 1
-	now := time.Now()
-	expiresAt := rpPromoOffenseExpiry(offenseNumber, now)
 
-	email, username := resolveUserContact(c.UDB, req.UserID)
-	htmlBody, textBody := renderOffenseEmail(username, offenseNumber, expiresAt, req.Reason, parseEvidence(req.Evidence))
-
-	expiresStr := ""
-	if expiresAt != nil {
-		expiresStr = expiresAt.Time().UTC().Format(time.RFC3339)
+	resp := map[string]interface{}{"notifications": notifications}
+	if plan.UserOffense != nil {
+		resp["user"] = map[string]interface{}{
+			"offenseNumber": plan.UserOffense.OffenseNumber,
+			"penaltyLabel":  rpPromoPenaltyLabel(plan.UserOffense.OffenseNumber),
+			"expiresAt":     offenseExpiresStr(plan.UserOffense),
+			"email":         plan.UserOffense.Email,
+			"username":      plan.UserOffense.Username,
+		}
 	}
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"offenseNumber":  offenseNumber,
-		"penaltyLabel":   rpPromoPenaltyLabel(offenseNumber),
-		"expiresAt":      expiresStr,
-		"recipientEmail": email,
-		"username":       username,
-		"emailHtml":      htmlBody,
-		"emailText":      textBody,
-	})
+	if plan.CommunityOffense != nil {
+		resp["community"] = map[string]interface{}{
+			"offenseNumber": plan.CommunityOffense.OffenseNumber,
+			"penaltyLabel":  rpPromoPenaltyLabel(plan.CommunityOffense.OffenseNumber),
+			"expiresAt":     offenseExpiresStr(plan.CommunityOffense),
+			"communityName": plan.CommunityOffense.CommunityName,
+			"ownerEmail":    plan.CommunityOffense.Email,
+			"ownerUsername": plan.CommunityOffense.Username,
+		}
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// renderOffenseEmail builds the offense email bodies for both preview and send.
-func renderOffenseEmail(username string, offenseNumber int, expiresAt *primitive.DateTime, reason string, ev []models.RpPromoEvidence) (htmlBody, textBody string) {
-	liftsAt := ""
-	if expiresAt != nil {
-		liftsAt = expiresAt.Time().UTC().Format("Jan 2, 2006")
-	}
-	return templates.RenderRpPromoOffenseEmail(templates.RpPromoOffenseEmailParams{
-		Username:      username,
-		OffenseNumber: offenseNumber,
-		PenaltyLabel:  rpPromoPenaltyLabel(offenseNumber),
-		LiftsAt:       liftsAt,
-		Reason:        reason,
-		Evidence:      evidenceEmailLines(ev),
-		ToSURL:        rpPromoModerationToSURL,
-		AppealInfo:    rpPromoModerationAppealInfo,
-	})
-}
-
-// AdminRpPromoBanHandler issues an escalating ban against a user, optionally
-// removes their live promos from Discord, and sends the evidence email.
-// Staff (admin or owner).
-func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request) {
+// AdminRpPromoBanTestEmailHandler renders the same email(s) a real ban would
+// send and delivers them to the admin (or a provided testEmail) — no offense is
+// recorded, nothing is enforced, no posts are removed. Lets staff verify the
+// email end-to-end (safe to run against the ignored test accounts). Staff only.
+func (c Community) AdminRpPromoBanTestEmailHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	var req struct {
-		adminCurrentUserBody
-		UserID         string                      `json:"userId"`
-		Reason         string                      `json:"reason"`
-		Evidence       []adminRpPromoEvidenceInput `json:"evidence"`
-		RemoveLivePosts bool                       `json:"removeLivePosts"`
-		SendEmail      *bool                       `json:"sendEmail"`
-	}
+	var req adminRpPromoBanRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
 		return
@@ -691,8 +878,66 @@ func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request
 		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
 		return
 	}
-	if strings.TrimSpace(req.UserID) == "" {
-		config.ErrorStatus("userId is required", http.StatusBadRequest, w, nil)
+	if err := req.validate(); err != nil {
+		config.ErrorStatus(err.Error(), http.StatusBadRequest, w, err)
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+	adminEmail, _ := req.CurrentUser["email"].(string)
+
+	dest := strings.TrimSpace(req.TestEmail)
+	if dest == "" {
+		dest = adminEmail
+	}
+	if dest == "" {
+		config.ErrorStatus("no test recipient — provide testEmail or sign in with an email", http.StatusBadRequest, w, nil)
+		return
+	}
+
+	plan := c.buildRpPromoBanPlan(ctx, req, adminEmail)
+	evidence := parseEvidence(req.Evidence)
+
+	sent := 0
+	for _, n := range plan.Notifications {
+		realRecipient := n.Email
+		if realRecipient == "" {
+			realRecipient = "(no email on file)"
+		}
+		banner := "This is a test. A real ban would send this to " + realRecipient + "."
+		if err := c.sendNotificationEmail(dest, n, req.Reason, evidence, banner); err != nil {
+			zap.S().Errorw("rp promo moderation: test email failed", "to", dest, "error", err)
+			config.ErrorStatus("failed to send test email", http.StatusBadGateway, w, err)
+			return
+		}
+		sent++
+	}
+
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "test email sent",
+		"sentTo":  dest,
+		"count":   sent,
+	})
+}
+
+// AdminRpPromoBanHandler issues escalating bans against the poster and/or the
+// community, optionally removes their live promos from Discord, and emails each
+// affected party. Staff (admin or owner).
+func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req adminRpPromoBanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		config.ErrorStatus("invalid request body", http.StatusBadRequest, w, err)
+		return
+	}
+	if err := checkAdminOrOwnerPermissions(req.CurrentUser); err != nil {
+		config.ErrorStatus("insufficient permissions", http.StatusForbidden, w, err)
+		return
+	}
+	if err := req.validate(); err != nil {
+		config.ErrorStatus(err.Error(), http.StatusBadRequest, w, err)
 		return
 	}
 	adminEmail, _ := req.CurrentUser["email"].(string)
@@ -700,78 +945,71 @@ func (c Community) AdminRpPromoBanHandler(w http.ResponseWriter, r *http.Request
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
-	prior, err := c.countActiveRpPromoOffenses(ctx, req.UserID)
-	if err != nil {
-		config.ErrorStatus("failed to compute offense history", http.StatusInternalServerError, w, err)
-		return
-	}
-	offenseNumber := int(prior) + 1
-	now := time.Now()
-	nowDT := primitive.NewDateTimeFromTime(now)
-	expiresAt := rpPromoOffenseExpiry(offenseNumber, now)
+	plan := c.buildRpPromoBanPlan(ctx, req, adminEmail)
 	evidence := parseEvidence(req.Evidence)
 
-	email, username := resolveUserContact(c.UDB, req.UserID)
-
-	offense := models.RpPromoOffense{
-		UserID:        req.UserID,
-		Username:      username,
-		Email:         email,
-		OffenseNumber: offenseNumber,
-		Reason:        strings.TrimSpace(req.Reason),
-		Evidence:      evidence,
-		IssuedBy:      adminEmail,
-		IssuedAt:      nowDT,
-		ExpiresAt:     expiresAt,
-		Status:        models.RpPromoOffenseStatusActive,
-	}
-
-	// Optionally remove the user's live promos from Discord first, so a partial
-	// failure here surfaces before we record the ban.
+	// Optionally remove the live promos first so a partial failure surfaces
+	// before any ban is recorded.
 	removed := 0
 	if req.RemoveLivePosts {
 		removed = c.removeEvidencePosts(ctx, evidence, adminEmail)
 	}
 
-	// Send the evidence email (default on). A send failure does not block the
-	// ban — the restriction still applies; we just report emailSent=false.
-	emailSent := false
+	// Send one email per affected recipient (default on). Track which recipient
+	// emails succeeded so we can stamp emailSentAt on the matching offense(s).
+	emailsSent := 0
+	sentTo := map[string]bool{}
 	if req.SendEmail == nil || *req.SendEmail {
-		if email != "" {
-			if err := sendOffenseEmail(email, username, offenseNumber, expiresAt, req.Reason, evidence); err != nil {
-				zap.S().Errorw("rp promo moderation: offense email failed", "userId", req.UserID, "error", err)
-			} else {
-				emailSent = true
-				offense.EmailSentAt = &nowDT
+		for _, n := range plan.Notifications {
+			if n.Email == "" {
+				continue
 			}
+			if err := c.sendNotificationEmail(n.Email, n, req.Reason, evidence, ""); err != nil {
+				zap.S().Errorw("rp promo moderation: offense email failed", "to", n.Email, "error", err)
+				continue
+			}
+			emailsSent++
+			sentTo[n.Email] = true
 		}
 	}
 
-	res, err := c.OffDB.InsertOne(ctx, offense)
-	if err != nil {
-		config.ErrorStatus("failed to record the ban", http.StatusInternalServerError, w, err)
-		return
-	}
-	offenseID := ""
-	if oid, ok := res.Decode().(primitive.ObjectID); ok {
-		offenseID = oid.Hex()
+	nowDT := primitive.NewDateTimeFromTime(time.Now())
+	resp := map[string]interface{}{
+		"message":      "ban issued",
+		"emailsSent":   emailsSent,
+		"removedPosts": removed,
 	}
 
-	logAudit(c.ALDB, primitive.NilObjectID, "rp_promotion.banned", "user", "", adminEmail, req.UserID, email,
-		map[string]interface{}{"offenseNumber": offenseNumber, "reason": req.Reason, "removedPosts": removed})
-
-	expiresStr := "permanent"
-	if expiresAt != nil {
-		expiresStr = expiresAt.Time().UTC().Format(time.RFC3339)
+	insert := func(o *models.RpPromoOffense, key, scope, targetID, targetName string) {
+		if o == nil {
+			return
+		}
+		if sentTo[o.Email] {
+			o.EmailSentAt = &nowDT
+		}
+		res, err := c.OffDB.InsertOne(ctx, *o)
+		if err != nil {
+			zap.S().Errorw("rp promo moderation: failed to record offense", "scope", scope, "error", err)
+			return
+		}
+		id := ""
+		if oid, ok := res.Decode().(primitive.ObjectID); ok {
+			id = oid.Hex()
+		}
+		resp[key] = map[string]interface{}{
+			"offenseId":     id,
+			"offenseNumber": o.OffenseNumber,
+			"expiresAt":     offenseExpiresStr(o),
+		}
+		logAudit(c.ALDB, primitive.NilObjectID, "rp_promotion.banned", scope, "", adminEmail, targetID, targetName,
+			map[string]interface{}{"offenseNumber": o.OffenseNumber, "reason": req.Reason, "removedPosts": removed})
 	}
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"message":       "ban issued",
-		"offenseId":     offenseID,
-		"offenseNumber": offenseNumber,
-		"expiresAt":     expiresStr,
-		"emailSent":     emailSent,
-		"removedPosts":  removed,
-	})
+	insert(plan.UserOffense, "user", "user", req.UserID, "")
+	if plan.CommunityOffense != nil {
+		insert(plan.CommunityOffense, "community", "community", req.CommunityID, plan.CommunityOffense.CommunityName)
+	}
+
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // removeEvidencePosts removes from Discord, and marks removed, each evidence
@@ -809,12 +1047,16 @@ func (c Community) removeEvidencePosts(ctx context.Context, evidence []models.Rp
 	return removed
 }
 
-// sendOffenseEmail renders and sends the offense email via SendGrid.
-func sendOffenseEmail(toEmail, username string, offenseNumber int, expiresAt *primitive.DateTime, reason string, ev []models.RpPromoEvidence) error {
-	htmlBody, textBody := renderOffenseEmail(username, offenseNumber, expiresAt, reason, ev)
+// sendNotificationEmail renders a recipient notification and sends it via
+// SendGrid to toEmail (the real recipient, or an override for test sends).
+func (c Community) sendNotificationEmail(toEmail string, n rpPromoNotification, reason string, ev []models.RpPromoEvidence, testBanner string) error {
+	htmlBody, textBody := renderNotificationEmail(n, reason, ev, testBanner)
 	subject := "Action taken on your Lines Police CAD server promotions"
+	if testBanner != "" {
+		subject = "[TEST] " + subject
+	}
 	from := mail.NewEmail("Lines Police CAD", "no-reply@linespolice-cad.com")
-	to := mail.NewEmail(username, toEmail)
+	to := mail.NewEmail(n.Username, toEmail)
 	message := mail.NewSingleEmail(from, subject, to, textBody, htmlBody)
 	client := sendgrid.NewSendClient(os.Getenv("SENDGRID_API_KEY"))
 	resp, err := client.Send(message)
@@ -890,7 +1132,10 @@ func (c Community) AdminListRpPromoOffensesHandler(w http.ResponseWriter, r *htt
 		}
 		out = append(out, map[string]interface{}{
 			"id":            o.ID.Hex(),
+			"scope":         o.Scope,
 			"userId":        o.UserID,
+			"communityId":   o.CommunityID,
+			"communityName": o.CommunityName,
 			"username":      o.Username,
 			"email":         o.Email,
 			"offenseNumber": o.OffenseNumber,

--- a/api/handlers/admin_rp_promos.go
+++ b/api/handlers/admin_rp_promos.go
@@ -294,11 +294,18 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// First pass: tally, per invite and per normalized name, the set of DISTINCT
-	// communities using it. Only cross-community reuse is suspicious — one
-	// community re-promoting on different days (respecting the cooldown) is fine.
+	// First pass: tally the set of DISTINCT communities behind each invite and
+	// each name. Only cross-community reuse is suspicious — one community
+	// re-promoting on different days (respecting the cooldown) is fine.
+	//
+	// Invite is owner-agnostic: the same Discord invite under two communities is
+	// literally the same server, whoever owns it. Name is scoped per OWNER
+	// (key = name + ownerID): generic names like "San Andreas State Roleplay"
+	// collide across unrelated communities constantly, so a name match only
+	// signals evasion when the SAME owner is behind both communities (the
+	// "spin up a near-identical community" pattern).
 	inviteCommunities := map[string]map[string]bool{} // invite -> set of communityIds
-	nameCommunities := map[string]map[string]bool{}   // normName -> set of communityIds
+	nameCommunities := map[string]map[string]bool{}   // name+ownerID -> set of communityIds
 	for _, row := range rows {
 		cid := row.CommunityID.Hex()
 		if inv := rpPromoNormalizeInvite(row.Post.Data.InviteURL); inv != "" {
@@ -308,10 +315,11 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			inviteCommunities[inv][cid] = true
 		}
 		if nm := rpPromoNormalizeName(row.Post.Data.ServerName); nm != "" {
-			if nameCommunities[nm] == nil {
-				nameCommunities[nm] = map[string]bool{}
+			key := nm + "\x00" + row.OwnerID
+			if nameCommunities[key] == nil {
+				nameCommunities[key] = map[string]bool{}
 			}
-			nameCommunities[nm][cid] = true
+			nameCommunities[key][cid] = true
 		}
 	}
 
@@ -339,8 +347,12 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 		p := row.Post
 		inv := rpPromoNormalizeInvite(p.Data.InviteURL)
 		nm := rpPromoNormalizeName(p.Data.ServerName)
+		nameKey := ""
+		if nm != "" {
+			nameKey = nm + "\x00" + row.OwnerID
+		}
 		dupInvite := inv != "" && len(inviteCommunities[inv]) > 1
-		dupName := nm != "" && len(nameCommunities[nm]) > 1
+		dupName := nameKey != "" && len(nameCommunities[nameKey]) > 1
 
 		postedByName := p.PostedByName
 		if postedByName == "" {
@@ -373,10 +385,10 @@ func (c Community) AdminListRpPromosHandler(w http.ResponseWriter, r *http.Reque
 			it.DupCommunityCount = len(inviteCommunities[inv])
 			it.DupAlsoName = dupName
 		case dupName:
-			it.DupGroupID = "name:" + nm
+			it.DupGroupID = "name:" + nameKey
 			it.DupGroupType = "name"
 			it.DupGroupValue = p.Data.ServerName
-			it.DupCommunityCount = len(nameCommunities[nm])
+			it.DupCommunityCount = len(nameCommunities[nameKey])
 		}
 		items = append(items, it)
 	}

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -285,6 +285,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/rp-promos/offenses/{id}/reverse", http.HandlerFunc(c.AdminReverseRpPromoOffenseHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/offenses", http.HandlerFunc(c.AdminListRpPromoOffensesHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/ban/preview", http.HandlerFunc(c.AdminRpPromoBanPreviewHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/ban/test-email", http.HandlerFunc(c.AdminRpPromoBanTestEmailHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/ban", http.HandlerFunc(c.AdminRpPromoBanHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/delete", http.HandlerFunc(c.AdminDeleteRpPromoHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos", http.HandlerFunc(c.AdminListRpPromosHandler)).Methods("POST")

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -283,6 +283,7 @@ func (a *App) New() *mux.Router {
 
 	// Admin RP server promotion moderation routes (specific before general)
 	apiCreate.Handle("/admin/rp-promos/offenses/{id}/reverse", http.HandlerFunc(c.AdminReverseRpPromoOffenseHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/flagged-count", http.HandlerFunc(c.AdminRpPromoFlaggedCountHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/offenses", http.HandlerFunc(c.AdminListRpPromoOffensesHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/ban/preview", http.HandlerFunc(c.AdminRpPromoBanPreviewHandler)).Methods("POST")
 	apiCreate.Handle("/admin/rp-promos/ban/test-email", http.HandlerFunc(c.AdminRpPromoBanTestEmailHandler)).Methods("POST")

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -54,7 +54,7 @@ func (a *App) New() *mux.Router {
 	sessionDB := databases.NewClockSessionDatabase(a.dbHelper)
 	u := User{DB: databases.NewUserDatabase(a.dbHelper), CDB: databases.NewCommunityDatabase(a.dbHelper), EntDB: databases.NewContentCreatorEntitlementDatabase(a.dbHelper), PTDB: ptDB, ALDB: alDB, UPDB: upDB, SEDB: seDB, ACDB: acDB, SDB: sessionDB}
 	dept := Community{DB: databases.NewCommunityDatabase(a.dbHelper), UDB: databases.NewUserDatabase(a.dbHelper)}
-	c := Community{DB: databases.NewCommunityDatabase(a.dbHelper), UDB: databases.NewUserDatabase(a.dbHelper), ADB: databases.NewArchivedCommunityDatabase(a.dbHelper), IDB: databases.NewInviteCodeDatabase(a.dbHelper), UPDB: databases.NewUserPreferencesDatabase(a.dbHelper), CDB: databases.NewCivilianDatabase(a.dbHelper), VDB: databases.NewVehicleDatabase(a.dbHelper), FDB: databases.NewFirearmDatabase(a.dbHelper), DBHelper: a.dbHelper, PTDB: ptDB, ALDB: alDB, TLDB: tlDB}
+	c := Community{DB: databases.NewCommunityDatabase(a.dbHelper), UDB: databases.NewUserDatabase(a.dbHelper), ADB: databases.NewArchivedCommunityDatabase(a.dbHelper), IDB: databases.NewInviteCodeDatabase(a.dbHelper), UPDB: databases.NewUserPreferencesDatabase(a.dbHelper), CDB: databases.NewCivilianDatabase(a.dbHelper), VDB: databases.NewVehicleDatabase(a.dbHelper), FDB: databases.NewFirearmDatabase(a.dbHelper), DBHelper: a.dbHelper, PTDB: ptDB, ALDB: alDB, TLDB: tlDB, OffDB: databases.NewRpPromoOffenseDatabase(a.dbHelper)}
 	civ := Civilian{DB: databases.NewCivilianDatabase(a.dbHelper), UDB: databases.NewUserDatabase(a.dbHelper), CommDB: databases.NewCommunityDatabase(a.dbHelper), IDB: databases.NewInboxItemDatabase(a.dbHelper), SDB: databases.NewClockSessionDatabase(a.dbHelper), ACDB: acDB}
 	v := Vehicle{DB: databases.NewVehicleDatabase(a.dbHelper)}
 	f := Firearm{DB: databases.NewFirearmDatabase(a.dbHelper)}
@@ -280,6 +280,14 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/admin/admins/{id}", http.HandlerFunc(adminHandler.AdminGetAdminDetailsHandler)).Methods("GET")
 	apiCreate.Handle("/admin/admins/{id}", http.HandlerFunc(adminHandler.AdminDeleteAdminHandler)).Methods("DELETE")
 	apiCreate.Handle("/admin/admins", http.HandlerFunc(adminHandler.AdminGetAllAdminsHandler)).Methods("POST")
+
+	// Admin RP server promotion moderation routes (specific before general)
+	apiCreate.Handle("/admin/rp-promos/offenses/{id}/reverse", http.HandlerFunc(c.AdminReverseRpPromoOffenseHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/offenses", http.HandlerFunc(c.AdminListRpPromoOffensesHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/ban/preview", http.HandlerFunc(c.AdminRpPromoBanPreviewHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/ban", http.HandlerFunc(c.AdminRpPromoBanHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos/delete", http.HandlerFunc(c.AdminDeleteRpPromoHandler)).Methods("POST")
+	apiCreate.Handle("/admin/rp-promos", http.HandlerFunc(c.AdminListRpPromosHandler)).Methods("POST")
 
 	// Other admin routes
 	apiCreate.Handle("/admin/send-reset-email", http.HandlerFunc(adminHandler.SendAdminResetEmailHandler)).Methods("POST")

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -208,6 +208,7 @@ type Community struct {
 	PTDB     databases.PushTokenDatabase
 	ALDB     databases.AuditLogDatabase
 	TLDB     databases.ToneLogDatabase
+	OffDB    databases.RpPromoOffenseDatabase
 }
 
 // CommunityHandler returns a community given a communityID

--- a/api/handlers/rp_promotion.go
+++ b/api/handlers/rp_promotion.go
@@ -311,6 +311,30 @@ func (c Community) PostRpPromotionHandler(w http.ResponseWriter, r *http.Request
 
 	tier := rpPromotionTierForCommunity(community)
 
+	// Moderation gate — a staff admin may ban a user from promoting. The ban is
+	// keyed by user (not community), so we block the post if EITHER the target
+	// community's owner OR the user clicking "post" is currently restricted.
+	// This is what stops the multi-community evasion the per-community cooldown
+	// below cannot catch.
+	banCandidates := []string{community.Details.OwnerID}
+	if actorID != community.Details.OwnerID {
+		banCandidates = append(banCandidates, actorID)
+	}
+	if ban := c.activeRpPromoBan(ctx, banCandidates...); ban != nil {
+		restrictedUntil := "permanent"
+		if ban.ExpiresAt != nil {
+			restrictedUntil = ban.ExpiresAt.Time().UTC().Format(time.RFC3339)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":           "this account is restricted from posting promotions",
+			"restrictedUntil": restrictedUntil,
+			"appealInfo":      "If you believe this is a mistake, open a ticket in the assistance channel of the Lines Police CAD Discord server.",
+		})
+		return
+	}
+
 	// Cooldown gate — one promotion per community per cooldown window.
 	cooldown := rpPromotionCooldown()
 	if rp := community.Details.RpPromotion; rp != nil && rp.LastPostedAt != nil {

--- a/api/handlers/rp_promotion.go
+++ b/api/handlers/rp_promotion.go
@@ -320,7 +320,7 @@ func (c Community) PostRpPromotionHandler(w http.ResponseWriter, r *http.Request
 	if actorID != community.Details.OwnerID {
 		banCandidates = append(banCandidates, actorID)
 	}
-	if ban := c.activeRpPromoBan(ctx, banCandidates...); ban != nil {
+	if ban := c.activeRpPromoBan(ctx, communityID, banCandidates...); ban != nil {
 		restrictedUntil := "permanent"
 		if ban.ExpiresAt != nil {
 			restrictedUntil = ban.ExpiresAt.Time().UTC().Format(time.RFC3339)

--- a/api/handlers/rp_promotion.go
+++ b/api/handlers/rp_promotion.go
@@ -400,6 +400,10 @@ func (c Community) PostRpPromotionHandler(w http.ResponseWriter, r *http.Request
 	logAudit(c.ALDB, communityObjID, "rp_promotion.posted", "community", actorID, actorName, "", "",
 		map[string]interface{}{"serverName": data.ServerName, "tier": tier.Key})
 
+	// Nudge staff if this post looks like a possible duplicate. Runs detached so
+	// it never slows the user's request.
+	go c.alertIfRpPromoFlagged(communityID, community.Details.Name, community.Details.OwnerID, data)
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{

--- a/api/handlers/rp_promotion_discord.go
+++ b/api/handlers/rp_promotion_discord.go
@@ -255,3 +255,45 @@ func sendRpPromotionWebhook(webhookURL string, data models.RpPromotionData, tier
 	_ = json.NewDecoder(resp.Body).Decode(&parsed)
 	return parsed.ID, parsed.ChannelID, nil
 }
+
+// deleteRpPromotionWebhookMessage removes a previously posted promotion from the
+// Discord channel. A webhook can delete its own messages, so no bot token is
+// needed — we issue DELETE {webhookURL}/messages/{messageID}. The webhook URL
+// is of the form https://discord.com/api/webhooks/{id}/{token}; we strip any
+// query string before appending the messages path. A 404 means the message is
+// already gone, which we treat as success (the desired end state is reached).
+func deleteRpPromotionWebhookMessage(webhookURL, messageID string) error {
+	if strings.TrimSpace(webhookURL) == "" {
+		return fmt.Errorf("webhook url not configured")
+	}
+	if strings.TrimSpace(messageID) == "" {
+		return fmt.Errorf("missing message id")
+	}
+
+	base := webhookURL
+	if i := strings.Index(base, "?"); i >= 0 {
+		base = base[:i]
+	}
+	base = strings.TrimRight(base, "/")
+	url := base + "/messages/" + messageID
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("build delete request: %w", err)
+	}
+
+	client := &http.Client{Timeout: rpPromoHTTPDeadline}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete from discord: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil // already deleted
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("discord returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/api/handlers/rp_promotion_discord.go
+++ b/api/handlers/rp_promotion_discord.go
@@ -5,11 +5,101 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/linesmerrill/police-cad-api/models"
 )
+
+// Best-effort alert to the staff "alerts-website" Discord channel when a newly
+// posted promotion looks like a possible duplicate, so staff know to review the
+// Server Promos moderation panel. Reads DISCORD_ALERTS_WEBSITE_WEBHOOK_URL;
+// silent no-op when unset. One alert per (community, match-kind) within a dedup
+// window so a flag isn't announced repeatedly.
+const (
+	rpPromoAlertWebhookEnv  = "DISCORD_ALERTS_WEBSITE_WEBHOOK_URL"
+	rpPromoModerationPanelURL = "https://www.linespolice-cad.com/admin/console#rp-promos"
+	rpPromoAlertDedupWindow = 10 * time.Minute
+)
+
+var (
+	rpPromoAlertMu     sync.Mutex
+	rpPromoAlertRecent = map[string]time.Time{}
+)
+
+// sendRpPromoFlaggedAlert posts a single review-nudge embed to the alerts
+// channel. dedupSig collapses repeats within the dedup window.
+func sendRpPromoFlaggedAlert(serverName, ownerName, matchKind string, communityNames []string, inviteURL, dedupSig string) {
+	webhook := os.Getenv(rpPromoAlertWebhookEnv)
+	if webhook == "" {
+		return
+	}
+
+	now := time.Now()
+	rpPromoAlertMu.Lock()
+	if t, ok := rpPromoAlertRecent[dedupSig]; ok && now.Sub(t) < rpPromoAlertDedupWindow {
+		rpPromoAlertMu.Unlock()
+		return
+	}
+	rpPromoAlertRecent[dedupSig] = now
+	for k, t := range rpPromoAlertRecent {
+		if now.Sub(t) > rpPromoAlertDedupWindow {
+			delete(rpPromoAlertRecent, k)
+		}
+	}
+	rpPromoAlertMu.Unlock()
+
+	desc := fmt.Sprintf("**%s** by **%s** looks like a possible duplicate (%s).\nCommunities: %s",
+		truncRpAlert(serverName, 200), truncRpAlert(ownerName, 100), matchKind, truncRpAlert(strings.Join(communityNames, ", "), 500))
+	if inviteURL != "" {
+		desc += "\nInvite: " + truncRpAlert(inviteURL, 200)
+	}
+	desc += "\n\n[Review in Server Promos](" + rpPromoModerationPanelURL + ")"
+
+	payload := map[string]interface{}{
+		"content": "🚩 A server promotion was flagged for review.",
+		"embeds": []map[string]interface{}{{
+			"title":       "Possible duplicate server promo",
+			"description": desc,
+			"color":       0xfbbf24,
+			"timestamp":   now.UTC().Format(time.RFC3339),
+		}},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		zap.S().Warnw("rp promo flagged alert: marshal failed", "error", err)
+		return
+	}
+
+	go func() {
+		req, rErr := http.NewRequest(http.MethodPost, webhook, bytes.NewReader(body))
+		if rErr != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		client := &http.Client{Timeout: rpPromoHTTPDeadline}
+		resp, hErr := client.Do(req)
+		if hErr != nil {
+			zap.S().Warnw("rp promo flagged alert: post failed", "error", hErr)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			zap.S().Warnw("rp promo flagged alert: bad response", "status", resp.StatusCode)
+		}
+	}()
+}
+
+func truncRpAlert(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
 
 // RP server promotion → Discord webhook.
 //

--- a/databases/rp_promo_offense.go
+++ b/databases/rp_promo_offense.go
@@ -1,0 +1,49 @@
+package databases
+
+import (
+	"context"
+
+	"github.com/linesmerrill/police-cad-api/models"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const rpPromoOffenseCollectionName = "rp_promo_offenses"
+
+// RpPromoOffenseDatabase defines the interface for rp_promo_offenses operations.
+type RpPromoOffenseDatabase interface {
+	InsertOne(ctx context.Context, offense models.RpPromoOffense, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error)
+	FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) SingleResultHelper
+	Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (*MongoCursor, error)
+	CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error)
+	UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error
+}
+
+type rpPromoOffenseDatabase struct {
+	db DatabaseHelper
+}
+
+// NewRpPromoOffenseDatabase creates a new rp_promo_offenses database wrapper.
+func NewRpPromoOffenseDatabase(db DatabaseHelper) RpPromoOffenseDatabase {
+	return &rpPromoOffenseDatabase{db: db}
+}
+
+func (s *rpPromoOffenseDatabase) InsertOne(ctx context.Context, offense models.RpPromoOffense, opts ...*options.InsertOneOptions) (InsertOneResultHelper, error) {
+	return s.db.Collection(rpPromoOffenseCollectionName).InsertOne(ctx, offense, opts...)
+}
+
+func (s *rpPromoOffenseDatabase) FindOne(ctx context.Context, filter interface{}, opts ...*options.FindOneOptions) SingleResultHelper {
+	return s.db.Collection(rpPromoOffenseCollectionName).FindOne(ctx, filter, opts...)
+}
+
+func (s *rpPromoOffenseDatabase) Find(ctx context.Context, filter interface{}, opts ...*options.FindOptions) (*MongoCursor, error) {
+	return s.db.Collection(rpPromoOffenseCollectionName).Find(ctx, filter, opts...)
+}
+
+func (s *rpPromoOffenseDatabase) CountDocuments(ctx context.Context, filter interface{}, opts ...*options.CountOptions) (int64, error) {
+	return s.db.Collection(rpPromoOffenseCollectionName).CountDocuments(ctx, filter, opts...)
+}
+
+func (s *rpPromoOffenseDatabase) UpdateOne(ctx context.Context, filter interface{}, update interface{}, opts ...*options.UpdateOptions) error {
+	_, err := s.db.Collection(rpPromoOffenseCollectionName).UpdateOne(ctx, filter, update, opts...)
+	return err
+}

--- a/models/community.go
+++ b/models/community.go
@@ -106,6 +106,14 @@ type RpPromotionPost struct {
 	MessageID string             `json:"messageId,omitempty" bson:"messageId,omitempty"` // Discord message ID
 	ChannelID string             `json:"channelId,omitempty" bson:"channelId,omitempty"` // Discord channel ID, for building a jump link
 	Data      RpPromotionData    `json:"data" bson:"data"`
+
+	// Soft-removal fields, set when a staff admin removes a promotion from the
+	// Discord channel via the moderation console. The entry is retained (not
+	// $pull-ed) so it survives as evidence for any offense issued against the
+	// poster. RemovedAt being non-nil means the live Discord message is gone.
+	RemovedAt    *primitive.DateTime `json:"removedAt,omitempty" bson:"removedAt,omitempty"`
+	RemovedBy    string              `json:"removedBy,omitempty" bson:"removedBy,omitempty"` // admin email
+	RemoveReason string              `json:"removeReason,omitempty" bson:"removeReason,omitempty"`
 }
 
 // RpPromotionData is the structured content of an RP server promotion post.

--- a/models/rp_promo_offense.go
+++ b/models/rp_promo_offense.go
@@ -15,10 +15,17 @@ import "go.mongodb.org/mongo-driver/bson/primitive"
 // counts every "active" offense (expired-by-time ones still count) and excludes
 // "reversed" ones (those were overturned on appeal).
 type RpPromoOffense struct {
-	ID             primitive.ObjectID  `json:"_id,omitempty" bson:"_id,omitempty"`
-	UserID         string              `json:"userId" bson:"userId"`                                 // the banned user (a community owner or the posting actor)
-	Username       string              `json:"username,omitempty" bson:"username,omitempty"`         // captured at issue time for the audit trail
-	Email          string              `json:"email,omitempty" bson:"email,omitempty"`               // captured at issue time
+	ID    primitive.ObjectID `json:"_id,omitempty" bson:"_id,omitempty"`
+	Scope string             `json:"scope" bson:"scope"` // "user" | "community"
+	// User-scoped bans set UserID (the banned poster); community-scoped bans set
+	// CommunityID instead and leave UserID empty, so escalation counts and the
+	// enforcement lookup stay unambiguous. Username/Email are the notified
+	// contact either way (the banned user, or the community's owner).
+	UserID        string `json:"userId,omitempty" bson:"userId,omitempty"`               // banned user (user scope)
+	CommunityID   string `json:"communityId,omitempty" bson:"communityId,omitempty"`     // banned community (community scope)
+	CommunityName string `json:"communityName,omitempty" bson:"communityName,omitempty"` // captured at issue time
+	Username      string `json:"username,omitempty" bson:"username,omitempty"`           // notified contact username
+	Email         string `json:"email,omitempty" bson:"email,omitempty"`                 // notified contact email
 	OffenseNumber  int                 `json:"offenseNumber" bson:"offenseNumber"`                   // 1, 2, 3, 4+ — drives the penalty ladder
 	Reason         string              `json:"reason" bson:"reason"`                                 // admin-supplied reason
 	Evidence       []RpPromoEvidence   `json:"evidence,omitempty" bson:"evidence,omitempty"`         // the promos that justify the ban
@@ -48,4 +55,10 @@ type RpPromoEvidence struct {
 const (
 	RpPromoOffenseStatusActive   = "active"
 	RpPromoOffenseStatusReversed = "reversed"
+)
+
+// RpPromoOffense scope values.
+const (
+	RpPromoOffenseScopeUser      = "user"
+	RpPromoOffenseScopeCommunity = "community"
 )

--- a/models/rp_promo_offense.go
+++ b/models/rp_promo_offense.go
@@ -1,0 +1,51 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+// RpPromoOffense is a single moderation action taken against a user for abusing
+// the RP server promotion feature (for example, spinning up multiple
+// communities to evade the per-community posting cooldown). One document is
+// stored per offense, keyed by the offending user so escalation can span every
+// community they own.
+//
+// There is deliberately no "expired" status and no expiry cron. Relying on a
+// stored flag that nothing flips is a known footgun in this codebase, so an
+// offense is only ever "active" or "reversed". A ban is considered in force
+// when Status == "active" AND (ExpiresAt == nil OR ExpiresAt > now); escalation
+// counts every "active" offense (expired-by-time ones still count) and excludes
+// "reversed" ones (those were overturned on appeal).
+type RpPromoOffense struct {
+	ID             primitive.ObjectID  `json:"_id,omitempty" bson:"_id,omitempty"`
+	UserID         string              `json:"userId" bson:"userId"`                                 // the banned user (a community owner or the posting actor)
+	Username       string              `json:"username,omitempty" bson:"username,omitempty"`         // captured at issue time for the audit trail
+	Email          string              `json:"email,omitempty" bson:"email,omitempty"`               // captured at issue time
+	OffenseNumber  int                 `json:"offenseNumber" bson:"offenseNumber"`                   // 1, 2, 3, 4+ — drives the penalty ladder
+	Reason         string              `json:"reason" bson:"reason"`                                 // admin-supplied reason
+	Evidence       []RpPromoEvidence   `json:"evidence,omitempty" bson:"evidence,omitempty"`         // the promos that justify the ban
+	IssuedBy       string              `json:"issuedBy" bson:"issuedBy"`                             // admin email
+	IssuedAt       primitive.DateTime  `json:"issuedAt" bson:"issuedAt"`
+	ExpiresAt      *primitive.DateTime `json:"expiresAt,omitempty" bson:"expiresAt,omitempty"`       // nil = permanent
+	Status         string              `json:"status" bson:"status"`                                 // "active" | "reversed"
+	ReversedBy     string              `json:"reversedBy,omitempty" bson:"reversedBy,omitempty"`     // admin email
+	ReversedAt     *primitive.DateTime `json:"reversedAt,omitempty" bson:"reversedAt,omitempty"`
+	ReversalReason string              `json:"reversalReason,omitempty" bson:"reversalReason,omitempty"`
+	EmailSentAt    *primitive.DateTime `json:"emailSentAt,omitempty" bson:"emailSentAt,omitempty"`
+}
+
+// RpPromoEvidence is a snapshot of a single promotion that contributed to an
+// offense, retained on the offense document so the evidence survives even if
+// the underlying promo is later removed or ages out of the community's history.
+type RpPromoEvidence struct {
+	CommunityID   string             `json:"communityId" bson:"communityId"`
+	CommunityName string             `json:"communityName" bson:"communityName"`
+	ServerName    string             `json:"serverName" bson:"serverName"`
+	InviteURL     string             `json:"inviteUrl" bson:"inviteUrl"`
+	MessageID     string             `json:"messageId,omitempty" bson:"messageId,omitempty"`
+	PostedAt      primitive.DateTime `json:"postedAt" bson:"postedAt"`
+}
+
+// RpPromoOffense status values.
+const (
+	RpPromoOffenseStatusActive   = "active"
+	RpPromoOffenseStatusReversed = "reversed"
+)

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -857,5 +857,16 @@ createIndexSafe(
   }
 );
 
+// Community-scoped bans are looked up by communityId on every promotion post
+// (enforcement gate) and counted for the community escalation ladder.
+createIndexSafe(
+  db.rp_promo_offenses,
+  { communityId: 1, status: 1 },
+  {
+    name: "rp_promo_offenses_community_status_idx",
+    background: true
+  }
+);
+
 print("\n=== All indexes (including Performance Advisor recommendations) processed ===");
 

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -845,5 +845,17 @@ createIndexSafe(
   }
 );
 
+// RP server promotion moderation: the enforcement gate looks up a user's
+// in-force bans by userId + status on every promotion post, and the admin
+// console lists offenses by user. One compound index covers both.
+createIndexSafe(
+  db.rp_promo_offenses,
+  { userId: 1, status: 1 },
+  {
+    name: "rp_promo_offenses_user_status_idx",
+    background: true
+  }
+);
+
 print("\n=== All indexes (including Performance Advisor recommendations) processed ===");
 

--- a/templates/html/rpPromoOffense.go
+++ b/templates/html/rpPromoOffense.go
@@ -15,20 +15,29 @@ type RpPromoOffenseEvidenceLine struct {
 	PostedAt      string // human-readable, already formatted by the caller
 }
 
-// RpPromoOffenseEmailParams is the content for an RP promotion offense email.
-type RpPromoOffenseEmailParams struct {
-	Username      string
-	OffenseNumber int
+// RpPromoOffenseRestriction is one restriction applied to the recipient — their
+// own account, and/or a community they own. A single recipient can have more
+// than one (e.g. the poster who also owns the banned community).
+type RpPromoOffenseRestriction struct {
+	Label         string // e.g. "your account" or the community "Vice City Rejects"
 	PenaltyLabel  string // e.g. "7-day", "30-day", "1-year", "permanent"
-	LiftsAt       string // human-readable date the restriction lifts, or "" if permanent
-	Reason        string // admin-supplied reason / summary of what happened
-	Evidence      []RpPromoOffenseEvidenceLine
-	ToSURL        string // link to the Discord Community Promotion section of the ToS
-	AppealInfo    string // how to appeal (e.g. open a ticket in the Discord assistance channel)
+	LiftsAt       string // human-readable date it lifts, or "" if permanent
+	OffenseNumber int
 }
 
-// rpPromoOffenseLadder describes the full escalation ladder so the email can
-// transparently show the recipient where they are and what comes next.
+// RpPromoOffenseEmailParams is the content for an RP promotion offense email.
+type RpPromoOffenseEmailParams struct {
+	Username     string
+	Restrictions []RpPromoOffenseRestriction
+	Reason       string // admin-supplied reason / summary of what happened
+	Evidence     []RpPromoOffenseEvidenceLine
+	ToSURL       string // link to the Discord Community Promotion section of the ToS
+	AppealInfo   string // how to appeal
+	TestBanner   string // non-empty renders a "this is a test" banner (test sends only)
+}
+
+// rpPromoOffenseLadder describes the full escalation ladder so the recipient can
+// see what comes next.
 var rpPromoOffenseLadder = []string{
 	"1st offense — 7-day restriction",
 	"2nd offense — 30-day restriction",
@@ -37,17 +46,16 @@ var rpPromoOffenseLadder = []string{
 }
 
 // RenderRpPromoOffenseEmail returns the HTML and plain-text bodies for an RP
-// promotion offense notification. The HTML mirrors the branded style of
-// RenderGenericEmail. All user-controlled values are HTML-escaped.
+// promotion offense notification. All user-controlled values are HTML-escaped.
 func RenderRpPromoOffenseEmail(p RpPromoOffenseEmailParams) (htmlBody, textBody string) {
 	return renderRpPromoOffenseHTML(p), renderRpPromoOffenseText(p)
 }
 
-func rpPromoPenaltySentence(p RpPromoOffenseEmailParams) string {
-	if p.LiftsAt == "" || strings.EqualFold(p.PenaltyLabel, "permanent") {
-		return "Your ability to post server promotions has been permanently restricted."
+func rpPromoRestrictionSentence(r RpPromoOffenseRestriction) string {
+	if r.LiftsAt == "" || strings.EqualFold(r.PenaltyLabel, "permanent") {
+		return fmt.Sprintf("Offense #%d — %s is permanently restricted from posting server promotions.", r.OffenseNumber, r.Label)
 	}
-	return fmt.Sprintf("Your ability to post server promotions has been restricted for %s. The restriction lifts on %s.", p.PenaltyLabel, p.LiftsAt)
+	return fmt.Sprintf("Offense #%d — %s is restricted from posting server promotions for %s (lifts %s).", r.OffenseNumber, r.Label, r.PenaltyLabel, r.LiftsAt)
 }
 
 func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
@@ -56,6 +64,11 @@ func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
 	greeting := "Hello,"
 	if strings.TrimSpace(p.Username) != "" {
 		greeting = "Hello " + html.EscapeString(p.Username) + ","
+	}
+
+	var penalties strings.Builder
+	for _, r := range p.Restrictions {
+		penalties.WriteString("<div style=\"margin-bottom:6px;\">" + html.EscapeString(rpPromoRestrictionSentence(r)) + "</div>")
 	}
 
 	var rows strings.Builder
@@ -74,12 +87,8 @@ func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
 	}
 
 	var ladder strings.Builder
-	for i, step := range rpPromoOffenseLadder {
-		style := "color:#9ca3af;"
-		if i+1 == p.OffenseNumber {
-			style = "color:#fbbf24;font-weight:700;" // highlight the current step
-		}
-		ladder.WriteString(fmt.Sprintf(`<li style="%s margin-bottom:4px;">%s</li>`, style, html.EscapeString(step)))
+	for _, step := range rpPromoOffenseLadder {
+		ladder.WriteString(fmt.Sprintf(`<li style="color:#9ca3af; margin-bottom:4px;">%s</li>`, html.EscapeString(step)))
 	}
 
 	reasonBlock := ""
@@ -88,8 +97,11 @@ func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
 			strings.ReplaceAll(html.EscapeString(p.Reason), "\n", "<br>"))
 	}
 
-	appeal := html.EscapeString(p.AppealInfo)
-	tosURL := html.EscapeString(p.ToSURL)
+	testBanner := ""
+	if strings.TrimSpace(p.TestBanner) != "" {
+		testBanner = fmt.Sprintf(`<div style="background:rgba(56,189,248,0.12); border:1px solid rgba(56,189,248,0.4); border-radius:8px; padding:12px 14px; margin:0 0 16px; color:#7dd3fc;"><strong>TEST EMAIL</strong> — %s</div>`,
+			html.EscapeString(p.TestBanner))
+	}
 
 	return fmt.Sprintf(`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -116,8 +128,9 @@ func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
   <div class="container">
     <div class="header"><h1>%s</h1></div>
     <div class="content">
+      %s
       <p style="margin:0 0 16px;">%s</p>
-      <div class="penalty"><strong>Offense #%d.</strong> %s</div>
+      <div class="penalty">%s</div>
       %s
       <p style="margin:0 0 8px;"><strong>Promotions involved:</strong></p>
       <table>
@@ -135,17 +148,23 @@ func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
     </div>
   </div>
 </body>
-</html>`, subject, subject, greeting, p.OffenseNumber, rpPromoPenaltySentence(p), reasonBlock, rows.String(), tosURL, ladder.String(), appeal)
+</html>`, subject, subject, testBanner, greeting, penalties.String(), reasonBlock, rows.String(), html.EscapeString(p.ToSURL), ladder.String(), html.EscapeString(p.AppealInfo))
 }
 
 func renderRpPromoOffenseText(p RpPromoOffenseEmailParams) string {
 	var b strings.Builder
+	if strings.TrimSpace(p.TestBanner) != "" {
+		b.WriteString("*** TEST EMAIL — " + p.TestBanner + " ***\n\n")
+	}
 	if strings.TrimSpace(p.Username) != "" {
 		b.WriteString("Hello " + p.Username + ",\n\n")
 	} else {
 		b.WriteString("Hello,\n\n")
 	}
-	b.WriteString(fmt.Sprintf("Offense #%d. %s\n\n", p.OffenseNumber, rpPromoPenaltySentence(p)))
+	for _, r := range p.Restrictions {
+		b.WriteString(rpPromoRestrictionSentence(r) + "\n")
+	}
+	b.WriteString("\n")
 	if strings.TrimSpace(p.Reason) != "" {
 		b.WriteString("What happened:\n" + p.Reason + "\n\n")
 	}

--- a/templates/html/rpPromoOffense.go
+++ b/templates/html/rpPromoOffense.go
@@ -1,0 +1,164 @@
+package templates
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// RpPromoOffenseEvidenceLine is a single promotion shown in the evidence table
+// of an offense email.
+type RpPromoOffenseEvidenceLine struct {
+	CommunityName string
+	ServerName    string
+	InviteURL     string
+	PostedAt      string // human-readable, already formatted by the caller
+}
+
+// RpPromoOffenseEmailParams is the content for an RP promotion offense email.
+type RpPromoOffenseEmailParams struct {
+	Username      string
+	OffenseNumber int
+	PenaltyLabel  string // e.g. "7-day", "30-day", "1-year", "permanent"
+	LiftsAt       string // human-readable date the restriction lifts, or "" if permanent
+	Reason        string // admin-supplied reason / summary of what happened
+	Evidence      []RpPromoOffenseEvidenceLine
+	ToSURL        string // link to the Discord Community Promotion section of the ToS
+	AppealInfo    string // how to appeal (e.g. open a ticket in the Discord assistance channel)
+}
+
+// rpPromoOffenseLadder describes the full escalation ladder so the email can
+// transparently show the recipient where they are and what comes next.
+var rpPromoOffenseLadder = []string{
+	"1st offense — 7-day restriction",
+	"2nd offense — 30-day restriction",
+	"3rd offense — 1-year restriction",
+	"4th offense — permanent restriction (appealable)",
+}
+
+// RenderRpPromoOffenseEmail returns the HTML and plain-text bodies for an RP
+// promotion offense notification. The HTML mirrors the branded style of
+// RenderGenericEmail. All user-controlled values are HTML-escaped.
+func RenderRpPromoOffenseEmail(p RpPromoOffenseEmailParams) (htmlBody, textBody string) {
+	return renderRpPromoOffenseHTML(p), renderRpPromoOffenseText(p)
+}
+
+func rpPromoPenaltySentence(p RpPromoOffenseEmailParams) string {
+	if p.LiftsAt == "" || strings.EqualFold(p.PenaltyLabel, "permanent") {
+		return "Your ability to post server promotions has been permanently restricted."
+	}
+	return fmt.Sprintf("Your ability to post server promotions has been restricted for %s. The restriction lifts on %s.", p.PenaltyLabel, p.LiftsAt)
+}
+
+func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {
+	subject := "Action taken on your Lines Police CAD server promotions"
+
+	greeting := "Hello,"
+	if strings.TrimSpace(p.Username) != "" {
+		greeting = "Hello " + html.EscapeString(p.Username) + ","
+	}
+
+	var rows strings.Builder
+	for _, e := range p.Evidence {
+		invite := html.EscapeString(e.InviteURL)
+		rows.WriteString(fmt.Sprintf(`<tr>
+      <td style="padding:8px 12px;border-bottom:1px solid rgba(255,255,255,0.08);">%s</td>
+      <td style="padding:8px 12px;border-bottom:1px solid rgba(255,255,255,0.08);">%s</td>
+      <td style="padding:8px 12px;border-bottom:1px solid rgba(255,255,255,0.08);"><a href="%s" style="color:#38bdf8;text-decoration:none;">%s</a></td>
+      <td style="padding:8px 12px;border-bottom:1px solid rgba(255,255,255,0.08);">%s</td>
+    </tr>`,
+			html.EscapeString(e.CommunityName),
+			html.EscapeString(e.ServerName),
+			invite, invite,
+			html.EscapeString(e.PostedAt)))
+	}
+
+	var ladder strings.Builder
+	for i, step := range rpPromoOffenseLadder {
+		style := "color:#9ca3af;"
+		if i+1 == p.OffenseNumber {
+			style = "color:#fbbf24;font-weight:700;" // highlight the current step
+		}
+		ladder.WriteString(fmt.Sprintf(`<li style="%s margin-bottom:4px;">%s</li>`, style, html.EscapeString(step)))
+	}
+
+	reasonBlock := ""
+	if strings.TrimSpace(p.Reason) != "" {
+		reasonBlock = fmt.Sprintf(`<p style="margin:0 0 16px;"><strong>What happened:</strong><br>%s</p>`,
+			strings.ReplaceAll(html.EscapeString(p.Reason), "\n", "<br>"))
+	}
+
+	appeal := html.EscapeString(p.AppealInfo)
+	tosURL := html.EscapeString(p.ToSURL)
+
+	return fmt.Sprintf(`<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1">
+  <title>%s</title>
+  <style type="text/css">
+    body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; padding: 0; background-color: #0a0a0f; }
+    .container { max-width: 640px; margin: 0 auto; background-color: #12121f; }
+    .header { background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%); padding: 36px 30px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 22px; font-weight: 700; }
+    .content { padding: 36px 30px; color: #e5e7eb; line-height: 1.6; font-size: 15px; }
+    .penalty { background: rgba(248,113,113,0.12); border: 1px solid rgba(248,113,113,0.35); border-radius: 8px; padding: 16px; margin: 0 0 20px; color: #fecaca; }
+    table { width: 100%%; border-collapse: collapse; font-size: 13px; margin: 8px 0 20px; }
+    th { text-align: left; padding: 8px 12px; color: #9ca3af; border-bottom: 1px solid rgba(255,255,255,0.18); font-weight: 600; }
+    ul { padding-left: 20px; margin: 8px 0 20px; }
+    .footer { padding: 28px 30px; text-align: center; color: #6b7280; font-size: 12px; border-top: 1px solid rgba(255,255,255,0.1); }
+    .footer a { color: #667eea; text-decoration: none; }
+    a { color: #38bdf8; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header"><h1>%s</h1></div>
+    <div class="content">
+      <p style="margin:0 0 16px;">%s</p>
+      <div class="penalty"><strong>Offense #%d.</strong> %s</div>
+      %s
+      <p style="margin:0 0 8px;"><strong>Promotions involved:</strong></p>
+      <table>
+        <thead><tr><th>Community</th><th>Server name</th><th>Invite</th><th>Posted</th></tr></thead>
+        <tbody>%s</tbody>
+      </table>
+      <p style="margin:0 0 8px;">This violates our server-promotion terms, which allow only one promotion per community per posting window. Creating additional communities to post again is treated as evading that limit. See the <a href="%s">Discord Community Promotion</a> section of our Terms of Service.</p>
+      <p style="margin:16px 0 8px;"><strong>How restrictions escalate:</strong></p>
+      <ul>%s</ul>
+      <p style="margin:0 0 8px;"><strong>Appeals:</strong> %s</p>
+    </div>
+    <div class="footer">
+      <p>&copy; Lines Police CAD | <a href="https://www.linespolice-cad.com">linespolice-cad.com</a></p>
+      <p><a href="https://www.linespolice-cad.com/contact-us">Contact Support</a></p>
+    </div>
+  </div>
+</body>
+</html>`, subject, subject, greeting, p.OffenseNumber, rpPromoPenaltySentence(p), reasonBlock, rows.String(), tosURL, ladder.String(), appeal)
+}
+
+func renderRpPromoOffenseText(p RpPromoOffenseEmailParams) string {
+	var b strings.Builder
+	if strings.TrimSpace(p.Username) != "" {
+		b.WriteString("Hello " + p.Username + ",\n\n")
+	} else {
+		b.WriteString("Hello,\n\n")
+	}
+	b.WriteString(fmt.Sprintf("Offense #%d. %s\n\n", p.OffenseNumber, rpPromoPenaltySentence(p)))
+	if strings.TrimSpace(p.Reason) != "" {
+		b.WriteString("What happened:\n" + p.Reason + "\n\n")
+	}
+	b.WriteString("Promotions involved:\n")
+	for _, e := range p.Evidence {
+		b.WriteString(fmt.Sprintf("  - %s | %s | %s | %s\n", e.CommunityName, e.ServerName, e.InviteURL, e.PostedAt))
+	}
+	b.WriteString("\nThis violates our server-promotion terms, which allow only one promotion per community per posting window. Creating additional communities to post again is treated as evading that limit.\n")
+	b.WriteString("Terms of Service: " + p.ToSURL + "\n\n")
+	b.WriteString("How restrictions escalate:\n")
+	for _, step := range rpPromoOffenseLadder {
+		b.WriteString("  - " + step + "\n")
+	}
+	b.WriteString("\nAppeals: " + p.AppealInfo + "\n")
+	return b.String()
+}

--- a/templates/html/rpPromoOffense.go
+++ b/templates/html/rpPromoOffense.go
@@ -51,11 +51,21 @@ func RenderRpPromoOffenseEmail(p RpPromoOffenseEmailParams) (htmlBody, textBody 
 	return renderRpPromoOffenseHTML(p), renderRpPromoOffenseText(p)
 }
 
-func rpPromoRestrictionSentence(r RpPromoOffenseRestriction) string {
-	if r.LiftsAt == "" || strings.EqualFold(r.PenaltyLabel, "permanent") {
-		return fmt.Sprintf("Offense #%d — %s is permanently restricted from posting server promotions.", r.OffenseNumber, r.Label)
+// capitalizeFirst upper-cases the first letter so a label like "your account"
+// reads correctly at the start of a sentence.
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
 	}
-	return fmt.Sprintf("Offense #%d — %s is restricted from posting server promotions for %s (lifts %s).", r.OffenseNumber, r.Label, r.PenaltyLabel, r.LiftsAt)
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func rpPromoRestrictionSentence(r RpPromoOffenseRestriction) string {
+	label := capitalizeFirst(r.Label)
+	if r.LiftsAt == "" || strings.EqualFold(r.PenaltyLabel, "permanent") {
+		return fmt.Sprintf("Offense #%d: %s is permanently restricted from posting server promotions.", r.OffenseNumber, label)
+	}
+	return fmt.Sprintf("Offense #%d: %s is restricted from posting server promotions for %s (lifts %s).", r.OffenseNumber, label, r.PenaltyLabel, r.LiftsAt)
 }
 
 func renderRpPromoOffenseHTML(p RpPromoOffenseEmailParams) string {


### PR DESCRIPTION
## Why

A user (\`rhiley03\`) posted two near-duplicate RP server promos minutes apart by creating **two separate communities** and promoting each. The per-community 24h cooldown worked correctly — it's just scoped per community, so spinning up another community evades it. This is allowable by the system but violates our ToS. Tightening the automated cooldown can't fix it (owners can legitimately own multiple communities; name matching false-positives), so this adds a human-in-the-loop moderation surface.

## What (backend)

- **\`rp_promo_offenses\` collection + model** — one doc per offense, keyed by user. Cumulative escalation **7d → 30d → 1yr → permanent**. No expiry cron: effective ban is computed (\`status==active\` AND not past \`expiresAt\`); reversed offenses are excluded from the escalation count.
- **Enforcement** in \`PostRpPromotionHandler\` — blocks a post if the community **owner OR the posting actor** is under an in-force ban (403 + appeal info).
- **Admin endpoints** (owner-only, \`currentUser\` body + \`checkAdminPermissions\`): list promos (advisory owner/name/invite duplicate flags + real pagination), remove promo (Discord webhook self-delete + soft-mark), ban preview, issue ban (+ optional live-post removal + evidence email), list offenses, reverse offense.
- **Offense email** via SendGrid — evidence table, ToS link, escalation ladder, appeal instructions; preview-then-confirm.
- Soft-removal fields on \`RpPromotionPost\`; \`rp_promo_offenses\` index appended to \`create_indexes.js\`.

## Verification

- \`go build ./...\` and \`go vet\` pass (vet's pre-existing unkeyed-bson style warnings only; none from new files).
- Companion website PR adds the admin console panel + ToS clause; mobile surfaces the 403 on \`production\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)