### PR TITLE
fix(cors): allow apex/www/Cloudflare origins so the website can read API responses

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/linesmerrill/police-cad-api/models"
@@ -658,7 +660,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/calls", api.Middleware(http.HandlerFunc(call.CallHandler))).Methods("GET")
 	apiCreate.Handle("/calls", api.Middleware(http.HandlerFunc(call.CreateCallHandler))).Methods("POST")
 	apiCreate.Handle("/calls/community/{community_id}", api.Middleware(http.HandlerFunc(call.CallsByCommunityIDHandler))).Methods("GET") // Deprecated: use /api/v2/calls/community/{community_id}
-	apiV2.Handle("/calls/community/{community_id}", api.Middleware(http.HandlerFunc(call.CallsByCommunityIDHandlerV2))).Methods("GET")        // v2 with pagination support
+	apiV2.Handle("/calls/community/{community_id}", api.Middleware(http.HandlerFunc(call.CallsByCommunityIDHandlerV2))).Methods("GET")   // v2 with pagination support
 
 	apiCreate.Handle("/bolo/{bolo_id}", api.Middleware(http.HandlerFunc(bolo.GetBoloByIDHandler))).Methods("GET")
 	apiCreate.Handle("/bolo/{bolo_id}", api.Middleware(http.HandlerFunc(bolo.UpdateBoloHandler))).Methods("PUT")
@@ -922,9 +924,10 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 // PII, no auth context.
 //
 // Top-level fields:
-//   alive: bool — does the scheduler have any registered jobs?
-//   nowAt: ISO timestamp of the response (anchor for staleness math)
-//   jobs:  { [jobName]: JobStat } — see scheduler.JobStat
+//
+//	alive: bool — does the scheduler have any registered jobs?
+//	nowAt: ISO timestamp of the response (anchor for staleness math)
+//	jobs:  { [jobName]: JobStat } — see scheduler.JobStat
 func (a *App) schedulerHealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if a.Scheduler == nil {
@@ -944,16 +947,47 @@ func (a *App) schedulerHealthHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// isAllowedCorsOrigin reports whether we should echo this Origin back in
+// Access-Control-Allow-Origin. We trust our own site on any
+// linespolice-cad.com host (apex, www, or a Cloudflare-fronted subdomain),
+// the dev Heroku app, and local development hosts. We echo the exact origin
+// (never "*") so it stays valid alongside Access-Control-Allow-Credentials.
+func isAllowedCorsOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	switch {
+	case host == "linespolice-cad.com" || strings.HasSuffix(host, ".linespolice-cad.com"):
+		return true
+	case host == "police-cad-dev.herokuapp.com":
+		return true
+	case host == "localhost" || host == "127.0.0.1":
+		return true
+	}
+	return false
+}
+
 // CorsMiddleware is a middleware that adds CORS headers to the response
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if os.Getenv("ENV") == "local" {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-		} else if os.Getenv("ENV") == "development" {
-			w.Header().Set("Access-Control-Allow-Origin", "https://police-cad-dev.herokuapp.com")
+		// Echo the request's Origin when it's one of our own domains. The site
+		// is served on multiple hosts (apex linespolice-cad.com, www, and a
+		// Cloudflare-fronted host), so a single hardcoded origin doesn't match —
+		// and "*" is illegal alongside Allow-Credentials: true (browsers reject
+		// it), which silently broke every browser fetch. Falls back to the
+		// canonical origin (a SPECIFIC value, never "*").
+		origin := r.Header.Get("Origin")
+		if isAllowedCorsOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
 		} else {
 			w.Header().Set("Access-Control-Allow-Origin", "https://www.linespolice-cad.com")
 		}
+		w.Header().Add("Vary", "Origin")
 
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-User-ID")

--- a/api/handlers/cors_test.go
+++ b/api/handlers/cors_test.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCorsMiddleware_EchoesAllowedOriginNeverWildcardWithCredentials(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+	handler := CorsMiddleware(next)
+
+	tests := []struct {
+		name            string
+		origin          string
+		wantAllowOrigin string
+	}{
+		{"apex", "https://linespolice-cad.com", "https://linespolice-cad.com"},
+		{"www", "https://www.linespolice-cad.com", "https://www.linespolice-cad.com"},
+		{"cloudflare subdomain", "https://app.linespolice-cad.com", "https://app.linespolice-cad.com"},
+		{"dev heroku", "https://police-cad-dev.herokuapp.com", "https://police-cad-dev.herokuapp.com"},
+		{"localhost", "http://localhost:8080", "http://localhost:8080"},
+		{"unknown origin falls back to canonical (never *)", "https://evil.example.com", "https://www.linespolice-cad.com"},
+		{"no origin falls back to canonical (never *)", "", "https://www.linespolice-cad.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/communities/tag/all", nil)
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("Access-Control-Allow-Origin")
+			if got != tt.wantAllowOrigin {
+				t.Errorf("Allow-Origin = %q, want %q", got, tt.wantAllowOrigin)
+			}
+			if got == "*" && rec.Header().Get("Access-Control-Allow-Credentials") == "true" {
+				t.Errorf("emitted illegal Allow-Origin:* with Allow-Credentials:true")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The actual root cause of the empty `/communities` page

Your site is loaded at **`linespolice-cad.com`** (and/or a Cloudflare-fronted host), but the API's CORS layer only allowed **`https://www.linespolice-cad.com`** (or `*` when `ENV=local`). So:

- The browser's Origin (apex / Cloudflare host) **doesn't match** the allowed origin → the browser **discards every API response** → pages render empty.
- `*` combined with `Access-Control-Allow-Credentials: true` is an **illegal** combination browsers reject outright (that's the `ENV=local` case).
- The **native mobile app has no CORS**, which is why it worked the whole time.
- This is also why setting `ENV=production` didn't help — it returns `www`, not the apex.

### Fix
Echo the request's `Origin` back in `Access-Control-Allow-Origin` when it's one of our own domains — any `linespolice-cad.com` host (apex, `www`, or a Cloudflare subdomain), the dev Heroku app, or localhost. Otherwise fall back to the canonical origin. **Never `*`.** Adds `Vary: Origin`.

This is independent of `ENV` and is a **clean hotfix off `main`** — CORS only, nothing else.

### Verification
`go build ./...` ✅ and a new test covering apex / www / Cloudflare subdomain / dev / localhost / unknown-origin-fallback / never-`*`-with-credentials. ✅

After deploying this to `police-cad-api`, `/communities` (and any other browser‑direct API call from the site) will load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014aW3Ywj76tXX4nAQLiCTXu)_