### PR TITLE
ci: bump actions/checkout to v5 in feature-triage workflow

### DIFF
--- a/.github/workflows/feature-triage.yml
+++ b/.github/workflows/feature-triage.yml
@@ -18,7 +18,7 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch + regenerate triage doc
         id: refresh


### PR DESCRIPTION
Silences the Node 20 deprecation warning in the weekly feature-triage workflow (`actions/checkout@v4` was being force-run on Node 24). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)