### PR TITLE
fix(logging): stop warning on omitted pagination params

### DIFF
--- a/api/handlers/bolo.go
+++ b/api/handlers/bolo.go
@@ -10,7 +10,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.uber.org/zap"
 
 	"github.com/linesmerrill/police-cad-api/api"
 	"github.com/linesmerrill/police-cad-api/config"
@@ -61,7 +60,7 @@ func (b Bolo) FetchDepartmentBolosHandler(w http.ResponseWriter, r *http.Request
 	departmentID := r.URL.Query().Get("departmentId")
 	Limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
 	if err != nil {
-		zap.S().Warnf("limit not set, using default of %v, err: %v", Limit|10, err)
+		// Omitting ?limit is the normal default case; don't warn on it.
 		Limit = 10
 	}
 	limit64 := int64(Limit)

--- a/api/handlers/civilian.go
+++ b/api/handlers/civilian.go
@@ -328,20 +328,22 @@ func (c Civilian) CiviliansByNameSearchHandler(w http.ResponseWriter, r *http.Re
 }
 
 func getPage(Page int, r *http.Request) int {
-	if r.URL.Query().Get("page") == "" {
-		zap.S().Warnf("page not set, using default of %v", Page)
-	} else {
-		var err error
-		Page, err = strconv.Atoi(r.URL.Query().Get("page"))
-		if err != nil {
-			zap.S().Warnf(fmt.Sprintf("warning parsing page number: %v", err))
-		}
-		if Page < 0 {
-			zap.S().Warnf(fmt.Sprintf("cannot process page number less than 1. Got: %v", Page))
-			return 0
-		}
+	// Omitting ?page is the normal default case, not a warnable event — logging
+	// it warned on nearly every paginated request (a shared helper across many
+	// handlers). Only a malformed value is worth a note, at Debug.
+	raw := r.URL.Query().Get("page")
+	if raw == "" {
+		return Page
 	}
-	return Page
+	parsed, err := strconv.Atoi(raw)
+	if err != nil {
+		zap.S().Debugf("invalid page %q, using default %v", raw, Page)
+		return Page
+	}
+	if parsed < 0 {
+		return 0
+	}
+	return parsed
 }
 
 // CreateCivilianHandler creates a civilian


### PR DESCRIPTION
## What

Removes the top remaining log-noise source after the 500+stacktrace flood fix (#145): `getPage` and bolo's inline limit parse logged a **Warn every time a client omitted `?page` or `?limit`**. Using a default is normal behavior, not a warnable event.

`getPage` is a shared helper (civilian, courtcase, warrant, courtsession, formSubmission, formTemplate, …), so this warned on nearly every paginated request — **~2,000 noise Warn lines/hour**, observed via the SWO log triage run (they were the single largest log source once the flood was gone).

## Change

- `getPage` (civilian.go): fall back to the default silently when `?page` is absent; keep only a **Debug** note for genuinely malformed input (mirrors the well-behaved `ParseLimitPage` helper, which already logs nothing).
- `bolo.go`: drop the "limit not set" Warn on the default path; remove the now-unused `zap` import.

No behavior change to responses — same defaults, same clamping — only the logging is quieter.

## Testing

- `go build ./...` and `go test ./api/handlers/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)