### PR TITLE
feat(ranks): "reset stats on promotion" community toggle

### DIFF
--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -1090,12 +1090,18 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 			fmt.Sprintf("community.departments.%d.members.%d.rankId", deptIdx, memberIdx):             memberStatus.RankID,
 			fmt.Sprintf("community.departments.%d.members.%d.rankAssignedAt", deptIdx, memberIdx):     memberStatus.RankAssignedAt,
 			fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx): memberStatus.RankAssignmentType,
+			// Reset met custom requirements: they belong to the rank the member just earned,
+			// so progress toward the new rank starts fresh (admins must re-verify).
+			fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx): []string{},
 		}
 		err = c.DB.UpdateOne(ctx, bson.M{"_id": cID}, bson.M{"$set": setFields})
 		if err != nil {
 			config.ErrorStatus("failed to persist auto-promotion", http.StatusInternalServerError, w, err)
 			return
 		}
+		// Mirror the reset in-memory so the progress built below for the new
+		// next rank reflects the cleared state rather than the old met requirements.
+		memberStatus.CustomRequirementsMet = nil
 		logAudit(c.ALDB, cID, "rank.auto_promoted", "rank", userID, "", memberStatus.RankID, currentRank.Name, map[string]interface{}{
 			"departmentId": departmentID,
 		})
@@ -1276,6 +1282,13 @@ func (c Community) AssignMemberRankHandler(w http.ResponseWriter, r *http.Reques
 		fmt.Sprintf("community.departments.%d.members.%d.rankId", deptIdx, memberIdx):             requestBody.RankID,
 		fmt.Sprintf("community.departments.%d.members.%d.rankAssignedAt", deptIdx, memberIdx):     primitive.NewDateTimeFromTime(time.Now()),
 		fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx): "manual",
+	}
+
+	// When the rank actually changes, reset met custom requirements: they belonged
+	// to the prior rank's progress, so the new rank starts fresh. Re-assigning the
+	// same rank leaves the existing met requirements untouched.
+	if requestBody.RankID != dept.Members[memberIdx].RankID {
+		setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
 	}
 
 	err = c.DB.UpdateOne(ctx, bson.M{"_id": cID}, bson.M{"$set": setFields})
@@ -1516,6 +1529,8 @@ func (c Community) CheckAllPromotionsHandler(w http.ResponseWriter, r *http.Requ
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankId", deptIdx, memberIdx)] = bestRankID
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankAssignedAt", deptIdx, memberIdx)] = primitive.NewDateTimeFromTime(time.Now())
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx)] = "auto"
+			// Reset met custom requirements so progress toward the new rank starts fresh.
+			setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
 			promotedCount++
 
 			logAudit(c.ALDB, cID, "rank.auto_promoted", "rank", member.UserID, "", bestRankID, bestRankName, map[string]interface{}{

--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -546,19 +546,26 @@ type OfficerMetric struct {
 	MetricType   string `json:"metricType"`
 	DisplayName  string `json:"displayName"`
 	CurrentValue int    `json:"currentValue"`
+	// AllTimeValue is the lifetime total. When reset-stats-on-promotion is off it
+	// equals CurrentValue; when on, CurrentValue counts since the last promotion
+	// while AllTimeValue still shows the lifetime figure for context.
+	AllTimeValue int `json:"allTimeValue"`
 }
 
 // RankProgress shows progress toward a single requirement
 type RankProgress struct {
-	MetricType    string  `json:"metricType"`
-	DisplayName   string  `json:"displayName"`
-	CurrentValue  int     `json:"currentValue"`
-	Threshold     int     `json:"threshold"`
-	Percentage    float64 `json:"percentage"`
-	Met           bool    `json:"met"`
-	IsCustom      bool    `json:"isCustom,omitempty"`
-	CustomLabel   string  `json:"customLabel,omitempty"`
-	RequirementID string  `json:"requirementId,omitempty"`
+	MetricType   string  `json:"metricType"`
+	DisplayName  string  `json:"displayName"`
+	CurrentValue int     `json:"currentValue"`
+	Threshold    int     `json:"threshold"`
+	Percentage   float64 `json:"percentage"`
+	Met          bool    `json:"met"`
+	// AllTimeValue mirrors OfficerMetric.AllTimeValue for the requirement's metric;
+	// 0 for custom requirements.
+	AllTimeValue  int    `json:"allTimeValue"`
+	IsCustom      bool   `json:"isCustom,omitempty"`
+	CustomLabel   string `json:"customLabel,omitempty"`
+	RequirementID string `json:"requirementId,omitempty"`
 }
 
 // containsString checks if a string slice contains a value.
@@ -569,6 +576,33 @@ func containsString(slice []string, val string) bool {
 		}
 	}
 	return false
+}
+
+// rankStatsSince returns the lower-bound time for counting a member's metrics, or
+// nil to count all-time. When the community has reset-stats-on-promotion enabled and
+// the member has a recorded rank-assignment time, metrics are counted from that point
+// forward. Members without a RankAssignedAt (e.g. those still on the default rank) fall
+// back to all-time so they aren't unfairly zeroed out.
+func rankStatsSince(community *models.Community, member models.MemberStatus) *time.Time {
+	if community == nil || !community.Details.RankSettings.ResetStatsOnPromotion {
+		return nil
+	}
+	if member.RankAssignedAt == 0 {
+		return nil
+	}
+	t := member.RankAssignedAt.Time()
+	return &t
+}
+
+// findMember returns the index and a copy of the member matching userID in a department,
+// or (-1, zero) if not present.
+func findMember(dept *models.Department, userID string) (int, models.MemberStatus) {
+	for i, m := range dept.Members {
+		if m.UserID == userID {
+			return i, m
+		}
+	}
+	return -1, models.MemberStatus{}
 }
 
 // ensureRequirementIDs assigns IDs to any requirements that don't have one.
@@ -598,7 +632,10 @@ func checkAllRequirementsMet(reqs []models.RankRequirement, metricsMap map[strin
 }
 
 // buildRequirementProgress builds RankProgress entries for a set of requirements.
-func buildRequirementProgress(reqs []models.RankRequirement, metricsMap map[string]int, customMet []string) []RankProgress {
+// metricsMap drives eligibility and the progress bar (since-promotion counts in reset
+// mode); allTimeMap supplies the lifetime figure shown alongside. Pass the same map for
+// both when reset mode is off.
+func buildRequirementProgress(reqs []models.RankRequirement, metricsMap, allTimeMap map[string]int, customMet []string) []RankProgress {
 	var progress []RankProgress
 	for _, req := range reqs {
 		if req.MetricType == "custom" {
@@ -633,6 +670,7 @@ func buildRequirementProgress(reqs []models.RankRequirement, metricsMap map[stri
 				MetricType:   req.MetricType,
 				DisplayName:  models.MetricTypeDisplayNames[req.MetricType],
 				CurrentValue: current,
+				AllTimeValue: allTimeMap[req.MetricType],
 				Threshold:    req.Threshold,
 				Percentage:   pct,
 				Met:          current >= req.Threshold,
@@ -645,8 +683,22 @@ func buildRequirementProgress(reqs []models.RankRequirement, metricsMap map[stri
 // computeOfficerMetrics aggregates metric values for a given officer in a department.
 // deptType filters which pipelines to run (e.g. "police", "ems", "fire", "dispatch", "judicial").
 // If deptType is empty, all pipelines run (backward compat).
-func (c Community) computeOfficerMetrics(ctx context.Context, communityID, departmentID, userID, deptType string) (map[string]int, error) {
+//
+// When since is non-nil, only records created at or after that time are counted
+// (used by "reset stats on promotion" mode to measure progress since the member's
+// last rank assignment). A nil since counts all-time, preserving historical behavior.
+func (c Community) computeOfficerMetrics(ctx context.Context, communityID, departmentID, userID, deptType string, since *time.Time) (map[string]int, error) {
 	metrics := make(map[string]int)
+
+	// applySince adds a createdAt lower-bound to a metric's $match when since is set.
+	// prefix is the document path that holds the createdAt field for that metric
+	// (e.g. "arrestReport", "civilian.criminalHistory").
+	applySince := func(match bson.M, prefix string) bson.M {
+		if since != nil {
+			match[prefix+".createdAt"] = bson.M{"$gte": primitive.NewDateTimeFromTime(*since)}
+		}
+		return match
+	}
 
 	// Build set of relevant metric types for this department
 	relevant := make(map[string]bool)
@@ -676,11 +728,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 		pipeline := bson.A{
 			bson.M{"$match": bson.M{"civilian.activeCommunityID": communityID}},
 			bson.M{"$unwind": "$civilian.criminalHistory"},
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"civilian.criminalHistory.officerID":    userID,
 				"civilian.criminalHistory.type":         entry.crimHistType,
 				"civilian.criminalHistory.departmentId": departmentID,
-			}},
+			}, "civilian.criminalHistory")},
 			bson.M{"$count": "total"},
 		}
 		count, err := c.runCountPipeline(ctx, "civilians", pipeline)
@@ -693,11 +745,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Arrests Made — from arrestreports collection
 	if needMetric("arrests_made") {
 		count, err := c.runCountPipeline(ctx, "arrestreports", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"arrestReport.activeCommunityID": communityID,
 				"arrestReport.officerID":         userID,
 				"arrestReport.departmentId":      departmentID,
-			}},
+			}, "arrestReport")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -709,11 +761,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Calls Created
 	if needMetric("calls_created") {
 		count, err := c.runCountPipeline(ctx, "calls", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"call.communityID": communityID,
 				"call.createdByID": userID,
 				"call.departments": departmentID,
-			}},
+			}, "call")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -725,11 +777,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Calls Responded
 	if needMetric("calls_responded") {
 		count, err := c.runCountPipeline(ctx, "calls", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"call.communityID": communityID,
 				"call.assignedTo":  userID,
 				"call.departments": departmentID,
-			}},
+			}, "call")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -741,11 +793,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Calls Cleared
 	if needMetric("calls_cleared") {
 		count, err := c.runCountPipeline(ctx, "calls", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"call.communityID":       communityID,
 				"call.clearingOfficerID": userID,
 				"call.departments":       departmentID,
-			}},
+			}, "call")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -757,11 +809,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// BOLOs Created
 	if needMetric("bolos_created") {
 		count, err := c.runCountPipeline(ctx, "bolos", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"bolo.communityID":  communityID,
 				"bolo.reportedByID": userID,
 				"bolo.departmentID": departmentID,
-			}},
+			}, "bolo")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -773,11 +825,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Warrants Requested
 	if needMetric("warrants_requested") {
 		count, err := c.runCountPipeline(ctx, "warrants", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"warrant.activeCommunityID":   communityID,
 				"warrant.requestingOfficerID": userID,
 				"warrant.departmentId":        departmentID,
-			}},
+			}, "warrant")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -789,11 +841,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Warrants Executed
 	if needMetric("warrants_executed") {
 		count, err := c.runCountPipeline(ctx, "warrants", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"warrant.activeCommunityID":  communityID,
 				"warrant.executingOfficerID": userID,
 				"warrant.departmentId":       departmentID,
-			}},
+			}, "warrant")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -805,10 +857,10 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Medical Reports Created — EMS/Fire
 	if needMetric("medical_reports_created") {
 		count, err := c.runCountPipeline(ctx, "medicalreports", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"medicalReport.activeCommunityID": communityID,
 				"medicalReport.reportingEmsID":    userID,
-			}},
+			}, "medicalReport")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -820,10 +872,10 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Calls Dispatched — Dispatch (same as calls_created but scoped for dispatch departments)
 	if needMetric("calls_dispatched") {
 		count, err := c.runCountPipeline(ctx, "calls", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"call.communityID": communityID,
 				"call.createdByID": userID,
-			}},
+			}, "call")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -835,10 +887,10 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Warrants Reviewed — Judicial (judge who reviewed the warrant)
 	if needMetric("warrants_reviewed") {
 		count, err := c.runCountPipeline(ctx, "warrants", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"warrant.activeCommunityID": communityID,
 				"warrant.judgeID":           userID,
-			}},
+			}, "warrant")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -850,11 +902,11 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	// Court Cases Completed — Judicial
 	if needMetric("court_cases_completed") {
 		count, err := c.runCountPipeline(ctx, "courtcases", bson.A{
-			bson.M{"$match": bson.M{
+			bson.M{"$match": applySince(bson.M{
 				"courtCase.communityID": communityID,
 				"courtCase.judgeID":     userID,
 				"courtCase.status":      "completed",
-			}},
+			}, "courtCase")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {
@@ -864,6 +916,25 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 	}
 
 	return metrics, nil
+}
+
+// computeOfficerMetricsDual returns both the all-time metrics and the "current" metrics
+// used for requirement evaluation. When since is nil (reset-stats mode off, or no
+// baseline), current is identical to all-time and only one aggregation pass runs.
+// When since is set, current counts records from that point forward.
+func (c Community) computeOfficerMetricsDual(ctx context.Context, communityID, departmentID, userID, deptType string, since *time.Time) (allTime, current map[string]int, err error) {
+	allTime, err = c.computeOfficerMetrics(ctx, communityID, departmentID, userID, deptType, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if since == nil {
+		return allTime, allTime, nil
+	}
+	current, err = c.computeOfficerMetrics(ctx, communityID, departmentID, userID, deptType, since)
+	if err != nil {
+		return nil, nil, err
+	}
+	return allTime, current, nil
 }
 
 // runCountPipeline runs an aggregation pipeline and returns the count from the first result's "total" field.
@@ -909,11 +980,14 @@ func (c Community) GetOfficerStatsHandler(w http.ResponseWriter, r *http.Request
 	}
 	_, dept := findDepartment(community, departmentID)
 	deptType := ""
+	var since *time.Time
 	if dept != nil {
 		deptType = getDepartmentType(dept)
+		_, member := findMember(dept, userID)
+		since = rankStatsSince(community, member)
 	}
 
-	metricsMap, err := c.computeOfficerMetrics(ctx, communityID, departmentID, userID, deptType)
+	allTimeMap, currentMap, err := c.computeOfficerMetricsDual(ctx, communityID, departmentID, userID, deptType, since)
 	if err != nil {
 		config.ErrorStatus("failed to compute officer metrics", http.StatusInternalServerError, w, err)
 		return
@@ -929,15 +1003,17 @@ func (c Community) GetOfficerStatsHandler(w http.ResponseWriter, r *http.Request
 		metrics = append(metrics, OfficerMetric{
 			MetricType:   mt.Type,
 			DisplayName:  mt.DisplayName,
-			CurrentValue: metricsMap[mt.Type],
+			CurrentValue: currentMap[mt.Type],
+			AllTimeValue: allTimeMap[mt.Type],
 		})
 	}
 
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"userId":       userID,
-		"departmentId": departmentID,
-		"metrics":      metrics,
+		"userId":                userID,
+		"departmentId":          departmentID,
+		"metrics":               metrics,
+		"resetStatsOnPromotion": since != nil,
 	})
 }
 
@@ -1010,8 +1086,12 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	// Compute metrics
-	metricsMap, err := c.computeOfficerMetrics(ctx, communityID, departmentID, userID, getDepartmentType(dept))
+	// Compute metrics. In reset-stats mode, evalMap counts only since the member's
+	// current rank assignment (drives promotion eligibility + the progress bar) while
+	// allTimeMap keeps the lifetime totals for display. Off mode: the two are identical.
+	resetMode := community.Details.RankSettings.ResetStatsOnPromotion
+	since := rankStatsSince(community, *memberStatus)
+	allTimeMap, evalMap, err := c.computeOfficerMetricsDual(ctx, communityID, departmentID, userID, getDepartmentType(dept), since)
 	if err != nil {
 		config.ErrorStatus("failed to compute officer metrics", http.StatusInternalServerError, w, err)
 		return
@@ -1060,27 +1140,51 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 		previousRank = &prevCopy
 	}
 
-	// Auto-promotion check: try to promote to the highest eligible rank
+	// Auto-promotion check.
 	promoted := false
-	for i := range ranks {
-		// Only consider ranks above current (lower displayOrder = higher rank)
-		if ranks[i].DisplayOrder >= currentRankOrder {
-			continue
+	if resetMode {
+		// Reset-stats mode: promote at most ONE step (to the immediate next rank up).
+		// Because stats are measured since the last promotion, eligibility for any
+		// higher rank can only be earned after this promotion's fresh count, which
+		// prevents the instant chain-promotion all-time totals allow.
+		var next *models.Rank
+		for i := len(ranks) - 1; i >= 0; i-- {
+			if ranks[i].DisplayOrder < currentRankOrder {
+				next = &ranks[i]
+				break
+			}
 		}
-		if !ranks[i].AutoPromote {
-			continue
-		}
-		// Check if all requirements are met (tracked + custom)
-		allMet := len(ranks[i].Requirements) > 0 && checkAllRequirementsMet(ranks[i].Requirements, metricsMap, memberStatus.CustomRequirementsMet)
-		if allMet {
-			// Promote to this rank
-			memberStatus.RankID = ranks[i].ID.Hex()
+		if next != nil && next.AutoPromote && len(next.Requirements) > 0 &&
+			checkAllRequirementsMet(next.Requirements, evalMap, memberStatus.CustomRequirementsMet) {
+			memberStatus.RankID = next.ID.Hex()
 			memberStatus.RankAssignedAt = primitive.NewDateTimeFromTime(time.Now())
 			memberStatus.RankAssignmentType = "auto"
-			currentRank = &ranks[i]
-			currentRankOrder = ranks[i].DisplayOrder
+			currentRank = next
+			currentRankOrder = next.DisplayOrder
 			promoted = true
-			// Continue to check for even higher ranks
+		}
+	} else {
+		// All-time mode: promote to the highest eligible rank in one pass.
+		for i := range ranks {
+			// Only consider ranks above current (lower displayOrder = higher rank)
+			if ranks[i].DisplayOrder >= currentRankOrder {
+				continue
+			}
+			if !ranks[i].AutoPromote {
+				continue
+			}
+			// Check if all requirements are met (tracked + custom)
+			allMet := len(ranks[i].Requirements) > 0 && checkAllRequirementsMet(ranks[i].Requirements, evalMap, memberStatus.CustomRequirementsMet)
+			if allMet {
+				// Promote to this rank
+				memberStatus.RankID = ranks[i].ID.Hex()
+				memberStatus.RankAssignedAt = primitive.NewDateTimeFromTime(time.Now())
+				memberStatus.RankAssignmentType = "auto"
+				currentRank = &ranks[i]
+				currentRankOrder = ranks[i].DisplayOrder
+				promoted = true
+				// Continue to check for even higher ranks
+			}
 		}
 	}
 
@@ -1090,18 +1194,28 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 			fmt.Sprintf("community.departments.%d.members.%d.rankId", deptIdx, memberIdx):             memberStatus.RankID,
 			fmt.Sprintf("community.departments.%d.members.%d.rankAssignedAt", deptIdx, memberIdx):     memberStatus.RankAssignedAt,
 			fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx): memberStatus.RankAssignmentType,
-			// Reset met custom requirements: they belong to the rank the member just earned,
-			// so progress toward the new rank starts fresh (admins must re-verify).
-			fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx): []string{},
+		}
+		// In reset-stats mode, met custom requirements belong to the rank the member
+		// just earned, so clear them for a fresh start. In all-time mode they persist
+		// (you keep what you earned), matching the historical behavior.
+		if resetMode {
+			setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
 		}
 		err = c.DB.UpdateOne(ctx, bson.M{"_id": cID}, bson.M{"$set": setFields})
 		if err != nil {
 			config.ErrorStatus("failed to persist auto-promotion", http.StatusInternalServerError, w, err)
 			return
 		}
-		// Mirror the reset in-memory so the progress built below for the new
-		// next rank reflects the cleared state rather than the old met requirements.
-		memberStatus.CustomRequirementsMet = nil
+		if resetMode {
+			// Mirror the reset in-memory and recompute the progress metrics against the
+			// new rank-assignment time so the next-rank progress starts fresh.
+			memberStatus.CustomRequirementsMet = nil
+			newSince := memberStatus.RankAssignedAt.Time()
+			if evalMap, err = c.computeOfficerMetrics(ctx, communityID, departmentID, userID, getDepartmentType(dept), &newSince); err != nil {
+				config.ErrorStatus("failed to recompute officer metrics", http.StatusInternalServerError, w, err)
+				return
+			}
+		}
 		logAudit(c.ALDB, cID, "rank.auto_promoted", "rank", userID, "", memberStatus.RankID, currentRank.Name, map[string]interface{}{
 			"departmentId": departmentID,
 		})
@@ -1127,14 +1241,15 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 		metricsResponse = append(metricsResponse, OfficerMetric{
 			MetricType:   mt.Type,
 			DisplayName:  mt.DisplayName,
-			CurrentValue: metricsMap[mt.Type],
+			CurrentValue: evalMap[mt.Type],
+			AllTimeValue: allTimeMap[mt.Type],
 		})
 	}
 
 	// Build progress toward next rank
 	var progress []RankProgress
 	if nextRank != nil {
-		progress = buildRequirementProgress(nextRank.Requirements, metricsMap, memberStatus.CustomRequirementsMet)
+		progress = buildRequirementProgress(nextRank.Requirements, evalMap, allTimeMap, memberStatus.CustomRequirementsMet)
 	}
 
 	allMet := len(progress) > 0
@@ -1178,6 +1293,7 @@ func (c Community) GetRankProgressHandler(w http.ResponseWriter, r *http.Request
 		"previousRank":        previousRank,
 		"rankAssignedAt":      memberStatus.RankAssignedAt,
 		"rankAssignmentType":  memberStatus.RankAssignmentType,
+		"resetStatsOnPromotion": resetMode,
 	})
 }
 
@@ -1284,10 +1400,10 @@ func (c Community) AssignMemberRankHandler(w http.ResponseWriter, r *http.Reques
 		fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx): "manual",
 	}
 
-	// When the rank actually changes, reset met custom requirements: they belonged
-	// to the prior rank's progress, so the new rank starts fresh. Re-assigning the
-	// same rank leaves the existing met requirements untouched.
-	if requestBody.RankID != dept.Members[memberIdx].RankID {
+	// In reset-stats mode, when the rank actually changes, clear met custom requirements
+	// so the new rank starts fresh. In all-time mode they persist (you keep what you
+	// earned). Re-assigning the same rank never clears them.
+	if community.Details.RankSettings.ResetStatsOnPromotion && requestBody.RankID != dept.Members[memberIdx].RankID {
 		setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
 	}
 
@@ -1397,15 +1513,17 @@ func (c Community) GetPendingPromotionsHandler(w http.ResponseWriter, r *http.Re
 			continue
 		}
 
-		// Compute metrics for this member
-		metricsMap, err := c.computeOfficerMetrics(ctx, communityID, departmentID, member.UserID, getDepartmentType(dept))
+		// Compute metrics for this member. In reset-stats mode, eligibility is measured
+		// since the member's last promotion; all-time totals ride along for display.
+		since := rankStatsSince(community, member)
+		allTimeMap, metricsMap, err := c.computeOfficerMetricsDual(ctx, communityID, departmentID, member.UserID, getDepartmentType(dept), since)
 		if err != nil {
 			continue
 		}
 
 		// Check progress toward next rank — show in pending if all TRACKED metrics are met
 		// (custom requirements can be toggled by admin from the pending promotions panel)
-		progress := buildRequirementProgress(nextRank.Requirements, metricsMap, member.CustomRequirementsMet)
+		progress := buildRequirementProgress(nextRank.Requirements, metricsMap, allTimeMap, member.CustomRequirementsMet)
 		trackedMet := true
 		for _, req := range nextRank.Requirements {
 			if req.MetricType != "custom" && metricsMap[req.MetricType] < req.Threshold {
@@ -1493,8 +1611,11 @@ func (c Community) CheckAllPromotionsHandler(w http.ResponseWriter, r *http.Requ
 	promotedCount := 0
 	setFields := bson.M{}
 
+	resetMode := community.Details.RankSettings.ResetStatsOnPromotion
+
 	for memberIdx, member := range dept.Members {
-		metricsMap, err := c.computeOfficerMetrics(ctx, communityID, departmentID, member.UserID, getDepartmentType(dept))
+		since := rankStatsSince(community, member)
+		metricsMap, err := c.computeOfficerMetrics(ctx, communityID, departmentID, member.UserID, getDepartmentType(dept), since)
 		if err != nil {
 			continue // skip members we can't compute metrics for
 		}
@@ -1511,17 +1632,34 @@ func (c Community) CheckAllPromotionsHandler(w http.ResponseWriter, r *http.Requ
 		bestRankOrder := currentRankOrder
 		var bestRankName string
 
-		for i := range ranks {
-			if ranks[i].DisplayOrder >= bestRankOrder {
-				continue
+		if resetMode {
+			// One step only: stats reset on promotion, so higher ranks can't be earned
+			// in the same pass. Consider just the immediate next rank up.
+			for i := len(ranks) - 1; i >= 0; i-- {
+				if ranks[i].DisplayOrder >= currentRankOrder {
+					continue
+				}
+				if ranks[i].AutoPromote && len(ranks[i].Requirements) > 0 &&
+					checkAllRequirementsMet(ranks[i].Requirements, metricsMap, member.CustomRequirementsMet) {
+					bestRankID = ranks[i].ID.Hex()
+					bestRankOrder = ranks[i].DisplayOrder
+					bestRankName = ranks[i].Name
+				}
+				break // only the immediate next rank is a candidate
 			}
-			if !ranks[i].AutoPromote || len(ranks[i].Requirements) == 0 {
-				continue
-			}
-			if checkAllRequirementsMet(ranks[i].Requirements, metricsMap, member.CustomRequirementsMet) {
-				bestRankID = ranks[i].ID.Hex()
-				bestRankOrder = ranks[i].DisplayOrder
-				bestRankName = ranks[i].Name
+		} else {
+			for i := range ranks {
+				if ranks[i].DisplayOrder >= bestRankOrder {
+					continue
+				}
+				if !ranks[i].AutoPromote || len(ranks[i].Requirements) == 0 {
+					continue
+				}
+				if checkAllRequirementsMet(ranks[i].Requirements, metricsMap, member.CustomRequirementsMet) {
+					bestRankID = ranks[i].ID.Hex()
+					bestRankOrder = ranks[i].DisplayOrder
+					bestRankName = ranks[i].Name
+				}
 			}
 		}
 
@@ -1529,8 +1667,11 @@ func (c Community) CheckAllPromotionsHandler(w http.ResponseWriter, r *http.Requ
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankId", deptIdx, memberIdx)] = bestRankID
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankAssignedAt", deptIdx, memberIdx)] = primitive.NewDateTimeFromTime(time.Now())
 			setFields[fmt.Sprintf("community.departments.%d.members.%d.rankAssignmentType", deptIdx, memberIdx)] = "auto"
-			// Reset met custom requirements so progress toward the new rank starts fresh.
-			setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
+			// In reset-stats mode, clear met custom requirements so progress toward the
+			// new rank starts fresh. In all-time mode they persist (you keep what you earned).
+			if resetMode {
+				setFields[fmt.Sprintf("community.departments.%d.members.%d.customRequirementsMet", deptIdx, memberIdx)] = []string{}
+			}
 			promotedCount++
 
 			logAudit(c.ALDB, cID, "rank.auto_promoted", "rank", member.UserID, "", bestRankID, bestRankName, map[string]interface{}{
@@ -1629,8 +1770,9 @@ func (c Community) GetPendingPromotionCountsHandler(w http.ResponseWriter, r *ht
 				continue
 			}
 
-			// Compute metrics for this member
-			metricsMap, err := c.computeOfficerMetrics(ctx, communityID, deptID, member.UserID, getDepartmentType(&dept))
+			// Compute metrics for this member (since-promotion when reset-stats mode is on)
+			since := rankStatsSince(community, member)
+			metricsMap, err := c.computeOfficerMetrics(ctx, communityID, deptID, member.UserID, getDepartmentType(&dept), since)
 			if err != nil {
 				continue
 			}

--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -856,11 +856,13 @@ func (c Community) computeOfficerMetrics(ctx context.Context, communityID, depar
 
 	// Medical Reports Created — EMS/Fire
 	if needMetric("medical_reports_created") {
+		// Medical reports are stored under the "report" key (model: MedicalReport.Report
+		// with bson:"report"), so the match paths use that prefix — not "medicalReport".
 		count, err := c.runCountPipeline(ctx, "medicalreports", bson.A{
 			bson.M{"$match": applySince(bson.M{
-				"medicalReport.activeCommunityID": communityID,
-				"medicalReport.reportingEmsID":    userID,
-			}, "medicalReport")},
+				"report.activeCommunityID": communityID,
+				"report.reportingEmsID":    userID,
+			}, "report")},
 			bson.M{"$count": "total"},
 		})
 		if err != nil {

--- a/api/handlers/rank_reset_test.go
+++ b/api/handlers/rank_reset_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -21,13 +22,14 @@ import (
 // buildRankAssignCommunity returns a community with a single department holding two
 // ranks and one member currently sitting at the lower rank with a custom requirement
 // already marked as met.
-func buildRankAssignCommunity(ownerID, memberUserID string, lowRankID, highRankID primitive.ObjectID) *models.Community {
+func buildRankAssignCommunity(ownerID, memberUserID string, lowRankID, highRankID primitive.ObjectID, resetStats bool) *models.Community {
 	cID := primitive.NewObjectID()
 	deptID := primitive.NewObjectID()
 	return &models.Community{
 		ID: cID,
 		Details: models.CommunityDetails{
-			OwnerID: ownerID,
+			OwnerID:      ownerID,
+			RankSettings: models.RankSettings{ResetStatsOnPromotion: resetStats},
 			Departments: []models.Department{
 			{
 				ID:   deptID,
@@ -104,43 +106,98 @@ func captureAssignRankUpdate(t *testing.T, community *models.Community, ownerID,
 	return captured
 }
 
-// When a member's rank actually changes, met custom requirements must be reset so
+// rankStatsSince gates the since-promotion metric window on the community flag and the
+// member's recorded rank-assignment time.
+func TestRankStatsSince(t *testing.T) {
+	assignedAt := primitive.NewDateTimeFromTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+
+	withReset := func(on bool) *models.Community {
+		return &models.Community{Details: models.CommunityDetails{
+			RankSettings: models.RankSettings{ResetStatsOnPromotion: on},
+		}}
+	}
+
+	t.Run("flag off returns nil (all-time)", func(t *testing.T) {
+		got := rankStatsSince(withReset(false), models.MemberStatus{RankAssignedAt: assignedAt})
+		assert.Nil(t, got)
+	})
+
+	t.Run("flag on but no assignment time returns nil (all-time fallback)", func(t *testing.T) {
+		got := rankStatsSince(withReset(true), models.MemberStatus{})
+		assert.Nil(t, got)
+	})
+
+	t.Run("flag on with assignment time returns that time", func(t *testing.T) {
+		got := rankStatsSince(withReset(true), models.MemberStatus{RankAssignedAt: assignedAt})
+		if assert.NotNil(t, got) {
+			assert.True(t, got.Equal(assignedAt.Time()), "expected since == RankAssignedAt")
+		}
+	})
+
+	t.Run("nil community returns nil", func(t *testing.T) {
+		assert.Nil(t, rankStatsSince(nil, models.MemberStatus{RankAssignedAt: assignedAt}))
+	})
+}
+
+// customRequirementsMetKey returns the $set key ending in customRequirementsMet, if any.
+func customRequirementsMetKey(set bson.M) string {
+	const suffix = "customRequirementsMet"
+	for k := range set {
+		if len(k) > len(suffix) && k[len(k)-len(suffix):] == suffix {
+			return k
+		}
+	}
+	return ""
+}
+
+// With reset-stats mode ON, a rank change must clear met custom requirements so
 // progress toward the new rank starts fresh.
-func TestAssignMemberRankHandler_ResetsCustomRequirementsOnRankChange(t *testing.T) {
+func TestAssignMemberRankHandler_ResetMode_ClearsCustomRequirementsOnRankChange(t *testing.T) {
 	ownerID := primitive.NewObjectID().Hex()
 	memberUserID := primitive.NewObjectID().Hex()
 	lowRankID := primitive.NewObjectID()
 	highRankID := primitive.NewObjectID()
 
-	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID)
+	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID, true)
 
 	set := captureAssignRankUpdate(t, community, ownerID, highRankID.Hex())
 
-	var customKey string
-	for k := range set {
-		if len(k) > len("customRequirementsMet") && k[len(k)-len("customRequirementsMet"):] == "customRequirementsMet" {
-			customKey = k
-		}
-	}
-	assert.NotEmpty(t, customKey, "expected customRequirementsMet to be reset on rank change")
-	assert.Equal(t, []string{}, set[customKey], "customRequirementsMet should be reset to an empty slice")
+	key := customRequirementsMetKey(set)
+	assert.NotEmpty(t, key, "expected customRequirementsMet to be reset on rank change in reset mode")
+	assert.Equal(t, []string{}, set[key], "customRequirementsMet should be reset to an empty slice")
 }
 
-// Re-assigning the same rank should leave met custom requirements untouched.
-func TestAssignMemberRankHandler_PreservesCustomRequirementsOnSameRank(t *testing.T) {
+// With reset-stats mode OFF (default / all-time), a rank change must NOT touch met
+// custom requirements — you keep what you earned.
+func TestAssignMemberRankHandler_AllTimeMode_PreservesCustomRequirementsOnRankChange(t *testing.T) {
 	ownerID := primitive.NewObjectID().Hex()
 	memberUserID := primitive.NewObjectID().Hex()
 	lowRankID := primitive.NewObjectID()
 	highRankID := primitive.NewObjectID()
 
-	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID)
+	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID, false)
+
+	set := captureAssignRankUpdate(t, community, ownerID, highRankID.Hex())
+
+	if key := customRequirementsMetKey(set); key != "" {
+		t.Fatalf("did not expect customRequirementsMet reset in all-time mode, got key %q", key)
+	}
+}
+
+// Re-assigning the same rank should leave met custom requirements untouched even in
+// reset-stats mode.
+func TestAssignMemberRankHandler_ResetMode_PreservesCustomRequirementsOnSameRank(t *testing.T) {
+	ownerID := primitive.NewObjectID().Hex()
+	memberUserID := primitive.NewObjectID().Hex()
+	lowRankID := primitive.NewObjectID()
+	highRankID := primitive.NewObjectID()
+
+	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID, true)
 
 	// Assign the rank the member already holds.
 	set := captureAssignRankUpdate(t, community, ownerID, lowRankID.Hex())
 
-	for k := range set {
-		if len(k) > len("customRequirementsMet") && k[len(k)-len("customRequirementsMet"):] == "customRequirementsMet" {
-			t.Fatalf("did not expect customRequirementsMet reset when re-assigning the same rank, got key %q", k)
-		}
+	if key := customRequirementsMetKey(set); key != "" {
+		t.Fatalf("did not expect customRequirementsMet reset when re-assigning the same rank, got key %q", key)
 	}
 }

--- a/api/handlers/rank_reset_test.go
+++ b/api/handlers/rank_reset_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// buildRankAssignCommunity returns a community with a single department holding two
+// ranks and one member currently sitting at the lower rank with a custom requirement
+// already marked as met.
+func buildRankAssignCommunity(ownerID, memberUserID string, lowRankID, highRankID primitive.ObjectID) *models.Community {
+	cID := primitive.NewObjectID()
+	deptID := primitive.NewObjectID()
+	return &models.Community{
+		ID: cID,
+		Details: models.CommunityDetails{
+			OwnerID: ownerID,
+			Departments: []models.Department{
+			{
+				ID:   deptID,
+				Name: "Police",
+				Ranks: []models.Rank{
+					{ID: lowRankID, Name: "Officer", DisplayOrder: 2},
+					{ID: highRankID, Name: "Sergeant", DisplayOrder: 1},
+				},
+				Members: []models.MemberStatus{
+					{
+						UserID:                memberUserID,
+						Status:                "approved",
+						RankID:                lowRankID.Hex(),
+						CustomRequirementsMet: []string{"req-already-met"},
+					},
+				},
+			},
+			},
+		},
+	}
+}
+
+// captureAssignRankUpdate exercises AssignMemberRankHandler and returns the $set
+// document persisted to Mongo so callers can assert on customRequirementsMet.
+func captureAssignRankUpdate(t *testing.T, community *models.Community, ownerID, newRankID string) bson.M {
+	t.Helper()
+
+	mockCommunityDB := &mocks.CommunityDatabase{}
+	mockUserDB := &mocks.UserDatabase{}
+	mockAuditDB := &mocks.AuditLogDatabase{}
+
+	handler := Community{
+		DB:   mockCommunityDB,
+		UDB:  mockUserDB,
+		ALDB: mockAuditDB,
+	}
+
+	deptID := community.Details.Departments[0].ID.Hex()
+	memberUserID := community.Details.Departments[0].Members[0].UserID
+
+	mockCommunityDB.On("FindOne", mock.Anything, bson.M{"_id": community.ID}).Return(community, nil)
+
+	var captured bson.M
+	mockCommunityDB.On("UpdateOne", mock.Anything, bson.M{"_id": community.ID}, mock.Anything).
+		Run(func(args mock.Arguments) {
+			update := args.Get(2).(bson.M)
+			if set, ok := update["$set"].(bson.M); ok {
+				captured = set
+			}
+		}).Return(nil)
+
+	// resolveActorName looks up the actor username; return an empty result.
+	actorResult := &mocks.SingleResultHelper{}
+	actorResult.On("Decode", mock.Anything).Return(nil)
+	mockUserDB.On("FindOne", mock.Anything, mock.Anything).Return(actorResult)
+
+	// logAudit fires asynchronously; allow the insert to succeed if it runs.
+	mockAuditDB.On("InsertOne", mock.Anything, mock.Anything).Return(nil, nil).Maybe()
+
+	body, _ := json.Marshal(map[string]string{"rankId": newRankID})
+	url := fmt.Sprintf("/api/v1/community/%s/departments/%s/members/%s/rank?userId=%s",
+		community.ID.Hex(), deptID, memberUserID, ownerID)
+	req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{
+		"communityId":  community.ID.Hex(),
+		"departmentId": deptID,
+		"userId":       memberUserID,
+	})
+	rec := httptest.NewRecorder()
+
+	handler.AssignMemberRankHandler(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	return captured
+}
+
+// When a member's rank actually changes, met custom requirements must be reset so
+// progress toward the new rank starts fresh.
+func TestAssignMemberRankHandler_ResetsCustomRequirementsOnRankChange(t *testing.T) {
+	ownerID := primitive.NewObjectID().Hex()
+	memberUserID := primitive.NewObjectID().Hex()
+	lowRankID := primitive.NewObjectID()
+	highRankID := primitive.NewObjectID()
+
+	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID)
+
+	set := captureAssignRankUpdate(t, community, ownerID, highRankID.Hex())
+
+	var customKey string
+	for k := range set {
+		if len(k) > len("customRequirementsMet") && k[len(k)-len("customRequirementsMet"):] == "customRequirementsMet" {
+			customKey = k
+		}
+	}
+	assert.NotEmpty(t, customKey, "expected customRequirementsMet to be reset on rank change")
+	assert.Equal(t, []string{}, set[customKey], "customRequirementsMet should be reset to an empty slice")
+}
+
+// Re-assigning the same rank should leave met custom requirements untouched.
+func TestAssignMemberRankHandler_PreservesCustomRequirementsOnSameRank(t *testing.T) {
+	ownerID := primitive.NewObjectID().Hex()
+	memberUserID := primitive.NewObjectID().Hex()
+	lowRankID := primitive.NewObjectID()
+	highRankID := primitive.NewObjectID()
+
+	community := buildRankAssignCommunity(ownerID, memberUserID, lowRankID, highRankID)
+
+	// Assign the rank the member already holds.
+	set := captureAssignRankUpdate(t, community, ownerID, lowRankID.Hex())
+
+	for k := range set {
+		if len(k) > len("customRequirementsMet") && k[len(k)-len("customRequirementsMet"):] == "customRequirementsMet" {
+			t.Fatalf("did not expect customRequirementsMet reset when re-assigning the same rank, got key %q", k)
+		}
+	}
+}

--- a/models/community.go
+++ b/models/community.go
@@ -69,6 +69,7 @@ type CommunityDetails struct {
 	MostWantedVisibleFields       []string                `json:"mostWantedVisibleFields" bson:"mostWantedVisibleFields"`
 	MostWantedCustomFields        []MostWantedCustomField `json:"mostWantedCustomFields" bson:"mostWantedCustomFields"`
 	Economy                       EconomySettings         `json:"economy" bson:"economy"`
+	RankSettings                  RankSettings            `json:"rankSettings" bson:"rankSettings"`
 	// RpPromotion holds the community's last "RP server promotion" Discord post
 	// and the timestamp used to enforce the once-per-cooldown posting gate.
 	// Pointer so legacy communities that never promoted serialize it as absent.
@@ -257,6 +258,16 @@ type RankRequirement struct {
 	MetricType  string `json:"metricType" bson:"metricType"`                       // e.g. "citations_issued" or "custom"
 	Threshold   int    `json:"threshold" bson:"threshold"`                         // e.g. 50 (ignored for custom)
 	CustomLabel string `json:"customLabel,omitempty" bson:"customLabel,omitempty"` // free-text label for custom requirements
+}
+
+// RankSettings holds community-wide rank/promotion configuration.
+type RankSettings struct {
+	// ResetStatsOnPromotion, when true, measures rank requirement progress from the
+	// member's most recent rank assignment (MemberStatus.RankAssignedAt) instead of
+	// all-time. Promotions then require a fresh count of metrics per rank, and met
+	// custom requirements are cleared on promotion. Default false preserves the
+	// historical all-time behavior so existing communities are unaffected.
+	ResetStatsOnPromotion bool `json:"resetStatsOnPromotion" bson:"resetStatsOnPromotion"`
 }
 
 // Rank defines a configurable LEO rank within a department

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -53,4 +53,7 @@ all-time and since-promotion numbers with progress labeled "since promotion".
 - Logic lives server-side; clients just render returned values + flag.
 
 ## Review
-(to be filled in after implementation)
+- Implemented across API (PR #133), website (PR #943), mobile (production).
+- Fixed pre-existing `medical_reports_created` metric bug: pipeline matched
+  `medicalReport.*` but docs are stored under `report.*` (MedicalReport.Report,
+  bson:"report"), so the metric always counted 0. Now uses the `report` prefix.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,56 @@
+# Reset stats on promotion (community toggle) — builds on PR #133
+
+## Goal
+Community-level toggle. **Default OFF = today's all-time behavior (no breakage).**
+When ON: rank requirement progress is measured **since the member's last promotion**
+(`RankAssignedAt`), custom requirements reset on promotion, and the UI shows BOTH
+all-time and since-promotion numbers with progress labeled "since promotion".
+
+## Data model
+- [ ] Add `RankSettings` to `CommunityDetails` (new field, keeps existing layout):
+      `community.rankSettings.resetStatsOnPromotion bool` (default false / absent = off).
+
+## API (police-cad-api)
+- [ ] `computeOfficerMetrics`: add optional `since *time.Time`. When set, inject
+      `{"<prefix>.createdAt": {"$gte": since}}` into each metric `$match`
+      (paths verified: civilian.criminalHistory.createdAt, arrestReport.createdAt,
+      call.createdAt, bolo.createdAt, warrant.createdAt, medicalReport.createdAt).
+      Empty/zero `since` => no filter (all-time).
+- [ ] Add helper to read the flag + resolve a member's "since" time:
+      flag ON && member.RankAssignedAt set => since = RankAssignedAt;
+      flag ON && no RankAssignedAt (default-rank members) => all-time fallback;
+      flag OFF => all-time.
+- [ ] `GetRankProgressHandler`:
+      - compute since-promotion metrics for requirement eval when flag ON.
+      - also compute all-time metrics for display.
+      - response: add `resetStatsOnPromotion` (top level); `OfficerMetric` and
+        `RankProgress` gain `allTimeValue` (currentValue stays the eval value).
+      - reset-mode: promote at most ONE rank per check (after promo, stats reset to ~0,
+        so no instant chain-promote — this is the core fix).
+- [ ] `CheckAllPromotionsHandler`: same since-promotion eval + one-step-per-check when ON.
+- [ ] PR #133 reconcile: gate the `customRequirementsMet` reset on the flag
+      (OFF = custom reqs persist / all-time philosophy; ON = reset on promotion).
+- [ ] Tests: since-promotion eval, all-time fallback, one-step promotion, flag-gated
+      custom reset. Keep existing tests green.
+
+## Website (police-cad)
+- [ ] Toggle in BOTH the community settings modal AND the Manage Ranks panel header.
+      Both bind to the same community-wide value (community.rankSettings.resetStatsOnPromotion);
+      changing one reflects in the other. Persisted via the community update path.
+      ddModal/standard patterns; immediate UI update.
+- [ ] Pending-promotions + per-member progress: when flag ON, label bar "since promotion"
+      and show all-time as secondary text (e.g. `2 / 2 since promotion · 4 all-time`).
+- [ ] Playwright coverage for the toggle + labeled display.
+
+## Mobile (police-cad-app)
+- [ ] OfficerStatsScreen: read `resetStatsOnPromotion` + `allTimeValue` from API.
+      When ON, label progress "since promotion" and show all-time alongside. Read-only.
+
+## Decisions locked
+- Scope: community-level (one switch for the whole community).
+- Default OFF; existing communities unchanged.
+- No backfill: use existing `RankAssignedAt`; empty => all-time fallback for that member.
+- Logic lives server-side; clients just render returned values + flag.
+
+## Review
+(to be filled in after implementation)


### PR DESCRIPTION
## Problem

Two related sources of confusion around rank promotions:

1. **Stats carry over forever.** Requirement progress (arrests, citations, etc.) is counted all-time, so a member who already exceeds the next rank's thresholds is instantly eligible — and can chain-promote through several ranks at once. Many admins expect progress to start fresh at each rank ("as a trainee I need 10 arrests; after I'm promoted, the next rank's count starts over").
2. **Met custom requirements never reset** when a member's rank changes, so admin-checked items carried over and showed as already-complete against the new rank.

## Solution

A community-wide **`rankSettings.resetStatsOnPromotion`** toggle (default **off** = today's all-time behavior, so existing communities are unaffected).

When **on**:
- Requirement progress is measured from the member's last rank assignment (`RankAssignedAt`) instead of all-time, via a `createdAt >= since` filter applied to every metric pipeline in `computeOfficerMetrics`.
- Auto-promotion advances **at most one rank per check** — stats reset to ~0 right after a promotion, which structurally prevents the instant chain-promotion that all-time totals allowed.
- Met custom requirements are cleared on promotion (the original fix in this PR, now **gated on the flag**; all-time mode preserves them — "you keep what you earned").

When **off**: fully unchanged from current production behavior.

## API changes

- `models`: add `CommunityDetails.RankSettings.ResetStatsOnPromotion`.
- `computeOfficerMetrics(..., since *time.Time)`: optional lower-bound filter on every metric source (citations, warnings, arrests, calls, bolos, warrants, medical reports, court cases).
- `GetRankProgressHandler`, `CheckAllPromotionsHandler`, pending-promotion handlers, `GetOfficerStatsHandler`: reset-aware eligibility + one-step promotion in reset mode.
- Responses now return `allTimeValue` alongside `currentValue`, plus a top-level `resetStatsOnPromotion` flag, so clients can show both lifetime and since-promotion numbers and label the bar accordingly.
- Setting is persisted by the existing generic `PATCH /api/v1/community/{id}` (`{"rankSettings.resetStatsOnPromotion": bool}`) — no endpoint change needed.

## Also fixed (pre-existing bug)

`medical_reports_created` matched `medicalReport.*`, but medical report docs are stored under the `report` key (`MedicalReport.Report`, `bson:"report"`). The metric always counted 0, so any EMS/Fire rank requiring it could never be met. Corrected to the `report` prefix. **Behavior change:** affected members will now accrue progress and may become eligible once deployed.

## Tests

- `rankStatsSince` gating (flag off / no baseline / with baseline / nil community).
- Flag-gated custom-requirement reset on manual assign (reset mode clears on rank change; all-time mode preserves; same-rank never clears).
- Full handler suite green; `go build ./...` clean.

## Companion changes (separate repos)

- Website toggle + since-promotion labels: Linesmerrill/police-cad#943
- Mobile OfficerStatsScreen labels: pushed to `police-cad-app` `production`.

**Deploy order:** this PR first, then website #943, then mobile reads the new fields (all degrade safely if a field is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)