### PR TITLE
fix: resolve V2 Stripe price ids to plan (no more plan="unknown")

### DIFF
--- a/api/handlers/admin_subscription_users.go
+++ b/api/handlers/admin_subscription_users.go
@@ -1098,22 +1098,15 @@ func nonSubDuration(productID string) time.Duration {
 	return 0
 }
 
-// planFromStripePriceID mirrors the API's own price-id → plan mapping.
-// Returns ("", false) for unknown ids so the UI can show the raw price id.
+// planFromStripePriceID mirrors the API's own price-id → plan mapping by
+// delegating to the single source of truth (mapStripePriceIDToPlan), which
+// understands both V1 (original) and V2 (post-price-drop) price ids.
+// Converts the mapper's "unknown" sentinel to ("", false) so the admin UI
+// can fall back to showing the raw price id for genuinely unmapped prices.
 func planFromStripePriceID(priceID string) (string, bool) {
-	switch priceID {
-	case os.Getenv("STRIPE_BASE_MONTHLY_PRICE_ID"):
-		return "base", false
-	case os.Getenv("STRIPE_BASE_ANNUAL_PRICE_ID"):
-		return "base", true
-	case os.Getenv("STRIPE_PREMIUM_MONTHLY_PRICE_ID"):
-		return "premium", false
-	case os.Getenv("STRIPE_PREMIUM_ANNUAL_PRICE_ID"):
-		return "premium", true
-	case os.Getenv("STRIPE_PREMIUM_PLUS_MONTHLY_PRICE_ID"):
-		return "premium_plus", false
-	case os.Getenv("STRIPE_PREMIUM_PLUS_ANNUAL_PRICE_ID"):
-		return "premium_plus", true
+	plan, isAnnual := mapStripePriceIDToPlan(priceID)
+	if plan == "unknown" {
+		return "", false
 	}
-	return "", false
+	return plan, isAnnual
 }

--- a/api/handlers/stripe_plan_mapping_test.go
+++ b/api/handlers/stripe_plan_mapping_test.go
@@ -1,0 +1,138 @@
+package handlers
+
+import "testing"
+
+// setStripePriceEnv configures a full, representative set of V1 and V2 Stripe
+// price-id env vars for the duration of a test. t.Setenv restores them after.
+func setStripePriceEnv(t *testing.T) {
+	t.Helper()
+	vars := map[string]string{
+		// V1 (original) price ids.
+		"STRIPE_BASE_MONTHLY_PRICE_ID":         "price_base_m_v1",
+		"STRIPE_BASE_ANNUAL_PRICE_ID":          "price_base_a_v1",
+		"STRIPE_PREMIUM_MONTHLY_PRICE_ID":      "price_premium_m_v1",
+		"STRIPE_PREMIUM_ANNUAL_PRICE_ID":       "price_premium_a_v1",
+		"STRIPE_PREMIUM_PLUS_MONTHLY_PRICE_ID": "price_premiumplus_m_v1",
+		"STRIPE_PREMIUM_PLUS_ANNUAL_PRICE_ID":  "price_premiumplus_a_v1",
+		// V2 (post-price-drop) price ids — the ones the buggy checkout switch missed.
+		"STRIPE_BASE_V2_MONTHLY_PRICE_ID":         "price_base_m_v2",
+		"STRIPE_BASE_V2_ANNUAL_PRICE_ID":          "price_base_a_v2",
+		"STRIPE_PREMIUM_V2_MONTHLY_PRICE_ID":      "price_premium_m_v2",
+		"STRIPE_PREMIUM_V2_ANNUAL_PRICE_ID":       "price_premium_a_v2",
+		"STRIPE_PREMIUM_PLUS_V2_MONTHLY_PRICE_ID": "price_premiumplus_m_v2",
+		"STRIPE_PREMIUM_PLUS_V2_ANNUAL_PRICE_ID":  "price_premiumplus_a_v2",
+	}
+	for k, v := range vars {
+		t.Setenv(k, v)
+	}
+}
+
+func TestMapStripePriceIDToPlan(t *testing.T) {
+	setStripePriceEnv(t)
+
+	cases := []struct {
+		name       string
+		priceID    string
+		wantPlan   string
+		wantAnnual bool
+	}{
+		// V1 ids.
+		{"v1 base monthly", "price_base_m_v1", "base", false},
+		{"v1 base annual", "price_base_a_v1", "base", true},
+		{"v1 premium monthly", "price_premium_m_v1", "premium", false},
+		{"v1 premium annual", "price_premium_a_v1", "premium", true},
+		{"v1 premium_plus monthly", "price_premiumplus_m_v1", "premium_plus", false},
+		{"v1 premium_plus annual", "price_premiumplus_a_v1", "premium_plus", true},
+
+		// V2 ids — the regression that caused plan="unknown" on new checkouts.
+		{"v2 base monthly", "price_base_m_v2", "base", false},
+		{"v2 base annual", "price_base_a_v2", "base", true},
+		{"v2 premium monthly", "price_premium_m_v2", "premium", false},
+		{"v2 premium annual", "price_premium_a_v2", "premium", true},
+		{"v2 premium_plus monthly", "price_premiumplus_m_v2", "premium_plus", false},
+		{"v2 premium_plus annual", "price_premiumplus_a_v2", "premium_plus", true},
+
+		// Unmapped / empty must surface as the explicit "unknown" sentinel —
+		// never silently downgrade to a real plan.
+		{"empty", "", "unknown", false},
+		{"unmapped price id", "price_does_not_exist", "unknown", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPlan, gotAnnual := mapStripePriceIDToPlan(tc.priceID)
+			if gotPlan != tc.wantPlan || gotAnnual != tc.wantAnnual {
+				t.Errorf("mapStripePriceIDToPlan(%q) = (%q, %v), want (%q, %v)",
+					tc.priceID, gotPlan, gotAnnual, tc.wantPlan, tc.wantAnnual)
+			}
+		})
+	}
+}
+
+func TestPlanFromStripePriceID(t *testing.T) {
+	setStripePriceEnv(t)
+
+	cases := []struct {
+		name       string
+		priceID    string
+		wantPlan   string
+		wantAnnual bool
+	}{
+		// Resolves real plans for BOTH V1 and V2 ids.
+		{"v1 premium_plus monthly", "price_premiumplus_m_v1", "premium_plus", false},
+		{"v2 premium_plus monthly", "price_premiumplus_m_v2", "premium_plus", false},
+		{"v2 base annual", "price_base_a_v2", "base", true},
+
+		// Unmapped ids return the "" sentinel (NOT "unknown") so the admin UI
+		// can fall back to showing the raw price id.
+		{"empty", "", "", false},
+		{"unmapped price id", "price_does_not_exist", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPlan, gotAnnual := planFromStripePriceID(tc.priceID)
+			if gotPlan != tc.wantPlan || gotAnnual != tc.wantAnnual {
+				t.Errorf("planFromStripePriceID(%q) = (%q, %v), want (%q, %v)",
+					tc.priceID, gotPlan, gotAnnual, tc.wantPlan, tc.wantAnnual)
+			}
+		})
+	}
+}
+
+// TestStripePlanMappersAgree is the guard against the bug ever returning:
+// every price id that mapStripePriceIDToPlan resolves to a real plan MUST
+// resolve to the same plan/cadence via planFromStripePriceID (and vice-versa,
+// modulo the "unknown" -> "" sentinel translation). If a future change adds a
+// price id to one mapper but not the other, this fails.
+func TestStripePlanMappersAgree(t *testing.T) {
+	setStripePriceEnv(t)
+
+	priceIDs := []string{
+		"price_base_m_v1", "price_base_a_v1",
+		"price_premium_m_v1", "price_premium_a_v1",
+		"price_premiumplus_m_v1", "price_premiumplus_a_v1",
+		"price_base_m_v2", "price_base_a_v2",
+		"price_premium_m_v2", "price_premium_a_v2",
+		"price_premiumplus_m_v2", "price_premiumplus_a_v2",
+		"", "price_unmapped",
+	}
+
+	for _, id := range priceIDs {
+		mapPlan, mapAnnual := mapStripePriceIDToPlan(id)
+		adminPlan, adminAnnual := planFromStripePriceID(id)
+
+		// Translate the sentinels into a common shape before comparing.
+		wantAdminPlan := mapPlan
+		if mapPlan == "unknown" {
+			wantAdminPlan = ""
+		}
+		if adminPlan != wantAdminPlan {
+			t.Errorf("mappers disagree on plan for %q: map=%q admin=%q", id, mapPlan, adminPlan)
+		}
+		// Cadence only meaningful when a real plan resolved.
+		if wantAdminPlan != "" && adminAnnual != mapAnnual {
+			t.Errorf("mappers disagree on cadence for %q: map=%v admin=%v", id, mapAnnual, adminAnnual)
+		}
+	}
+}

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -3809,28 +3809,14 @@ func (u User) handleCheckoutSessionCompleted(event stripe.Event) error {
 		return fmt.Errorf("failed to get subscription: %v", err)
 	}
 
-	// Map the Price ID back to the tier and billing interval
-	plan := "unknown"
-	isAnnual := false
-	switch sub.Items.Data[0].Price.ID {
-	case os.Getenv("STRIPE_BASE_MONTHLY_PRICE_ID"):
-		plan = "base"
-		isAnnual = false
-	case os.Getenv("STRIPE_BASE_ANNUAL_PRICE_ID"):
-		plan = "base"
-		isAnnual = true
-	case os.Getenv("STRIPE_PREMIUM_MONTHLY_PRICE_ID"):
-		plan = "premium"
-		isAnnual = false
-	case os.Getenv("STRIPE_PREMIUM_ANNUAL_PRICE_ID"):
-		plan = "premium"
-		isAnnual = true
-	case os.Getenv("STRIPE_PREMIUM_PLUS_MONTHLY_PRICE_ID"):
-		plan = "premium_plus"
-		isAnnual = false
-	case os.Getenv("STRIPE_PREMIUM_PLUS_ANNUAL_PRICE_ID"):
-		plan = "premium_plus"
-		isAnnual = true
+	// Map the Price ID back to the tier and billing interval. Uses the
+	// shared V1+V2-aware mapper so post-price-drop (V2) price ids resolve
+	// correctly — an inline V1-only switch here previously wrote
+	// plan="unknown" for migrated/new-price subscriptions.
+	plan, isAnnual := mapStripePriceIDToPlan(sub.Items.Data[0].Price.ID)
+	if plan == "unknown" {
+		zap.S().Warnf("handleCheckoutSessionCompleted: unmapped Stripe price id %q for user %s (sub %s) — storing plan=unknown",
+			sub.Items.Data[0].Price.ID, userID, sub.ID)
 	}
 
 	// Update user subscription in database

--- a/scripts/remediate_unknown_plans/main.go
+++ b/scripts/remediate_unknown_plans/main.go
@@ -1,0 +1,286 @@
+// One-off remediation: repair users whose subscription.plan was written as
+// "unknown" by the (now-fixed) Stripe checkout handler. Before the fix, a
+// V1-only inline price→plan switch in handleCheckoutSessionCompleted fell
+// through to plan="unknown" for any V2 (post-price-drop) price id — e.g. the
+// $9.99 Premium Plus monthly price. This restores the correct plan from the
+// authoritative live Stripe subscription.
+//
+// For every user with user.subscription.plan == "unknown":
+//   - If they have a stripeCustomerId, list their live Stripe subscriptions,
+//     pick the most relevant one (active first, else most recent), and derive
+//     the plan/cadence from the same STRIPE_*_PRICE_ID env vars the API uses
+//     (V1 *and* V2 ids).
+//   - In --apply mode, update user.subscription.{plan,isAnnual} and write an
+//     audit row into subscription_events (eventType=REMEDIATE_UNKNOWN_PLAN,
+//     idempotent via providerEventId).
+//
+// READ-ONLY by default. Pass --apply to actually write. Users without a Stripe
+// customer id, or whose live price id still doesn't map to a known plan, are
+// reported and left untouched (never blindly downgraded).
+//
+// Usage:
+//
+//	DB_URI=mongodb+srv://... \
+//	DB_NAME=lpc \
+//	STRIPE_SECRET_KEY=sk_live_xxx \
+//	STRIPE_PREMIUM_PLUS_V2_MONTHLY_PRICE_ID=price_xxx  (+ the other STRIPE_*_PRICE_ID vars) \
+//	go run ./scripts/remediate_unknown_plans            # dry-run preview
+//	go run ./scripts/remediate_unknown_plans --apply    # write changes
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/subscription"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	dryRun := flag.Bool("dry-run", true, "preview only — no DB writes (default true)")
+	apply := flag.Bool("apply", false, "actually write changes (overrides --dry-run)")
+	limit := flag.Int("limit", 500, "max users to process this run (safety cap)")
+	flag.Parse()
+	if *apply {
+		*dryRun = false
+	}
+
+	mongoURI := mustEnv("DB_URI")
+	dbName := mustEnv("DB_NAME")
+	stripe.Key = mustEnv("STRIPE_SECRET_KEY")
+
+	priceMap := buildPriceMap()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(mongoURI))
+	if err != nil {
+		die("connect mongo: %v", err)
+	}
+	defer client.Disconnect(ctx)
+
+	users := client.Database(dbName).Collection("users")
+	events := client.Database(dbName).Collection("subscription_events")
+
+	mode := "DRY-RUN (no writes)"
+	if !*dryRun {
+		mode = "APPLY (writing changes)"
+	}
+	fmt.Printf("remediate_unknown_plans — %s, limit=%d\n", mode, *limit)
+
+	// Every user whose stored plan is the "unknown" sentinel.
+	filter := bson.M{"user.subscription.plan": "unknown"}
+	cursor, err := users.Find(ctx, filter, options.Find().SetBatchSize(200))
+	if err != nil {
+		die("query users: %v", err)
+	}
+	defer cursor.Close(ctx)
+
+	scanned, fixed, noCustomer, stillUnmapped, noActiveSub, stripeErrors := 0, 0, 0, 0, 0, 0
+
+	for cursor.Next(ctx) {
+		if scanned >= *limit {
+			fmt.Printf("Reached --limit=%d; stopping.\n", *limit)
+			break
+		}
+		scanned++
+
+		var doc struct {
+			ID   primitive.ObjectID `bson:"_id"`
+			User struct {
+				Email        string `bson:"email"`
+				Subscription struct {
+					StripeCustomerID string `bson:"stripeCustomerId"`
+					Plan             string `bson:"plan"`
+				} `bson:"subscription"`
+			} `bson:"user"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			continue
+		}
+		userID := doc.ID.Hex()
+
+		customerID := doc.User.Subscription.StripeCustomerID
+		if customerID == "" {
+			noCustomer++
+			fmt.Printf("SKIP    %s (%s) — plan=unknown but no stripeCustomerId (not a Stripe sub)\n", userID, doc.User.Email)
+			continue
+		}
+
+		subs, err := listAllCustomerSubscriptions(customerID)
+		if err != nil {
+			stripeErrors++
+			fmt.Fprintf(os.Stderr, "  ! Stripe list failed for %s (%s, customer=%s): %v\n", userID, doc.User.Email, customerID, err)
+			continue
+		}
+
+		sub := pickRelevantSub(subs)
+		if sub == nil {
+			noActiveSub++
+			fmt.Printf("SKIP    %s (%s) — no Stripe subscription found for customer %s\n", userID, doc.User.Email, customerID)
+			continue
+		}
+
+		priceID, plan, isAnnual := derivePlan(sub, priceMap)
+		if plan == "" {
+			stillUnmapped++
+			fmt.Printf("UNMAPPED %s (%s) — price id %q has no STRIPE_*_PRICE_ID env mapping (status=%s); left as unknown\n",
+				userID, doc.User.Email, priceID, sub.Status)
+			continue
+		}
+
+		fmt.Printf("FIX     %s (%s) — unknown -> %s (annual=%v) from sub %s [status=%s, price=%s]\n",
+			userID, doc.User.Email, plan, isAnnual, sub.ID, sub.Status, priceID)
+
+		if *dryRun {
+			continue
+		}
+
+		update := bson.M{"$set": bson.M{
+			"user.subscription.plan":      plan,
+			"user.subscription.isAnnual":  isAnnual,
+			"user.subscription.updatedAt": time.Now().UTC(),
+		}}
+		if _, err := users.UpdateOne(ctx, bson.M{"_id": doc.ID}, update); err != nil {
+			fmt.Fprintf(os.Stderr, "  ! update failed for %s: %v\n", userID, err)
+			continue
+		}
+
+		// Idempotent audit row — re-running won't duplicate it.
+		raw, _ := json.Marshal(sub)
+		evt := bson.M{
+			"providerEventId":  fmt.Sprintf("remediate:unknown-plan:%s", sub.ID),
+			"userId":           userID,
+			"userEmail":        doc.User.Email,
+			"provider":         "admin",
+			"store":            "STRIPE",
+			"eventType":        "REMEDIATE_UNKNOWN_PLAN",
+			"plan":             plan,
+			"isAnnual":         isAnnual,
+			"transactionId":    sub.ID,
+			"rawPayload":       string(raw),
+			"processingStatus": "ok",
+			"createdAt":        time.Now().UTC(),
+		}
+		if _, err := events.InsertOne(ctx, evt); err != nil && !mongo.IsDuplicateKeyError(err) {
+			fmt.Fprintf(os.Stderr, "  ! audit insert failed for %s/%s: %v\n", userID, sub.ID, err)
+		}
+		fixed++
+	}
+	if err := cursor.Err(); err != nil {
+		die("cursor: %v", err)
+	}
+
+	fmt.Printf("\nDone. Scanned %d unknown-plan users: %d fixed, %d no Stripe customer, %d still-unmapped price, %d no Stripe sub, %d Stripe errors.\n",
+		scanned, fixed, noCustomer, stillUnmapped, noActiveSub, stripeErrors)
+	if *dryRun {
+		fmt.Println("(dry-run — re-run with --apply to write the FIX rows above.)")
+	}
+}
+
+// pickRelevantSub chooses the subscription that best reflects the user's
+// current entitlement: the first active one, otherwise the most recently
+// started. Returns nil when the customer has no subscriptions.
+func pickRelevantSub(subs []*stripe.Subscription) *stripe.Subscription {
+	var best *stripe.Subscription
+	for _, s := range subs {
+		if s == nil {
+			continue
+		}
+		if s.Status == stripe.SubscriptionStatusActive || s.Status == stripe.SubscriptionStatusTrialing {
+			return s
+		}
+		if best == nil || s.StartDate > best.StartDate {
+			best = s
+		}
+	}
+	return best
+}
+
+// derivePlan resolves the plan/cadence from the subscription's price id using
+// the V1+V2-aware price map. Returns ("", false) when the price id is unmapped
+// so the caller can leave the record untouched rather than guess.
+func derivePlan(sub *stripe.Subscription, priceMap map[string]priceInfo) (priceID, plan string, isAnnual bool) {
+	if sub == nil || sub.Items == nil || len(sub.Items.Data) == 0 || sub.Items.Data[0].Price == nil {
+		return "", "", false
+	}
+	priceID = sub.Items.Data[0].Price.ID
+	if info, ok := priceMap[priceID]; ok {
+		return priceID, info.plan, info.isAnnual
+	}
+	return priceID, "", false
+}
+
+type priceInfo struct {
+	plan     string
+	isAnnual bool
+}
+
+// buildPriceMap reads the same env vars the API uses, including the V2
+// (post-price-drop) ids — the absence of which caused the original bug.
+func buildPriceMap() map[string]priceInfo {
+	m := map[string]priceInfo{}
+	add := func(envVar, plan string, isAnnual bool) {
+		if v := os.Getenv(envVar); v != "" {
+			m[v] = priceInfo{plan: plan, isAnnual: isAnnual}
+		}
+	}
+	add("STRIPE_BASE_MONTHLY_PRICE_ID", "base", false)
+	add("STRIPE_BASE_ANNUAL_PRICE_ID", "base", true)
+	add("STRIPE_PREMIUM_MONTHLY_PRICE_ID", "premium", false)
+	add("STRIPE_PREMIUM_ANNUAL_PRICE_ID", "premium", true)
+	add("STRIPE_PREMIUM_PLUS_MONTHLY_PRICE_ID", "premium_plus", false)
+	add("STRIPE_PREMIUM_PLUS_ANNUAL_PRICE_ID", "premium_plus", true)
+	// V2 (post-price-drop) ids — the ones the buggy checkout switch missed.
+	add("STRIPE_BASE_V2_MONTHLY_PRICE_ID", "base", false)
+	add("STRIPE_BASE_V2_ANNUAL_PRICE_ID", "base", true)
+	add("STRIPE_PREMIUM_V2_MONTHLY_PRICE_ID", "premium", false)
+	add("STRIPE_PREMIUM_V2_ANNUAL_PRICE_ID", "premium", true)
+	add("STRIPE_PREMIUM_PLUS_V2_MONTHLY_PRICE_ID", "premium_plus", false)
+	add("STRIPE_PREMIUM_PLUS_V2_ANNUAL_PRICE_ID", "premium_plus", true)
+	if len(m) == 0 {
+		fmt.Fprintln(os.Stderr, "WARNING: no STRIPE_*_PRICE_ID env vars set — nothing can be remediated")
+	}
+	return m
+}
+
+// listAllCustomerSubscriptions returns every Stripe subscription for a
+// customer including canceled ones (Stripe's default omits canceled).
+func listAllCustomerSubscriptions(customerID string) ([]*stripe.Subscription, error) {
+	params := &stripe.SubscriptionListParams{
+		Customer: stripe.String(customerID),
+		Status:   stripe.String("all"),
+	}
+	params.Limit = stripe.Int64(100)
+	iter := subscription.List(params)
+	var out []*stripe.Subscription
+	for iter.Next() {
+		out = append(out, iter.Subscription())
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func mustEnv(k string) string {
+	v := os.Getenv(k)
+	if v == "" {
+		die("missing env var %s", k)
+	}
+	return v
+}
+
+func die(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "ERROR: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Problem

A user subscribed to **Premium Plus monthly** via Stripe, but our DB stored `subscription.plan = "unknown"` while Stripe correctly showed the plan active at `price_1TbO8u…` ($9.99/mo).

## Root cause

There were **three** Stripe price-id → plan mappers, but only one (`mapStripePriceIDToPlan`) knew about the post-price-drop **V2** price ids:

| Mapper | Knew V2? | Used by | Effect |
|---|---|---|---|
| `mapStripePriceIDToPlan` | ✅ | `handleSubscriptionUpdated` | correct |
| inline switch in `handleCheckoutSessionCompleted` | ❌ V1 only | new checkouts | **wrote `plan:"unknown"`** |
| `planFromStripePriceID` | ❌ V1 only | admin sync / LIVE display | "Fix" button couldn't repair; LIVE plan showed `—` |

The `$9.99` Premium Plus monthly price is `STRIPE_PREMIUM_PLUS_V2_MONTHLY_PRICE_ID` (correctly set in env) — the env was fine; the code just didn't consult the V2 vars on the checkout path.

## Fix

- `handleCheckoutSessionCompleted` now uses the shared V1+V2-aware `mapStripePriceIDToPlan`, and **warns** instead of silently storing `unknown` on a genuinely unmapped price id.
- `planFromStripePriceID` delegates to the same mapper (single source of truth), translating the `"unknown"` sentinel to `""` so the admin UI still falls back to the raw price id. This also fixes the admin "Fix"/sync path and LIVE Stripe plan display.

## Remediate existing affected users

- `scripts/remediate_unknown_plans` — **dry-run by default**. Finds every user with `subscription.plan == "unknown"`, re-derives the plan from live Stripe (V2-aware), and on `--apply` updates the User doc + writes an idempotent `subscription_events` audit row. Run against `police-cad-dev` first, then production.

```
go run ./scripts/remediate_unknown_plans            # preview
go run ./scripts/remediate_unknown_plans --apply    # write
```

## Tests

- Table-driven coverage of `mapStripePriceIDToPlan` and `planFromStripePriceID` across **V1 and V2** ids for all three tiers (monthly + annual), empty, and unmapped.
- `TestStripePlanMappersAgree` — guard asserting the two mappers can never diverge again.
- Full `api/handlers` package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
