### PR TITLE
fix: clear join_request notifications when a community request is resolved

### DIFF
--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -2109,6 +2109,27 @@ func (u User) AddCommunityToUserHandler(w http.ResponseWriter, r *http.Request) 
 			actorID := resolveActorFromRequest(r)
 			logAudit(u.ALDB, cID, "member.approved", "member", actorID, resolveActorName(u.DB, actorID), userID, resolveActorName(u.DB, userID), nil)
 		}
+
+		// Once a join request is resolved (approved or declined), clear the
+		// matching community-level join_request notifications from every admin
+		// who received one. Notification cleanup was previously client-driven and
+		// per-notification, so duplicate or cross-session notifications lingered
+		// as "requesting to join" until each surface manually refetched. This
+		// mirrors the cleanup already done on request cancellation and on
+		// department join-request resolution.
+		if requestBody.Status == "approved" || requestBody.Status == "declined" {
+			notifMatch := bson.M{
+				"type":       "join_request",
+				"sentFromID": userID,
+				"data1":      requestBody.CommunityID,
+				"data3":      "", // community-level request only (department requests carry data3)
+			}
+			notifFilter := bson.M{"user.notifications": bson.M{"$elemMatch": notifMatch}}
+			notifUpdate := bson.M{"$pull": bson.M{"user.notifications": notifMatch}}
+			// Best-effort cleanup — never fail the resolution if this errors.
+			_, _ = u.DB.UpdateMany(ctx, notifFilter, notifUpdate)
+		}
+
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"message": "Community status updated successfully"}`))
 		return


### PR DESCRIPTION
## Problem

A community owner reported that after **accepting** a member, the person still showed as "requesting to join" until the page was manually refreshed — on both the website and the mobile app.

## Root cause

Both clients already remove the notification optimistically and delete it server-side, but only the single copy the acting client knows about. `AddCommunityToUserHandler` updated the member's `status` but **never cleaned up the `join_request` notifications**. Because notification removal was entirely client-driven and per-notification:

- Duplicate `join_request` notifications (the existing "Member already exists" 409 handling on both clients confirms these occur) lingered after approving one.
- Approving on one device/session left the notification on every *other* admin/session/device until each manually refetched — exactly the reported "still requesting to join, fixed by refresh" symptom.

## Fix

On resolution (`approved` or `declined`), `AddCommunityToUserHandler` now `$pull`s **all** matching community-level `join_request` notifications across every admin who received one. This is the identical pattern already used in this file for:

- request cancellation (`~user.go:2309`)
- department join-request resolution (`~user.go:2941`)

`AddCommunityToUserHandler` was simply the one resolution path missing it. Cleanup is best-effort and never fails the resolution.

## Scope / safety

- Only fires when `status` is `approved` or `declined` (owner resolving a request) — not on self-initiated pending requests.
- Matches community-level requests only (`data3 == ""`); department requests carry `data3` and are handled by their own existing cleanup.
- No client changes required; existing optimistic updates on web/mobile remain and now reconcile correctly on refetch.

## Testing

- `go build ./...` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)