### PR TITLE
fix: admin community search resilient to one undecodable community doc

### DIFF
--- a/api/handlers/admin.go
+++ b/api/handlers/admin.go
@@ -793,10 +793,30 @@ func (h Admin) AdminCommunitySearchHandler(w http.ResponseWriter, r *http.Reques
 	}
 	defer cursor.Close(ctx)
 
-	var communities []models.Community
-	if err = cursor.All(ctx, &communities); err != nil {
+	// Decode per-document rather than cursor.All: a single malformed community
+	// (e.g. a legacy field whose BSON type no longer matches the struct) must not
+	// fail the entire admin search. Skip the bad doc and log its id/name + the
+	// decode error (which names the offending field path) so the data can be
+	// repaired, instead of 500-ing every search that happens to match it.
+	communities := []models.Community{}
+	for cursor.Next(ctx) {
+		var comm models.Community
+		if decErr := cursor.DecodeCurrent(&comm); decErr != nil {
+			var meta struct {
+				ID      interface{} `bson:"_id"`
+				Details struct {
+					Name string `bson:"name"`
+				} `bson:"community"`
+			}
+			_ = cursor.DecodeCurrent(&meta)
+			log.Printf("[admin community search] skipping undecodable community id=%v name=%q: %v", meta.ID, meta.Details.Name, decErr)
+			continue
+		}
+		communities = append(communities, comm)
+	}
+	if cErr := cursor.Err(); cErr != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to decode communities"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to iterate communities"})
 		return
 	}
 


### PR DESCRIPTION
## Bug
Admin console → community search for **"Ohio State Roleplay - Flashing Lights"** returns 500 `{"error":"failed to decode communities"}` (4.26s, not a timeout). Root cause: `AdminCommunitySearchHandler` used `cursor.All()` to decode every matched community at once — if **one** legacy doc has a field whose BSON type no longer matches `models.Community`, the entire batch fails, so any search matching that community 500s for everyone.

(This is unrelated to today's IOPS incident — that was fixed by the index work. Separate data/decoding issue.)

## Fix
Decode **per-document**: skip the malformed doc and `log.Printf` its id/name + the decode error (which names the exact offending field path), instead of failing the whole search. Search now returns all decodable matches.

## Next step to fully resolve "Ohio State Roleplay"
After this deploys, searching it will **log the exact field** that won't decode (e.g. `error decoding key community.xxx: cannot decode ... into ...`). Share that log line and I'll repair the data (targeted coercion) and/or add defensive decoding to the model so it can't recur.

- `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)