### PR TITLE
fix(departments): clear join-request notifications for all staff on resolve

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -3633,6 +3633,26 @@ func (c Community) UpdateDepartmentJoinRequestHandler(w http.ResponseWriter, r *
 	}
 	logAudit(c.ALDB, cID, auditAction, "department", actorID, resolveActorName(c.UDB, actorID), requestBody.UserID, resolveActorName(c.UDB, requestBody.UserID), map[string]interface{}{"departmentId": departmentID})
 
+	// Once the request is resolved (approved or declined), clear the matching
+	// join_request notifications from every admin who received one. Otherwise the
+	// notification lingers as "requesting to join" for all other staff until each
+	// surface manually refetches — so multiple staff can spend time acting on a
+	// request that was already handled. Department notifications carry
+	// data1=communityId and data3=departmentId. Mirrors the cleanup done on
+	// request cancellation (user.go) and community-level resolution.
+	if requestBody.Status == "approved" || requestBody.Status == "declined" {
+		notifMatch := bson.M{
+			"type":       "join_request",
+			"sentFromID": requestBody.UserID,
+			"data1":      communityID,
+			"data3":      departmentID,
+		}
+		notifFilter := bson.M{"user.notifications": bson.M{"$elemMatch": notifMatch}}
+		notifUpdate := bson.M{"$pull": bson.M{"user.notifications": notifMatch}}
+		// Best-effort cleanup — never fail the resolution if this errors.
+		_, _ = c.UDB.UpdateMany(ctx, notifFilter, notifUpdate)
+	}
+
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(`{"message": "Department join request updated successfully"}`))
 }


### PR DESCRIPTION
## Problem

A staff member can accept (or decline) a department join request, but the
notification still shows up for **other** staff members. They had no idea it
was already handled — e.g. spending ~2 hours on the LPC mobile app accepting
applications that were already accepted, with all the notifications still
present.

## Root cause

When a join request is created, a `join_request` notification is fanned out
to **every** admin (owner + anyone with `manage members`/`administrator`). On
resolution, the matching notifications should be pulled from all of those
admins.

That cleanup already exists in three sibling paths:
- community-level resolution (`user.go`)
- community request cancellation (`user.go`)
- department request cancellation (`user.go`)

…but `UpdateDepartmentJoinRequestHandler` (`community.go`) — the endpoint the
mobile app, website, and bot all PUT to when approving/declining a
**department** request — was the only resolution path missing it. So the
status flipped to `approved`/`declined` but the notifications lingered for
everyone else until each surface manually refetched.

## Fix

After the status update + audit log, on `approved`/`declined`, pull the
matching `join_request` notifications from all admins:

```
type = "join_request"
sentFromID = requestBody.UserID
data1 = communityId
data3 = departmentId
```

Best-effort (`UpdateMany`, errors ignored) so it never fails the resolution —
identical to the existing sibling implementations. Because the fix is
server-side it resolves the bug for mobile, website, and Discord bot at once.

## Testing

- `go build ./api/...` passes.
- Confirmed the mobile app (`services/departments.js` `updateDepartmentJoinRequest`)
  and website (`public/js/notifications.js`) both PUT to this exact endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
