### PR TITLE
feat(arrest): server-side fine + jail-time totals from charges

### DIFF
--- a/api/handlers/arrestReport.go
+++ b/api/handlers/arrestReport.go
@@ -68,6 +68,14 @@ func (a ArrestReport) CreateArrestReportHandler(w http.ResponseWriter, r *http.R
 	newArrestReport.ID = primitive.NewObjectID()
 	newArrestReport.Details.CreatedAt = primitive.NewDateTimeFromTime(time.Now())
 
+	// Recompute the canonical fine + jail-time totals from the structured charge
+	// list so stored values never depend on the submitting client's own math.
+	newArrestReport.Details.SentenceMode = models.NormalizeSentenceMode(newArrestReport.Details.SentenceMode)
+	tf, ts, tl := models.ComputeArrestTotals(newArrestReport.Details.ChargesList, newArrestReport.Details.SentenceMode)
+	newArrestReport.Details.TotalFine = tf
+	newArrestReport.Details.TotalJailTimeSeconds = ts
+	newArrestReport.Details.TotalJailTimeLabel = tl
+
 	// Use request context with timeout for proper trace tracking and timeout handling
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
@@ -104,6 +112,24 @@ func (a ArrestReport) UpdateArrestReportHandler(w http.ResponseWriter, r *http.R
 	update := bson.M{}
 	for key, value := range updatedDetails {
 		update["arrestReport."+key] = value
+	}
+
+	// When the update touches the charge list, recompute the canonical totals
+	// server-side (overriding anything the client sent) so stored fine/jail-time
+	// values never drift from the authoritative math. The edit form always
+	// resubmits chargesList alongside sentenceMode.
+	if raw, ok := updatedDetails["chargesList"]; ok {
+		var charges []models.ArrestCharge
+		if b, mErr := json.Marshal(raw); mErr == nil {
+			_ = json.Unmarshal(b, &charges)
+		}
+		mode, _ := updatedDetails["sentenceMode"].(string)
+		mode = models.NormalizeSentenceMode(mode)
+		tf, ts, tl := models.ComputeArrestTotals(charges, mode)
+		update["arrestReport.sentenceMode"] = mode
+		update["arrestReport.totalFine"] = tf
+		update["arrestReport.totalJailTimeSeconds"] = ts
+		update["arrestReport.totalJailTimeLabel"] = tl
 	}
 
 	// Set updatedAt to the current time

--- a/api/handlers/arrest_totals_test.go
+++ b/api/handlers/arrest_totals_test.go
@@ -1,0 +1,65 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/linesmerrill/police-cad-api/api/handlers"
+	"github.com/linesmerrill/police-cad-api/databases/mocks"
+	"github.com/linesmerrill/police-cad-api/models"
+)
+
+// The create handler must recompute the fine + jail-time totals server-side from
+// the submitted charge list, so stored values never depend on the client.
+func TestCreateArrestReport_ComputesTotals(t *testing.T) {
+	mockDB := &mocks.ArrestReportDatabase{}
+	var stored models.ArrestReport
+	mockDB.On("InsertOne", mock.Anything, mock.AnythingOfType("models.ArrestReport")).
+		Run(func(args mock.Arguments) {
+			stored = args.Get(1).(models.ArrestReport)
+		}).
+		Return(&mocks.InsertOneResultHelper{}, nil)
+
+	h := handlers.ArrestReport{DB: mockDB}
+	body := `{"arrestReport":{"chargesList":[
+		{"name":"Speeding","amount":100,"jailTime":"30 seconds"},
+		{"name":"Reckless Driving","amount":250,"jailTime":"2 minutes"}
+	]}}`
+	rr := httptest.NewRecorder()
+	h.CreateArrestReportHandler(rr, httptest.NewRequest("POST", "/", bytes.NewBufferString(body)))
+
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	assert.Equal(t, 350.0, stored.Details.TotalFine)
+	assert.Equal(t, int64(150), stored.Details.TotalJailTimeSeconds)
+	assert.Equal(t, "2 minutes 30 seconds", stored.Details.TotalJailTimeLabel)
+	// Unspecified mode normalises to consecutive.
+	assert.Equal(t, "consecutive", stored.Details.SentenceMode)
+}
+
+func TestCreateArrestReport_ConcurrentAndLife(t *testing.T) {
+	mockDB := &mocks.ArrestReportDatabase{}
+	var stored models.ArrestReport
+	mockDB.On("InsertOne", mock.Anything, mock.AnythingOfType("models.ArrestReport")).
+		Run(func(args mock.Arguments) { stored = args.Get(1).(models.ArrestReport) }).
+		Return(&mocks.InsertOneResultHelper{}, nil)
+
+	h := handlers.ArrestReport{DB: mockDB}
+	// concurrent -> single longest charge; a Life charge overrides the number.
+	body := `{"arrestReport":{"sentenceMode":"concurrent","chargesList":[
+		{"name":"A","amount":50,"jailTime":"1 minute"},
+		{"name":"B","amount":0,"jailTime":"Life"}
+	]}}`
+	rr := httptest.NewRecorder()
+	h.CreateArrestReportHandler(rr, httptest.NewRequest("POST", "/", bytes.NewBufferString(body)))
+
+	assert.Equal(t, http.StatusCreated, rr.Code)
+	assert.Equal(t, 50.0, stored.Details.TotalFine)
+	assert.Equal(t, models.LifeSentinelSeconds, stored.Details.TotalJailTimeSeconds)
+	assert.Equal(t, models.LifeLabel, stored.Details.TotalJailTimeLabel)
+	assert.Equal(t, "concurrent", stored.Details.SentenceMode)
+}

--- a/models/arrest_sentence.go
+++ b/models/arrest_sentence.go
@@ -1,0 +1,138 @@
+package models
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// SentenceModeConsecutive sums the jail time of every charge (the default).
+	SentenceModeConsecutive = "consecutive"
+	// SentenceModeConcurrent uses only the single longest charge.
+	SentenceModeConcurrent = "concurrent"
+	// LifeSentinelSeconds marks an indeterminate ("Life") sentence in the numeric
+	// TotalJailTimeSeconds field; display layers should render LifeLabel instead.
+	LifeSentinelSeconds = int64(-1)
+	// LifeLabel is the human-readable label for an indeterminate sentence.
+	LifeLabel = "Life"
+)
+
+// jailSegmentRe grabs "<number> <unit-word>" pairs so multi-part strings like
+// "1 year 2 months" total correctly.
+var jailSegmentRe = regexp.MustCompile(`(\d+(?:\.\d+)?)\s*([a-zA-Z]+)`)
+
+// lifeRe matches indeterminate sentences that cannot be summed numerically.
+var lifeRe = regexp.MustCompile(`(?i)\b(life|perp|perpetual|death|permanent)\b`)
+
+// jailUnitSeconds maps recognised unit words (and common abbreviations) to
+// seconds. A month is treated as 30 days and a year as 365 days.
+var jailUnitSeconds = map[string]int64{
+	"second": 1, "seconds": 1, "sec": 1, "secs": 1,
+	"minute": 60, "minutes": 60, "min": 60, "mins": 60,
+	"hour": 3600, "hours": 3600, "hr": 3600, "hrs": 3600,
+	"day": 86400, "days": 86400,
+	"week": 604800, "weeks": 604800, "wk": 604800, "wks": 604800,
+	"month": 2592000, "months": 2592000, "mo": 2592000, "mos": 2592000,
+	"year": 31536000, "years": 31536000, "yr": 31536000, "yrs": 31536000,
+}
+
+// ParseJailTimeSeconds converts a free-form jail-time string ("30 seconds",
+// "6 months", "1 year 2 months", "Life", "N/A", "") into a total number of
+// seconds. It returns isLife=true for indeterminate sentences (seconds is then
+// 0); callers should surface those as "Life" rather than a number.
+func ParseJailTimeSeconds(raw string) (seconds int64, isLife bool) {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	if s == "" || s == "n/a" || s == "na" || s == "none" || s == "0" {
+		return 0, false
+	}
+	if lifeRe.MatchString(s) {
+		return 0, true
+	}
+	var total int64
+	for _, m := range jailSegmentRe.FindAllStringSubmatch(s, -1) {
+		unit, ok := jailUnitSeconds[strings.ToLower(m[2])]
+		if !ok {
+			continue // unrecognised unit word — skip rather than guess
+		}
+		val, err := strconv.ParseFloat(m[1], 64)
+		if err != nil {
+			continue
+		}
+		total += int64(math.Round(val * float64(unit)))
+	}
+	return total, false
+}
+
+// NormalizeSentenceMode returns a valid sentence mode, defaulting to
+// consecutive for anything other than an explicit "concurrent".
+func NormalizeSentenceMode(mode string) string {
+	if strings.ToLower(strings.TrimSpace(mode)) == SentenceModeConcurrent {
+		return SentenceModeConcurrent
+	}
+	return SentenceModeConsecutive
+}
+
+// ComputeArrestTotals recomputes the fine + jail-time totals for a set of
+// charges. Fines always sum; jail time sums for "consecutive" (default) or
+// takes the single longest charge for "concurrent". Any "Life" charge makes the
+// whole sentence Life (LifeSentinelSeconds / LifeLabel).
+func ComputeArrestTotals(charges []ArrestCharge, mode string) (totalFine float64, totalSeconds int64, label string) {
+	var sum, longest int64
+	var anyLife bool
+	for _, c := range charges {
+		totalFine += c.Amount
+		secs, life := ParseJailTimeSeconds(c.JailTime)
+		if life {
+			anyLife = true
+		}
+		sum += secs
+		if secs > longest {
+			longest = secs
+		}
+	}
+	if anyLife {
+		return totalFine, LifeSentinelSeconds, LifeLabel
+	}
+	if NormalizeSentenceMode(mode) == SentenceModeConcurrent {
+		totalSeconds = longest
+	} else {
+		totalSeconds = sum
+	}
+	return totalFine, totalSeconds, FormatDuration(totalSeconds)
+}
+
+// FormatDuration renders seconds as up to the two most-significant non-zero
+// units, e.g. 2592045 -> "1 month 45 seconds". Zero (or less) renders "None".
+func FormatDuration(seconds int64) string {
+	if seconds <= 0 {
+		return "None"
+	}
+	units := []struct {
+		label string
+		secs  int64
+	}{
+		{"year", 31536000}, {"month", 2592000}, {"day", 86400},
+		{"hour", 3600}, {"minute", 60}, {"second", 1},
+	}
+	var parts []string
+	remaining := seconds
+	for _, u := range units {
+		if remaining < u.secs {
+			continue
+		}
+		n := remaining / u.secs
+		remaining %= u.secs
+		plural := ""
+		if n != 1 {
+			plural = "s"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s%s", n, u.label, plural))
+		if len(parts) == 2 {
+			break
+		}
+	}
+	return strings.Join(parts, " ")
+}

--- a/models/arrest_sentence_test.go
+++ b/models/arrest_sentence_test.go
@@ -1,0 +1,82 @@
+package models
+
+import "testing"
+
+func TestParseJailTimeSeconds(t *testing.T) {
+	cases := []struct {
+		in      string
+		seconds int64
+		life    bool
+	}{
+		{"", 0, false},
+		{"N/A", 0, false},
+		{"none", 0, false},
+		{"0", 0, false},
+		{"30 seconds", 30, false},
+		{"45 sec", 45, false},
+		{"20 minutes", 1200, false},
+		{"2 hours", 7200, false},
+		{"3 days", 259200, false},
+		{"6 months", 6 * 2592000, false},
+		{"1 year", 31536000, false},
+		{"1 year 2 months", 31536000 + 2*2592000, false},
+		{"Life", 0, true},
+		{"life in prison", 0, true},
+		{"death", 0, true},
+		{"banana", 0, false}, // unrecognised unit -> 0, not life
+	}
+	for _, c := range cases {
+		gotSecs, gotLife := ParseJailTimeSeconds(c.in)
+		if gotSecs != c.seconds || gotLife != c.life {
+			t.Errorf("ParseJailTimeSeconds(%q) = (%d, %v), want (%d, %v)",
+				c.in, gotSecs, gotLife, c.seconds, c.life)
+		}
+	}
+}
+
+func TestComputeArrestTotals(t *testing.T) {
+	charges := []ArrestCharge{
+		{Name: "Speeding", Amount: 100, JailTime: "30 seconds"},
+		{Name: "Reckless", Amount: 250, JailTime: "2 minutes"},
+	}
+
+	// consecutive: 30 + 120 = 150s; fine 350
+	fine, secs, label := ComputeArrestTotals(charges, "consecutive")
+	if fine != 350 || secs != 150 || label != "2 minutes 30 seconds" {
+		t.Errorf("consecutive = (%v, %d, %q); want (350, 150, \"2 minutes 30 seconds\")", fine, secs, label)
+	}
+
+	// concurrent: max(30, 120) = 120
+	_, secs, label = ComputeArrestTotals(charges, "concurrent")
+	if secs != 120 || label != "2 minutes" {
+		t.Errorf("concurrent = (%d, %q); want (120, \"2 minutes\")", secs, label)
+	}
+
+	// unspecified mode defaults to consecutive
+	if _, secs, _ = ComputeArrestTotals(charges, ""); secs != 150 {
+		t.Errorf("default mode secs = %d, want 150", secs)
+	}
+
+	// any Life charge overrides the numeric total
+	lifeCharges := append(charges, ArrestCharge{Name: "Murder", Amount: 0, JailTime: "Life"})
+	if fine, secs, label = ComputeArrestTotals(lifeCharges, "consecutive"); secs != LifeSentinelSeconds || label != LifeLabel || fine != 350 {
+		t.Errorf("life = (%v, %d, %q); want (350, %d, %q)", fine, secs, label, LifeSentinelSeconds, LifeLabel)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := map[int64]string{
+		0:        "None",
+		30:       "30 seconds",
+		60:       "1 minute",
+		150:      "2 minutes 30 seconds",
+		2592000:  "1 month",
+		2592045:  "1 month 45 seconds",
+		31536000: "1 year",
+	}
+	for secs, want := range cases {
+		if got := FormatDuration(secs); got != want {
+			t.Errorf("FormatDuration(%d) = %q, want %q", secs, got, want)
+		}
+	}
+}

--- a/models/arrestreport.go
+++ b/models/arrestreport.go
@@ -25,16 +25,35 @@ type ArrestReportDetails struct {
 	OfficerID        string             `json:"officerID" bson:"officerID"`
 	ActiveCommunityID string            `json:"activeCommunityID" bson:"activeCommunityID"`
 	DepartmentID     string             `json:"departmentId" bson:"departmentId"`
-	Charges          string             `json:"charges" bson:"charges"`
-	Narrative        string             `json:"narrative" bson:"narrative"`
-	Witnesses        string             `json:"witnesses" bson:"witnesses"`
-	ForceUsed        bool               `json:"forceUsed" bson:"forceUsed"`
-	AttachedForms    []AttachedForm     `json:"attachedForms" bson:"attachedForms"`
-	Status           string             `json:"status" bson:"status"`           // "", "contested", "dismissed"
-	DismissedBy      string             `json:"dismissedBy" bson:"dismissedBy"` // judge name when dismissed
-	CourtCaseID      string             `json:"courtCaseID" bson:"courtCaseID"` // linked court case ID
-	CreatedAt        primitive.DateTime `json:"createdAt" bson:"createdAt"`
-	UpdatedAt        primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+	Charges          string             `json:"charges" bson:"charges"` // legacy freeform summary, kept for back-compat
+	// ChargesList is the structured breakdown behind Charges. Each entry carries
+	// the penal-code amount + jail time so totals can be computed and audited.
+	ChargesList []ArrestCharge `json:"chargesList,omitempty" bson:"chargesList,omitempty"`
+	// SentenceMode controls how jail time is totalled: "consecutive" (sum, the
+	// default) or "concurrent" (the single longest charge). Fines always sum.
+	SentenceMode string `json:"sentenceMode,omitempty" bson:"sentenceMode,omitempty"`
+	// Totals are recomputed server-side from ChargesList on every write, so they
+	// are always canonical regardless of the client that submitted the report.
+	TotalFine            float64 `json:"totalFine" bson:"totalFine"`
+	TotalJailTimeSeconds int64   `json:"totalJailTimeSeconds" bson:"totalJailTimeSeconds"`
+	TotalJailTimeLabel   string  `json:"totalJailTimeLabel" bson:"totalJailTimeLabel"` // human-readable, e.g. "6 months"
+	Narrative            string  `json:"narrative" bson:"narrative"`
+	Witnesses            string  `json:"witnesses" bson:"witnesses"`
+	ForceUsed            bool    `json:"forceUsed" bson:"forceUsed"`
+	AttachedForms        []AttachedForm     `json:"attachedForms" bson:"attachedForms"`
+	Status               string             `json:"status" bson:"status"`           // "", "contested", "dismissed"
+	DismissedBy          string             `json:"dismissedBy" bson:"dismissedBy"` // judge name when dismissed
+	CourtCaseID          string             `json:"courtCaseID" bson:"courtCaseID"` // linked court case ID
+	CreatedAt            primitive.DateTime `json:"createdAt" bson:"createdAt"`
+	UpdatedAt            primitive.DateTime `json:"updatedAt" bson:"updatedAt"`
+}
+
+// ArrestCharge is a single penal-code charge attached to an arrest report.
+type ArrestCharge struct {
+	Name     string  `json:"name" bson:"name"`
+	Category string  `json:"category" bson:"category"`
+	Amount   float64 `json:"amount" bson:"amount"`     // fine amount
+	JailTime string  `json:"jailTime" bson:"jailTime"` // free-form, e.g. "30 seconds", "6 months", "Life"
 }
 
 // Arrestee represents the arrestee's details


### PR DESCRIPTION
## What

Backend for **Arrest Fine & Time Calculation** — arrest reports now carry a total fine and total jail time, computed from their charges.

- **Model** (`arrestreport.go`): persists the structured `chargesList` (name, category, amount, jailTime) that clients already send but was being dropped on create, plus `sentenceMode` and the `totalFine` / `totalJailTimeSeconds` / `totalJailTimeLabel` totals.
- **Calculator** (`arrest_sentence.go`): parses free-form jail-time strings (`"30 seconds"`, `"6 months"`, `"1 year 2 months"`, `"Life"`, `"N/A"`) into seconds; sums fines; totals jail time **consecutively** (sum, default) or **concurrently** (single longest); any `Life` charge makes the whole sentence Life. `FormatDuration` renders the human label.
- **Handlers**: create + update **recompute totals server-side** from `chargesList` on every write, overriding client values — so stored totals are always canonical regardless of client version.
- **Tests**: parser cases, totals math (consecutive/concurrent/life/default), and the create-handler wiring.

## Design

- **Server-authoritative** totals: web/mobile compute the same values for a live in-form preview, but the API is the source of truth on save.
- Jail time normalises with month = 30d, year = 365d. `TotalJailTimeSeconds = -1` (`LifeSentinelSeconds`) flags an indeterminate "Life" sentence; display layers render `LifeLabel`.
- Back-compat: the legacy `charges` string is untouched; no backfill — totals populate on new/edited arrests going forward.

## Base branch

Targets the **`feature/audio-alerts-and-whats-new`** soak branch (not `main`) so it rides your current soak → deploy cycle, per the staging-branch flow.

## Follow-ups

Website + mobile changes (live in-form calculator + consecutive/concurrent toggle + totals on the details views) build on this and ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
