### PR TITLE
fix: defensive decode for community pay values (bad number bricked whole communities)

### DIFF
--- a/api/handlers/economy.go
+++ b/api/handlers/economy.go
@@ -50,12 +50,12 @@ func resolveDepartmentEconomy(community *models.Community, deptID, rankID string
 	if dept == nil {
 		return nil, 0, "", 0, 0, false
 	}
-	payRate = dept.BasePayPerHour
+	payRate = int64(dept.BasePayPerHour)
 	if rankID != "" {
 		for i := range dept.Ranks {
 			if dept.Ranks[i].ID.Hex() == rankID {
 				if dept.Ranks[i].PayRatePerHour > 0 {
-					payRate = dept.Ranks[i].PayRatePerHour
+					payRate = int64(dept.Ranks[i].PayRatePerHour)
 				}
 				break
 			}

--- a/models/community.go
+++ b/models/community.go
@@ -23,31 +23,35 @@ import (
 type Cents int64
 
 // UnmarshalBSONValue implements defensive decoding for Cents. See the type doc.
+// Never panics and never returns an error: uses the non-panicking ...OK()
+// accessors, and any missing / null / undefined / unexpected / corrupt value
+// decodes to 0. (A missing field never calls this at all and stays the zero
+// value; there is no null int64 in Go, and the int64(...) conversions callers
+// do are pure numeric casts that cannot panic.)
 func (c *Cents) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
 	rv := bson.RawValue{Type: t, Value: data}
+	*c = 0
 	switch t {
 	case bsontype.Int32:
-		*c = Cents(rv.Int32())
+		if n, ok := rv.Int32OK(); ok {
+			*c = Cents(n)
+		}
 	case bsontype.Int64:
-		*c = Cents(rv.Int64())
+		if n, ok := rv.Int64OK(); ok {
+			*c = Cents(n)
+		}
 	case bsontype.Double:
-		d := rv.Double()
-		if math.IsNaN(d) || math.IsInf(d, 0) || d > math.MaxInt64 || d < math.MinInt64 {
-			*c = 0
-		} else {
+		if d, ok := rv.DoubleOK(); ok && !math.IsNaN(d) && !math.IsInf(d, 0) &&
+			d <= math.MaxInt64 && d >= math.MinInt64 {
 			*c = Cents(d)
 		}
 	case bsontype.String:
-		s := strings.TrimSpace(strings.TrimPrefix(rv.StringValue(), "$"))
-		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
-			*c = Cents(n)
-		} else {
-			*c = 0
+		if s, ok := rv.StringValueOK(); ok {
+			s = strings.TrimSpace(strings.TrimPrefix(s, "$"))
+			if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+				*c = Cents(n)
+			}
 		}
-	case bsontype.Null, bsontype.Undefined:
-		*c = 0
-	default:
-		*c = 0
 	}
 	return nil
 }

--- a/models/community.go
+++ b/models/community.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -9,6 +10,47 @@ import (
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
+
+// Cents is a monetary amount in cents (hourly pay, etc.) that decodes
+// DEFENSIVELY from BSON. A community once had a rank payRatePerHour of 1e32 (a
+// bad value written via the website's Mongoose path) stored as a BSON double;
+// decoding it into a plain int64 overflowed and made the ENTIRE community fail
+// to decode — 500ing every community-scoped read (page load, panic alerts,
+// units, signal-100, ...). Accept int32/int64/double/string and clamp anything
+// non-finite or out of int64 range to 0, so a single bad value can never brick
+// a community again. Underlying type stays int64, so callers convert with
+// int64(...) and JSON still serializes as a plain number.
+type Cents int64
+
+// UnmarshalBSONValue implements defensive decoding for Cents. See the type doc.
+func (c *Cents) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
+	rv := bson.RawValue{Type: t, Value: data}
+	switch t {
+	case bsontype.Int32:
+		*c = Cents(rv.Int32())
+	case bsontype.Int64:
+		*c = Cents(rv.Int64())
+	case bsontype.Double:
+		d := rv.Double()
+		if math.IsNaN(d) || math.IsInf(d, 0) || d > math.MaxInt64 || d < math.MinInt64 {
+			*c = 0
+		} else {
+			*c = Cents(d)
+		}
+	case bsontype.String:
+		s := strings.TrimSpace(strings.TrimPrefix(rv.StringValue(), "$"))
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			*c = Cents(n)
+		} else {
+			*c = 0
+		}
+	case bsontype.Null, bsontype.Undefined:
+		*c = 0
+	default:
+		*c = 0
+	}
+	return nil
+}
 
 // Community holds the structure for the community collection in mongo
 type Community struct {
@@ -280,7 +322,7 @@ type Rank struct {
 	AutoPromote    bool               `json:"autoPromote" bson:"autoPromote"`
 	CanViewStats   bool               `json:"canViewStats" bson:"canViewStats"`     // can view department metrics
 	IsDefault      bool               `json:"isDefault" bson:"isDefault"`           // unranked members get this rank
-	PayRatePerHour int64              `json:"payRatePerHour" bson:"payRatePerHour"` // Economy: hourly pay in cents; 0 falls back to Department.BasePayPerHour
+	PayRatePerHour Cents              `json:"payRatePerHour" bson:"payRatePerHour"` // Economy: hourly pay in cents; 0 falls back to Department.BasePayPerHour. Cents = defensive decode (see type doc).
 }
 
 // Department holds the structure for a department
@@ -304,7 +346,7 @@ type Department struct {
 	RestrictCivilianRecordDeletion *bool `json:"restrictCivilianRecordDeletion,omitempty" bson:"restrictCivilianRecordDeletion,omitempty"`
 	// Economy fields
 	EconomyEnabled           bool               `json:"economyEnabled" bson:"economyEnabled"`
-	BasePayPerHour           int64              `json:"basePayPerHour" bson:"basePayPerHour"`                     // cents/hr, fallback if rank pay is 0
+	BasePayPerHour           Cents              `json:"basePayPerHour" bson:"basePayPerHour"`                     // cents/hr, fallback if rank pay is 0. Cents = defensive decode (see type doc).
 	MaxSessionMinutes        int                `json:"maxSessionMinutes" bson:"maxSessionMinutes"`               // default 120
 	AfkPromptIntervalSeconds int                `json:"afkPromptIntervalSeconds" bson:"afkPromptIntervalSeconds"` // e.g. 600
 	AfkGraceSeconds          int                `json:"afkGraceSeconds" bson:"afkGraceSeconds"`                   // e.g. 60

--- a/scripts/remediate_payrate_overflow.js
+++ b/scripts/remediate_payrate_overflow.js
@@ -1,0 +1,47 @@
+// Remediation: cap out-of-int64-range economy pay values on communities.
+//
+// A rank payRatePerHour (or department basePayPerHour) stored as a huge BSON
+// double (e.g. 1e32, from a bad website/Mongoose write) overflows the Go int64
+// field and makes the ENTIRE community fail to decode — 500ing every
+// community-scoped read (page load, panic alerts, units, signal-100, ...).
+//
+// This finds every community with an overflowing value and sets it to 0 (which
+// the app treats as "unset" → falls back to base pay). The Cents defensive
+// decoder in models/community.go now prevents this from bricking reads going
+// forward; this script cleans up existing bad data.
+//
+// Usage: mongosh "<CONNECTION_STRING>" scripts/remediate_payrate_overflow.js
+// Idempotent — safe to re-run.
+
+var INT64_MAX = 9223372036854775807;
+var comms = 0, fields = 0;
+
+db.communities.find(
+  {
+    $or: [
+      { "community.departments.ranks.payRatePerHour": { $gt: INT64_MAX } },
+      { "community.departments.basePayPerHour": { $gt: INT64_MAX } }
+    ]
+  },
+  { "community.departments": 1, "community.name": 1 }
+).forEach(function (c) {
+  var set = {};
+  (c.community.departments || []).forEach(function (d, di) {
+    if (typeof d.basePayPerHour === "number" && Math.abs(d.basePayPerHour) > INT64_MAX) {
+      set["community.departments." + di + ".basePayPerHour"] = 0;
+    }
+    (d.ranks || []).forEach(function (r, ri) {
+      if (typeof r.payRatePerHour === "number" && Math.abs(r.payRatePerHour) > INT64_MAX) {
+        set["community.departments." + di + ".ranks." + ri + ".payRatePerHour"] = 0;
+      }
+    });
+  });
+  if (Object.keys(set).length) {
+    db.communities.updateOne({ _id: c._id }, { $set: set });
+    print("Fixed " + Object.keys(set).length + " field(s) on " + c._id + " (" + (c.community.name || "?") + ")");
+    comms++;
+    fields += Object.keys(set).length;
+  }
+});
+
+print("\nDone: fixed " + fields + " field(s) across " + comms + " communities");


### PR DESCRIPTION
## Bug (root cause of the "failed to decode communities" / dead community pages)
A rank `payRatePerHour` of **`1e+32`** (a bad value written through the website/Mongoose path, stored as a BSON double) **overflowed the Go `int64`** field. Because that field is deep inside the community document, the **entire community failed to decode** — so *every* community-scoped read 500'd: community page load, panic-alerts, units, signal-100, and admin community search. Confirmed from prod logs:
```
error decoding key community.departments.1.ranks.2.payRatePerHour: 1e+32 overflows int64
```
Two communities were affected (Ohio State Roleplay, California State Roleplay PS5) — both repaired.

## Fix
- New **`Cents`** type (underlying `int64`) with a defensive `UnmarshalBSONValue`: accepts int32/int64/double/string and **clamps non-finite / out-of-int64-range values to 0**. Applied to `Rank.PayRatePerHour` and `Department.BasePayPerHour`. A single garbage value can no longer brick a community's reads. Only caller (`economy.go`) converts with `int64(...)`; JSON still serializes as a plain number.
- **`scripts/remediate_payrate_overflow.js`** — caps existing overflow values across all communities (already run manually for the two affected; kept for a clean/repeatable migration).

## Why the defensive decode (not just validation)
The bad values entered via Mongoose (the Go API's JSON decode would reject `1e32` into int64), so read-side defense is the guaranteed safety net regardless of write path. Input validation on the website rank editor is a sensible follow-up but not sufficient alone.

- `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)