### PR TITLE
fix: promotion-eligibility owner lookup full-scanned users (830K docs)

### DIFF
--- a/api/handlers/rank.go
+++ b/api/handlers/rank.go
@@ -1912,9 +1912,19 @@ func (c Community) sendPromotionEligibleNotification(ctx context.Context, commun
 		return
 	}
 
-	// Look up owner by userID field (auth ID), not _id
+	// Look up the owner by _id. community.OwnerID IS the owner's user _id, so
+	// filtering on a (nonexistent) top-level "userID" field matched nothing and
+	// full-scanned the entire users collection (~830K docs) on every call.
+	// Query by _id — string first, then ObjectID — mirroring the owner lookup in
+	// AdminCommunitySearchHandler so both storage formats are covered.
 	var owner models.User
-	if err := c.UDB.FindOne(ctx, bson.M{"userID": ownerID}).Decode(&owner); err != nil {
+	err := c.UDB.FindOne(ctx, bson.M{"_id": ownerID}).Decode(&owner)
+	if err != nil {
+		if oid, oidErr := primitive.ObjectIDFromHex(ownerID); oidErr == nil {
+			err = c.UDB.FindOne(ctx, bson.M{"_id": oid}).Decode(&owner)
+		}
+	}
+	if err != nil {
 		return
 	}
 	ownerObjID := owner.ID // string hex of _id


### PR DESCRIPTION
## The last full-collection scan
After backfilling the recommended `users` indexes, Atlas Performance Advisor was left with **one** suggestion: `{ userID: 1 }` on `users` — **830,421 docs scanned, 0 returned, ~368 MB reads** per execution.

Root cause: `sendPromotionEligibleNotification` ([rank.go:1917](api/handlers/rank.go#L1917)) looked up the community owner with `bson.M{"userID": ownerID}`. **Users have no top-level `userID` field** — they key off `_id`, and `community.OwnerID` *is* that `_id`. So the filter matched nothing and full-scanned all ~830K users on every promotion-eligibility check (fires whenever an officer meets rank requirements).

## Fix
Query by `_id` — string first, then `ObjectID` fallback — mirroring the owner lookup in `AdminCommunitySearchHandler` (covers both id storage formats). Turns the scan into an `_id` seek and, as a bonus, the notification now actually finds the owner (it was silently returning before, so eligible-promotion notifications to owners were never sent).

## Notes
- `go build ./...` passes.
- Don't index the phantom `userID` field — fixing the query is the correct move; no new index needed.
- This clears the final Performance Advisor recommendation for `users`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)