### PR TITLE
fix(indexes): detect existing text indexes in createIndexSafe by name

### DIFF
--- a/scripts/create_indexes.js
+++ b/scripts/create_indexes.js
@@ -19,11 +19,17 @@ function createIndexSafe(collection, key, options) {
     }
   }
 
-  // Check if index with same key pattern already exists
-  const exists = indexes.some(idx => JSON.stringify(idx.key) === keyStr);
+  // Consider an index present if the key pattern matches OR the name matches.
+  // The name check is essential for TEXT indexes: Mongo rewrites their key to an
+  // internal { _fts: "text", _ftsx: 1 } (the real fields move into `weights`), so
+  // the key pattern we pass never matches getIndexes(). Without the name check
+  // every run re-issues createIndex for text indexes — a harmless no-op that
+  // misleadingly prints "Created".
+  const existingIdx = indexes.find(idx =>
+    JSON.stringify(idx.key) === keyStr || (options.name && idx.name === options.name)
+  );
 
-  if (exists) {
-    const existingIdx = indexes.find(idx => JSON.stringify(idx.key) === keyStr);
+  if (existingIdx) {
     print(`⚠️  Index already exists: ${existingIdx.name} (skipping ${options.name || 'unnamed'})`);
     return;
   }


### PR DESCRIPTION
## What

Fixes the cosmetic bug where `create_indexes.js` reports **"✓ Created"** for the 3 text indexes on every run instead of "already exists".

## Why it happened

`createIndexSafe` deduped only by **key pattern**. But MongoDB rewrites a text index's key to an internal `{ "_fts": "text", "_ftsx": 1 }` — the actual fields move into a separate `weights` property. So the spec we pass (`{ "user.username": "text", ... }`) never matches `getIndexes()`, the existence check fails, and it calls `createIndex` — which MongoDB no-ops (identical index already exists) and returns success, printing "✓ Created."

Verified in prod: each collection has exactly **one** text index (no duplication) — `user_search_text_idx`, `community_name_text_idx`, `feature_request_text_idx`, all with key `{_fts,_ftsx}`. So this was purely misleading output, not a real recreation.

## Fix

Also match by index **name** in the existence check, so text indexes (and any named index) are correctly detected and reported as "already exists."

## Testing
- `node --check scripts/create_indexes.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)