### PR TITLE
fix(roles): enforce owner-only Head Admin role membership

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -1209,6 +1209,17 @@ func (c Community) UpdateRoleMembersHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// The Head Admin role is owner-only by design; its membership changes only
+	// via ownership transfer. Reject attempts to add members to it. The web and
+	// mobile clients already hide the add-member control for this role, so this
+	// is the server-side backstop (legacy communities predate the client lock).
+	for _, role := range community.Details.Roles {
+		if role.ID == rID && models.IsHeadAdminRole(role) {
+			config.ErrorStatus("cannot add members to the Head Admin role; change it via ownership transfer", http.StatusForbidden, w, nil)
+			return
+		}
+	}
+
 	filter := bson.M{"_id": cID, "community.roles._id": rID}
 	update := bson.M{
 		"$addToSet": bson.M{

--- a/scripts/remediate_multi_head_admin.js
+++ b/scripts/remediate_multi_head_admin.js
@@ -1,0 +1,101 @@
+// remediate_multi_head_admin.js
+//
+// One-off remediation: enforce the Head Admin invariant retroactively.
+//
+// The Head Admin role is meant to hold exactly one member: the community owner.
+// Before the "Head Admin is locked" change shipped, owners could freely add
+// members to it, so 141 legacy communities ended up with multiple people in
+// that role. The UI/mobile now lock the role, which froze that membership and
+// left those owners unable to prune it. This script resets every such role to
+// owner-only, matching what a freshly-created community looks like.
+//
+// Safety:
+//   - Before any write, the current member list of each affected role is
+//     snapshotted into the `head_admin_reset_backup` collection so the change
+//     is fully reversible.
+//   - Head Admin roles are identified by permission signature (enabled
+//     "administrator" perm whose description is "Head Admin"), NOT by name,
+//     mirroring models.IsHeadAdminRole in the API.
+//   - Roles are matched for update by their stable _id, not array index.
+//
+// Usage (from a shell with the prod connection string):
+//   DRY=true  mongosh "$DB_URI" scripts/remediate_multi_head_admin.js   # report only
+//   DRY=false mongosh "$DB_URI" scripts/remediate_multi_head_admin.js   # execute
+
+const DRY = (process.env.DRY !== "false"); // default to dry-run; must opt in to write
+const BACKUP = "head_admin_reset_backup";
+
+function isHeadAdminRole(role) {
+  const perms = role.permissions || [];
+  return perms.some(p => p.name === "administrator" && p.description === "Head Admin" && p.enabled === true);
+}
+
+const cursor = db.communities.find(
+  { "community.roles": { $exists: true } },
+  { "community.name": 1, "community.ownerID": 1, "community.roles": 1 }
+);
+
+const worklist = [];
+cursor.forEach(c => {
+  const roles = (c.community && c.community.roles) || [];
+  const owner = c.community && c.community.ownerID;
+  const ha = roles.find(isHeadAdminRole);
+  if (!ha) return;
+  const members = ha.members || [];
+  if (members.length <= 1) return;
+  if (!owner) return; // no owner to reset to — skip, should not happen
+  worklist.push({
+    communityId: c._id,
+    communityName: (c.community && c.community.name) || "(no name)",
+    roleId: ha._id,
+    roleName: ha.name,
+    ownerID: owner,
+    previousMembers: members,
+    ownerWasInRole: members.includes(owner),
+  });
+});
+
+print(`Mode: ${DRY ? "DRY RUN (no writes)" : "EXECUTE"}`);
+print(`Communities to remediate: ${worklist.length}`);
+let removed = 0;
+worklist.forEach(w => { removed += w.previousMembers.filter(m => m !== w.ownerID).length; });
+print(`Member-slots to remove: ${removed}`);
+print(`Communities where owner was NOT in the role (owner added, net): ${worklist.filter(w => !w.ownerWasInRole).length}`);
+
+if (DRY) {
+  print("\n-- sample of first 5 --");
+  worklist.slice(0, 5).forEach(w => print(JSON.stringify({
+    community: String(w.communityId), name: w.communityName, role: w.roleName,
+    before: w.previousMembers.length, ownerWasInRole: w.ownerWasInRole,
+  })));
+  print("\nDRY RUN complete. Re-run with DRY=false to apply.");
+  quit(0);
+}
+
+// EXECUTE: backup first, then reset each role to owner-only.
+const stamp = new Date();
+let backedUp = 0, updated = 0;
+worklist.forEach(w => {
+  db.getCollection(BACKUP).insertOne({
+    communityId: w.communityId,
+    communityName: w.communityName,
+    roleId: w.roleId,
+    roleName: w.roleName,
+    ownerID: w.ownerID,
+    previousMembers: w.previousMembers,
+    ownerWasInRole: w.ownerWasInRole,
+    resetAt: stamp,
+    reason: "remediate_multi_head_admin: enforce owner-only Head Admin role",
+  });
+  backedUp++;
+
+  const res = db.communities.updateOne(
+    { _id: w.communityId, "community.roles._id": w.roleId },
+    { $set: { "community.roles.$.members": [w.ownerID], "community.updatedAt": stamp } }
+  );
+  updated += res.modifiedCount;
+});
+
+print(`\nBacked up: ${backedUp} into "${BACKUP}"`);
+print(`Communities updated: ${updated}`);
+print("Done.");


### PR DESCRIPTION
## Background

The Head Admin role is meant to hold exactly one member (the community owner); its membership is designed to change only via ownership transfer. The website and mobile clients lock the role's add/remove controls, but that lock was **UI-only** — the API's `UpdateRoleMembersHandler` only gated on `manage roles`.

Before the client lock shipped, owners could freely add members to the role. That left **141 legacy communities** with multiple people in the Head Admin role. Once the lock landed, those owners could no longer prune the extras, and in one case an owner was left with no admin at all.

## Changes

**1. Server-side backstop** — `UpdateRoleMembersHandler` now rejects adding members to a role identified as Head Admin (by permission signature, via `models.IsHeadAdminRole`) with a 403. This makes the invariant enforced everywhere, not just in the UI.

**2. One-off remediation script** — `scripts/remediate_multi_head_admin.js` (already run against prod) resets every multi-member Head Admin role to owner-only. It snapshots each affected role's prior member list into the `head_admin_reset_backup` collection first, so the change is fully reversible.

## Remediation result (already applied to prod)

- 141 communities reset to owner-only Head Admin
- 229 member-slots removed (226 distinct users)
- 3 communities where the owner wasn't in the role: owner added, extras removed (this also fixed 1 fully locked-out owner)
- Post-run verification: **0** multi-member Head Admin roles remain; 141 backup docs saved

## Reversibility

Every prior member list is preserved in `head_admin_reset_backup` (keyed by `communityId` + `roleId`), so any community can be restored if a customer reports lost admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)