### PR TITLE
chore(indexes): remove 6 redundant + 2 hidden index definitions

### DIFF
--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -96,16 +96,8 @@ createIndexSafe(
   }
 );
 
-// MEDIUM PRIORITY: Community Visibility Index
-// DONE
-createIndexSafe(
-  db.communities,
-  { "community.visibility": 1 }, 
-  {
-    name: "community_visibility_idx",
-    background: true
-  }
-);
+// Removed community_visibility_idx — redundant prefix of the community_visibility_*
+// compound indexes below (Atlas Performance Advisor). Dropped from prod 2026-07.
 
 // CRITICAL: Vehicle Registered Owner Index (for /vehicles/registered-owner/{id})
 // DONE
@@ -129,17 +121,9 @@ createIndexSafe(
   }
 );
 
-// CRITICAL: Vehicle Active Community ID Index (single field for queries filtering only by activeCommunityID)
-// Needed for queries that filter by activeCommunityID without userID
-// This fixes Query Targeting alerts for vehicles queries
-createIndexSafe(
-  db.vehicles,
-  { "vehicle.activeCommunityID": 1 },
-  {
-    name: "vehicle_active_community_idx",
-    background: true
-  }
-);
+// Removed vehicle_active_community_idx — redundant prefix of the
+// vehicle_activeCommunityID_{make,model,vin}_idx compounds (Atlas Performance
+// Advisor). Dropped from prod 2026-07.
 
 // CRITICAL: Civilian User ID Index (for /civilians/user/{id})
 // DONE
@@ -164,17 +148,10 @@ createIndexSafe(
   }
 );
 
-// CRITICAL: Civilian Active Community ID Index (single field for queries filtering only by activeCommunityID)
-// Needed for queries that filter by activeCommunityID without approvalStatus
-// This fixes Query Targeting alerts for civilians queries
-createIndexSafe(
-  db.civilians,
-  { "civilian.activeCommunityID": 1 },
-  {
-    name: "civilian_active_community_idx",
-    background: true
-  }
-);
+// Removed civilian_active_community_idx — redundant prefix of the
+// civilian_pending_approvals_idx / civilian_activeCommunityID_name_idx /
+// civilian_community_searchname_idx compounds (Atlas Performance Advisor).
+// Dropped from prod 2026-07.
 
 // CRITICAL: Firearm Registered Owner Index (for /firearms/registered-owner/{id})
 // The query uses $or with both fields, so we need separate indexes for each
@@ -199,14 +176,9 @@ createIndexSafe(
     background: true
   }
 );
-createIndexSafe(
-  db.firearms,
-  { "firearm.linkedCivilianID": 1 },
-  {
-    name: "firearm_linked_civilian_id_idx",
-    background: true
-  }
-);
+// Removed firearm_linked_civilian_id_idx — redundant prefix of the
+// firearm_registered_owner_idx compound { linkedCivilianID, registeredOwnerID }
+// (Atlas Performance Advisor). Dropped from prod 2026-07.
 
 // CRITICAL: Firearm Active Community ID Index (for queries filtering by activeCommunityID)
 // Needed for queries that filter by activeCommunityID
@@ -242,27 +214,13 @@ createIndexSafe(
   }
 );
 
-// MEDIUM PRIORITY: Community Tags Index (for tag-based queries)
-// DONE
-createIndexSafe(
-  db.communities,
-  { "community.tags": 1 },
-  {
-    name: "community_tags_idx",
-    background: true
-  }
-);
+// Removed community_tags_idx — hidden in prod and a redundant prefix of the
+// community_tags_visibility_name_idx compound below (Atlas Performance Advisor).
+// Dropped from prod 2026-07.
 
-// CRITICAL: Community Tags + Visibility Compound Index (for /communities/tag/{tag})
-// DONE
-createIndexSafe(
-  db.communities,
-  { "community.tags": 1, "community.visibility": 1 },
-  {
-    name: "community_tags_visibility_idx",
-    background: true
-  }
-);
+// Removed community_tags_visibility_idx — hidden in prod and a redundant prefix
+// of the community_tags_visibility_name_idx compound below (Atlas Performance
+// Advisor). Dropped from prod 2026-07.
 
 // CRITICAL: Community Tags + Visibility + Name Compound Index (for /communities/tag/{tag} with sorting)
 // MongoDB was using visibility+name index and filtering tags in memory (5.4s slow!)
@@ -424,29 +382,13 @@ createIndexSafe(
 // Based on MongoDB Performance Advisor analysis of slow queries
 // ============================================================================
 
-// HIGH PRIORITY: User Username + _id Index (Performance Advisor)
-// Expected Impact: Can reduce up to 269.1 MB of disk reads from 13.08 queries/hour
-// Avg Execution Time: 44474 ms, Avg Docs Scanned: 705303
-createIndexSafe(
-  db.users,
-  { "user.username": 1, "_id": 1 },
-  {
-    name: "user_username_id_idx",
-    background: true
-  }
-);
+// Removed user_username_id_idx — redundant prefix of the
+// user_username_id_deactivated_idx compound { username, _id, isDeactivated }
+// (Atlas Performance Advisor). Dropped from prod 2026-07.
 
-// HIGH PRIORITY: User Name + _id Index (Performance Advisor)
-// Expected Impact: Can reduce up to 269.1 MB of disk reads from 13.08 queries/hour
-// Avg Execution Time: 44474 ms, Avg Docs Scanned: 705303
-createIndexSafe(
-  db.users,
-  { "user.name": 1, "_id": 1 },
-  {
-    name: "user_name_id_idx",
-    background: true
-  }
-);
+// Removed user_name_id_idx — redundant prefix of the
+// user_name_id_deactivated_idx compound { name, _id, isDeactivated }
+// (Atlas Performance Advisor). Dropped from prod 2026-07.
 
 // HIGH PRIORITY: User Email Index (Performance Advisor)
 // Expected Impact: Can reduce up to 306.8 MB of disk reads from 9.46 queries/hour


### PR DESCRIPTION
## What

Removes 8 index definitions from `create_indexes.js` that Atlas Performance Advisor flagged as **redundant** (a strict prefix of an existing compound index — reads unaffected) or **hidden** (already disabled in prod). Verified via `getIndexes()`: all 8 are **plain** (no unique/partial/sparse/collation), so dropping removes no constraint or query coverage — only ~72 MB of storage and per-write index maintenance on hot collections (vehicles/civilians/users/firearms).

| Dropped index | Covered by (kept) | Size |
|---|---|---|
| `community_visibility_idx` | `community_visibility_*` compounds | 0.65 MB |
| `vehicle_active_community_idx` | `vehicle_activeCommunityID_{make,model,vin}_idx` | 13.8 MB |
| `civilian_active_community_idx` | `civilian_pending_approvals_idx` et al. | 11.2 MB |
| `firearm_linked_civilian_id_idx` | `firearm_registered_owner_idx` | 6.3 MB |
| `user_username_id_idx` | `user_username_id_deactivated_idx` | 22.8 MB |
| `user_name_id_idx` | `user_name_id_deactivated_idx` | 15.3 MB |
| `community_tags_idx` *(hidden)* | `community_tags_visibility_name_idx` | 0.7 MB |
| `community_tags_visibility_idx` *(hidden)* | `community_tags_visibility_name_idx` | 0.9 MB |

## Why remove from `create_indexes.js` (not just drop in prod)

All 8 were **created by this script**, so a prod-only drop would regrow them on the next migration run. Each removed block is replaced by a breadcrumb comment noting the covering compound, so they aren't re-added.

## Prod drops (applied separately)

The matching `dropIndex` calls are applied directly against prod (Atlas Performance Advisor "Drop", or a `dropIndex` script). This PR is the code side that keeps them gone.

## Reclaim expectation

~72 MB of index storage + reduced write latency. Note: like any delete, this won't drop the Atlas disk-**used** % without a `compact`/resize — the bigger disk lever remains the oplog (pending Atlas check). The main win here is **fewer indexes to maintain on write-heavy collections.**

## Testing
- `node --check scripts/create_indexes.js` passes; all 8 definitions gone, superset compounds retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)