### PR TITLE
feat(court): sentencing totals + 4-state charge dispositions

### DIFF
--- a/api/handlers/courtcase.go
+++ b/api/handlers/courtcase.go
@@ -446,10 +446,11 @@ func (cc CourtCase) ResolveCourtCaseHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	var resolveData struct {
-		Resolutions []models.CaseResolution `json:"resolutions"`
-		JudgeID     string                  `json:"judgeID"`
-		JudgeName   string                  `json:"judgeName"`
-		JudgeNotes  string                  `json:"judgeNotes"`
+		Resolutions  []models.CaseResolution `json:"resolutions"`
+		JudgeID      string                  `json:"judgeID"`
+		JudgeName    string                  `json:"judgeName"`
+		JudgeNotes   string                  `json:"judgeNotes"`
+		SentenceMode string                  `json:"sentenceMode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&resolveData); err != nil {
 		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
@@ -460,18 +461,42 @@ func (cc CourtCase) ResolveCourtCaseHandler(w http.ResponseWriter, r *http.Reque
 	defer cancel()
 
 	now := primitive.NewDateTimeFromTime(time.Now())
+	mode := models.NormalizeSentenceMode(resolveData.SentenceMode)
 
-	// Set resolvedAt on each resolution
 	for i := range resolveData.Resolutions {
-		resolveData.Resolutions[i].ResolvedAt = now
+		res := &resolveData.Resolutions[i]
+		res.ResolvedAt = now
+
+		// Derive each charge's back-compat Verdict from its Disposition so the
+		// source-record write-back further down still sets the right fine status
+		// (reduced/amended still count as upheld charges).
+		for j := range res.ChargeResolutions {
+			switch strings.ToLower(strings.TrimSpace(res.ChargeResolutions[j].Disposition)) {
+			case models.DispositionDismissed:
+				res.ChargeResolutions[j].Verdict = models.DispositionDismissed
+			case models.DispositionUpheld, models.DispositionReduced, models.DispositionAmended:
+				res.ChargeResolutions[j].Verdict = models.DispositionUpheld
+			}
+		}
+
+		// Server-authoritative per-item sentencing totals from the dispositions.
+		res.TotalFine, res.TotalJailTimeSeconds, res.TotalJailTimeLabel =
+			models.ComputeResolutionTotals(res.ChargeResolutions, mode)
 	}
+
+	// Case-wide final-judgment totals across every charge.
+	caseFine, caseSeconds, caseLabel := models.ComputeCourtCaseTotals(resolveData.Resolutions, mode)
 
 	update := bson.M{
 		"$set": bson.M{
-			"courtCase.resolutions": resolveData.Resolutions,
-			"courtCase.judgeNotes":  resolveData.JudgeNotes,
-			"courtCase.status":      "completed",
-			"courtCase.updatedAt":   now,
+			"courtCase.resolutions":          resolveData.Resolutions,
+			"courtCase.judgeNotes":           resolveData.JudgeNotes,
+			"courtCase.status":               "completed",
+			"courtCase.sentenceMode":         mode,
+			"courtCase.totalFine":            caseFine,
+			"courtCase.totalJailTimeSeconds": caseSeconds,
+			"courtCase.totalJailTimeLabel":   caseLabel,
+			"courtCase.updatedAt":            now,
 		},
 		"$push": bson.M{
 			"courtCase.history": models.CourtCaseHistoryEntry{

--- a/models/court_totals.go
+++ b/models/court_totals.go
@@ -1,0 +1,52 @@
+package models
+
+import "strings"
+
+// EffectiveCharge maps a resolved charge to the ArrestCharge the sentencing
+// totals should count, applying its disposition:
+//   - dismissed          => zeroed (no fine, no jail)
+//   - reduced / amended   => the judge's final fine + jail
+//   - upheld (or legacy)  => the original fine + jail
+//
+// Legacy resolutions carry only Verdict (no Disposition); those are treated as
+// upheld unless the verdict is "dismissed".
+func (cr ChargeResolution) EffectiveCharge() ArrestCharge {
+	switch strings.ToLower(strings.TrimSpace(cr.Disposition)) {
+	case DispositionDismissed:
+		return ArrestCharge{Name: cr.Name, Category: cr.Category}
+	case DispositionReduced, DispositionAmended:
+		return ArrestCharge{Name: cr.Name, Category: cr.Category, Amount: cr.FinalAmount, JailTime: cr.FinalJailTime}
+	case DispositionUpheld:
+		return ArrestCharge{Name: cr.Name, Category: cr.Category, Amount: cr.OriginalAmount, JailTime: cr.OriginalJailTime}
+	default:
+		// No disposition set — fall back to the legacy binary verdict.
+		if strings.ToLower(strings.TrimSpace(cr.Verdict)) == DispositionDismissed {
+			return ArrestCharge{Name: cr.Name, Category: cr.Category}
+		}
+		return ArrestCharge{Name: cr.Name, Category: cr.Category, Amount: cr.OriginalAmount, JailTime: cr.OriginalJailTime}
+	}
+}
+
+// ComputeResolutionTotals totals the charges on a single resolved item after
+// dispositions, reusing the arrest sentence calculator.
+func ComputeResolutionTotals(charges []ChargeResolution, mode string) (totalFine float64, totalSeconds int64, label string) {
+	effective := make([]ArrestCharge, 0, len(charges))
+	for _, cr := range charges {
+		effective = append(effective, cr.EffectiveCharge())
+	}
+	return ComputeArrestTotals(effective, mode)
+}
+
+// ComputeCourtCaseTotals totals every charge across every resolution for the
+// whole case, using the case-level sentence mode. Fines always sum; jail time
+// sums (consecutive) or takes the single longest charge (concurrent) across the
+// entire case; any "Life" charge makes the whole sentence Life.
+func ComputeCourtCaseTotals(resolutions []CaseResolution, mode string) (totalFine float64, totalSeconds int64, label string) {
+	var effective []ArrestCharge
+	for _, res := range resolutions {
+		for _, cr := range res.ChargeResolutions {
+			effective = append(effective, cr.EffectiveCharge())
+		}
+	}
+	return ComputeArrestTotals(effective, mode)
+}

--- a/models/court_totals_test.go
+++ b/models/court_totals_test.go
@@ -1,0 +1,71 @@
+package models
+
+import "testing"
+
+func TestChargeResolutionEffectiveCharge(t *testing.T) {
+	base := ChargeResolution{
+		Name: "Speeding", Category: "Traffic",
+		OriginalAmount: 100, OriginalJailTime: "2 minutes",
+		FinalAmount: 40, FinalJailTime: "30 seconds",
+	}
+	cases := []struct {
+		disp   string
+		amount float64
+		jail   string
+	}{
+		{DispositionUpheld, 100, "2 minutes"},
+		{DispositionDismissed, 0, ""},
+		{DispositionReduced, 40, "30 seconds"},
+		{DispositionAmended, 40, "30 seconds"},
+	}
+	for _, c := range cases {
+		cr := base
+		cr.Disposition = c.disp
+		ec := cr.EffectiveCharge()
+		if ec.Amount != c.amount || ec.JailTime != c.jail {
+			t.Errorf("%s => amount %v jail %q; want %v %q", c.disp, ec.Amount, ec.JailTime, c.amount, c.jail)
+		}
+	}
+
+	// Legacy resolutions (no Disposition) fall back to the binary Verdict.
+	if ec := (ChargeResolution{Verdict: "dismissed", OriginalAmount: 100, OriginalJailTime: "1 minute"}).EffectiveCharge(); ec.Amount != 0 || ec.JailTime != "" {
+		t.Errorf("legacy dismissed => %v %q; want 0 \"\"", ec.Amount, ec.JailTime)
+	}
+	if ec := (ChargeResolution{Verdict: "upheld", OriginalAmount: 100, OriginalJailTime: "1 minute"}).EffectiveCharge(); ec.Amount != 100 || ec.JailTime != "1 minute" {
+		t.Errorf("legacy upheld => %v %q; want 100 \"1 minute\"", ec.Amount, ec.JailTime)
+	}
+}
+
+func TestComputeResolutionTotals(t *testing.T) {
+	charges := []ChargeResolution{
+		{Disposition: DispositionUpheld, OriginalAmount: 100, OriginalJailTime: "30 seconds"},
+		{Disposition: DispositionReduced, OriginalAmount: 500, OriginalJailTime: "5 minutes", FinalAmount: 200, FinalJailTime: "1 minute"},
+		{Disposition: DispositionDismissed, OriginalAmount: 250, OriginalJailTime: "10 minutes"},
+	}
+	// consecutive: fine 100+200=300; jail 30+60=90s
+	fine, secs, label := ComputeResolutionTotals(charges, "consecutive")
+	if fine != 300 || secs != 90 || label != "1 minute 30 seconds" {
+		t.Errorf("consecutive => (%v, %d, %q); want (300, 90, \"1 minute 30 seconds\")", fine, secs, label)
+	}
+	// concurrent: jail max(30,60)=60
+	if _, secs, _ = ComputeResolutionTotals(charges, "concurrent"); secs != 60 {
+		t.Errorf("concurrent secs = %d, want 60", secs)
+	}
+}
+
+func TestComputeCourtCaseTotals_LifeOverride(t *testing.T) {
+	resolutions := []CaseResolution{
+		{ChargeResolutions: []ChargeResolution{
+			{Disposition: DispositionUpheld, OriginalAmount: 100, OriginalJailTime: "1 minute"},
+		}},
+		{ChargeResolutions: []ChargeResolution{
+			{Disposition: DispositionAmended, FinalAmount: 1000, FinalJailTime: "Life"},
+			{Disposition: DispositionDismissed, OriginalAmount: 50, OriginalJailTime: "5 minutes"},
+		}},
+	}
+	// fine 100 + 1000 = 1100; any Life charge => Life sentence
+	fine, secs, label := ComputeCourtCaseTotals(resolutions, "consecutive")
+	if fine != 1100 || secs != LifeSentinelSeconds || label != LifeLabel {
+		t.Errorf("case totals => (%v, %d, %q); want (1100, %d, %q)", fine, secs, label, LifeSentinelSeconds, LifeLabel)
+	}
+}

--- a/models/courtcase.go
+++ b/models/courtcase.go
@@ -44,6 +44,14 @@ type CourtCaseDetails struct {
 	// Resolution per contested item
 	Resolutions []CaseResolution `json:"resolutions" bson:"resolutions"`
 
+	// Final judgment totals across every charge on every resolved item, computed
+	// server-side from the dispositions. SentenceMode ("consecutive"|"concurrent")
+	// governs how jail time is combined case-wide; fines always sum.
+	SentenceMode         string  `json:"sentenceMode,omitempty" bson:"sentenceMode,omitempty"`
+	TotalFine            float64 `json:"totalFine" bson:"totalFine"`
+	TotalJailTimeSeconds int64   `json:"totalJailTimeSeconds" bson:"totalJailTimeSeconds"`
+	TotalJailTimeLabel   string  `json:"totalJailTimeLabel" bson:"totalJailTimeLabel"`
+
 	// Audit trail
 	History []CourtCaseHistoryEntry `json:"history" bson:"history"`
 
@@ -71,15 +79,39 @@ type CaseResolution struct {
 	Verdict           string             `json:"verdict" bson:"verdict"`       // "dismissed", "upheld", "partial"
 	JudgeNotes        string             `json:"judgeNotes" bson:"judgeNotes"` // judge's notes for this resolution
 	ChargeResolutions []ChargeResolution `json:"chargeResolutions,omitempty" bson:"chargeResolutions,omitempty"`
-	ResolvedAt        primitive.DateTime `json:"resolvedAt" bson:"resolvedAt"`
+	// Per-item sentencing totals after dispositions, recomputed server-side.
+	TotalFine            float64            `json:"totalFine" bson:"totalFine"`
+	TotalJailTimeSeconds int64              `json:"totalJailTimeSeconds" bson:"totalJailTimeSeconds"`
+	TotalJailTimeLabel   string             `json:"totalJailTimeLabel" bson:"totalJailTimeLabel"`
+	ResolvedAt           primitive.DateTime `json:"resolvedAt" bson:"resolvedAt"`
 }
 
-// ChargeResolution holds the verdict for a single fine within a citation /
-// warning. FineIndex references the position in CriminalHistory.Fines.
+// ChargeResolution holds a judge's disposition for a single charge on a
+// contested item. FineIndex is the charge's position in its source list
+// (CriminalHistory.Fines for citations/warnings, arrestReport.chargesList for
+// arrests). Name/category/original* are snapshots so the resolution is self-
+// contained for totals + audit. Verdict is kept for back-compat and derives
+// from Disposition (upheld|dismissed) for the source-record write-back.
 type ChargeResolution struct {
-	FineIndex int    `json:"fineIndex" bson:"fineIndex"`
-	Verdict   string `json:"verdict" bson:"verdict"` // "upheld" | "dismissed"
+	FineIndex        int     `json:"fineIndex" bson:"fineIndex"`
+	Verdict          string  `json:"verdict" bson:"verdict"`                                       // "upheld" | "dismissed" (derived; back-compat)
+	Disposition      string  `json:"disposition,omitempty" bson:"disposition,omitempty"`           // "upheld" | "dismissed" | "reduced" | "amended"
+	Name             string  `json:"name,omitempty" bson:"name,omitempty"`                         // charge name snapshot
+	Category         string  `json:"category,omitempty" bson:"category,omitempty"`                 // charge category snapshot
+	OriginalAmount   float64 `json:"originalAmount,omitempty" bson:"originalAmount,omitempty"`     // original fine
+	OriginalJailTime string  `json:"originalJailTime,omitempty" bson:"originalJailTime,omitempty"` // original jail (arrests only)
+	FinalAmount      float64 `json:"finalAmount,omitempty" bson:"finalAmount,omitempty"`           // judge's final fine (reduced/amended)
+	FinalJailTime    string  `json:"finalJailTime,omitempty" bson:"finalJailTime,omitempty"`       // judge's final jail (reduced/amended)
 }
+
+// Charge disposition values. Upheld/Dismissed match the legacy Verdict values;
+// Reduced/Amended carry judge-entered FinalAmount/FinalJailTime.
+const (
+	DispositionUpheld    = "upheld"
+	DispositionDismissed = "dismissed"
+	DispositionReduced   = "reduced"
+	DispositionAmended   = "amended"
+)
 
 // CourtCaseHistoryEntry records a single event in the court case lifecycle
 type CourtCaseHistoryEntry struct {


### PR DESCRIPTION
## What

Court-case backend for **judge sentencing**: auto-computed total fine + total jail time, with each charge markable **Upheld / Dismissed / Reduced / Amended** and totals updating from the final disposition.

- **Model** (`courtcase.go`): `ChargeResolution` gains `disposition`, name/category, and original + final amount/jail snapshots (legacy `verdict` kept, derived from disposition). Per-item totals on `CaseResolution`; case-wide `sentenceMode` + totals on `CourtCaseDetails`.
- **Calculator** (`court_totals.go`): `EffectiveCharge` applies the disposition (dismissed=0, reduced/amended=final, upheld/legacy=original); `ComputeResolutionTotals` + `ComputeCourtCaseTotals` **reuse the arrest `ComputeArrestTotals`** (consecutive/concurrent, Life).
- **Handler**: `ResolveCourtCaseHandler` recomputes per-item + case totals **server-side** and derives each charge's `verdict` from its `disposition` so the existing source-record write-back still works.
- **Tests** for the disposition→totals mapping.

## Design (owner-confirmed)
- **Judgment-only** — reduced/amended set the final values on the resolution; original citation/arrest amounts stay intact for audit.
- **Case-level** consecutive/concurrent toggle.
- All contested item types (citations = fine-only; arrests carry jail).

## Back-compat
Additive fields only. Existing binary `{fineIndex, verdict}` citation resolutions still read + write; legacy verdict path preserved in `EffectiveCharge`.

## Notes
Reuses the arrest `arrest_sentence.go` calculator (now in main via #155). Web + mobile judge UI build on this and ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)