### PR TITLE
feat(indexes): 30-day TTL + query index on tone_logs

### DIFF
--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -539,6 +539,36 @@ createIndexSafe(
   }
 );
 
+// TTL on tone_logs.createdAt: tone triggers are an activity feed — the only
+// reader (GetToneLogHandler) always sorts createdAt desc and caps at <=100, so
+// nothing reads rows older than the recent window. Auto-remove after 30 days to
+// keep this high-write collection bounded. Unlike the pendingVerifications TTL
+// (expireAfterSeconds: 0 on a stored expiresAt), this deletes 30 days *after*
+// the createdAt timestamp. createdAt is always written as a BSON Date, so every
+// row is covered; rows missing/with a non-date createdAt are simply ignored.
+createIndexSafe(
+  db.tone_logs,
+  { "createdAt": 1 },
+  {
+    name: "tone_logs_created_at_ttl",
+    expireAfterSeconds: 2592000, // 30 days
+    background: true
+  }
+);
+
+// Query index for the tone log feed: GetToneLogHandler filters by communityId
+// and sorts createdAt desc. Without this the read scans the whole collection
+// and sorts in memory. (Separate from the single-field TTL index above, which
+// MongoDB requires for expiry.)
+createIndexSafe(
+  db.tone_logs,
+  { "communityId": 1, "createdAt": -1 },
+  {
+    name: "tone_logs_community_createdAt_idx",
+    background: true
+  }
+);
+
 // MEDIUM PRIORITY: Invite Code + Remaining Uses Index (Performance Advisor)
 // Expected Impact: 0.71 queries/hour
 // Avg Execution Time: 1047 ms, Avg Docs Scanned: 6680


### PR DESCRIPTION
## What

Adds retention + a query index to `tone_logs`, the last disk item from the log/DB investigation.

`tone_logs` is a **high-write activity feed** — one row per tone-board trigger, which in an active community fires every few seconds — and it had **no retention and no indexes**. It was a suspected contributor to the MongoDB disk growth (the cluster is a 10 GB M20 that crossed the 80% alert).

The only reader, `GetToneLogHandler`, always sorts `createdAt` desc and caps at ≤100 rows — so **nothing ever reads past the recent window**, which makes old rows safe to age out.

## Changes (both via idempotent `createIndexSafe`)

1. **TTL index** `{ createdAt: 1 }`, `expireAfterSeconds: 2592000` (30 days). Deletes rows 30 days after their `createdAt`. `createdAt` is always written as a BSON Date (`primitive.NewDateTimeFromTime`), so every row is covered; any row missing/with a non-date `createdAt` is simply ignored by the TTL monitor.
2. **Query index** `{ communityId: 1, createdAt: -1 }` — the exact shape the feed read needs. The collection had no index, so that read was a full collection scan + in-memory sort. (TTL indexes must be single-field, hence the separate index.)

## Operational notes

- **This is a migration** — the index (and thus the cleanup) only takes effect when `scripts/create_indexes.js` is run against the target DB. `createIndexSafe` is safe to re-run.
- **Creating the TTL index triggers a one-time cleanup** of all `tone_logs` older than 30 days. That reclaims logical space; WiredTiger returns disk to the OS gradually (or via a `compact`). With storage auto-scaling on, this mainly flattens future growth.
- Recommend running against **police-cad-dev** first, then prod.

## Testing
- `node --check scripts/create_indexes.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)