### PR TITLE
feat(indexes): add arrestreports community+dept+officer compound index

### DIFF
--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -939,5 +939,15 @@ createIndexSafe(
   { name: "civilian_community_searchname_idx", background: true }
 );
 
+// Officer metrics: the "arrests made" count filters arrestreports by
+// activeCommunityID + departmentId + officerID (rank.go runMetrics). No existing
+// index covered it, so it was a full ~29k-doc collection scan per officer-stats
+// load. (Atlas Performance Advisor suggestion.)
+createIndexSafe(
+  db.arrestreports,
+  { "arrestReport.activeCommunityID": 1, "arrestReport.departmentId": 1, "arrestReport.officerID": 1 },
+  { name: "arrestreports_community_dept_officer_idx", background: true }
+);
+
 print("\n=== All indexes (including Performance Advisor recommendations) processed ===");
 

--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -19,11 +19,17 @@ function createIndexSafe(collection, key, options) {
     }
   }
 
-  // Check if index with same key pattern already exists
-  const exists = indexes.some(idx => JSON.stringify(idx.key) === keyStr);
+  // Consider an index present if the key pattern matches OR the name matches.
+  // The name check is essential for TEXT indexes: Mongo rewrites their key to an
+  // internal { _fts: "text", _ftsx: 1 } (the real fields move into `weights`), so
+  // the key pattern we pass never matches getIndexes(). Without the name check
+  // every run re-issues createIndex for text indexes — a harmless no-op that
+  // misleadingly prints "Created".
+  const existingIdx = indexes.find(idx =>
+    JSON.stringify(idx.key) === keyStr || (options.name && idx.name === options.name)
+  );
 
-  if (exists) {
-    const existingIdx = indexes.find(idx => JSON.stringify(idx.key) === keyStr);
+  if (existingIdx) {
     print(`⚠️  Index already exists: ${existingIdx.name} (skipping ${options.name || 'unnamed'})`);
     return;
   }


### PR DESCRIPTION
## What

Adds **one** index from the latest Atlas Performance Advisor batch — the only one that a real app query needs:

```
arrestreports { arrestReport.activeCommunityID: 1, arrestReport.departmentId: 1, arrestReport.officerID: 1 }
```

The officer-metrics **"arrests made"** count (`rank.go` runMetrics) filters arrestreports by exactly these three fields. No existing index covered that shape, so it was a full ~29k-doc collection scan per officer-stats load.

## The other 4 suggestions — intentionally skipped

Applying the same bar we used dropping redundant indexes (does the *app* run this query, often enough to earn the write cost?):

| Suggestion | Skipped because |
|---|---|
| `users.userID` | Query no longer used (confirmed) |
| `communities …ranks.payRatePerHour` | **No app query filters on it** — `payRatePerHour` is only read as a field on already-loaded departments (economy.go). The Advisor caught a one-off manual query. Indexing a doubly-nested array field for it = pure write-cost bloat. |
| `communities …basePayPerHour` | Same |
| `medications.activeCommunityID` | The hot query (civilian's meds) filters `civilianID + activeCommunityID` and already uses the existing `{civilianID}` index. The flagged scan is an `activeCommunityID`-only query (rare hard-delete cascade). |

## Apply
Merge, then it's created on the next `create_indexes.js` migration run (idempotent), or `createIndex` it directly. arrestreports is small (~29k docs, low write volume), so the write-cost is negligible.

## Testing
- `node --check scripts/create_indexes.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)