### PR TITLE
feat(most-wanted): audit-log create/update/delete/reorder

### DIFF
--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -680,7 +680,7 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/bolos", api.Middleware(http.HandlerFunc(bolo.FetchDepartmentBolosHandler))).Methods("GET")
 
 	// Most Wanted routes
-	mostWanted := MostWanted{DB: databases.NewMostWantedDatabase(a.dbHelper), CivDB: databases.NewCivilianDatabase(a.dbHelper)}
+	mostWanted := MostWanted{DB: databases.NewMostWantedDatabase(a.dbHelper), CivDB: databases.NewCivilianDatabase(a.dbHelper), ALDB: alDB, UDB: databases.NewUserDatabase(a.dbHelper)}
 	apiV2.Handle("/community/{communityId}/most-wanted", api.Middleware(http.HandlerFunc(mostWanted.FetchMostWantedHandler))).Methods("GET")
 	apiCreate.Handle("/most-wanted/reorder", api.Middleware(http.HandlerFunc(mostWanted.ReorderMostWantedHandler))).Methods("PUT")
 	apiCreate.Handle("/most-wanted/{entry_id}", api.Middleware(http.HandlerFunc(mostWanted.GetMostWantedByIDHandler))).Methods("GET")

--- a/api/handlers/mostwanted.go
+++ b/api/handlers/mostwanted.go
@@ -22,6 +22,8 @@ import (
 type MostWanted struct {
 	DB    databases.MostWantedDatabase
 	CivDB databases.CivilianDatabase
+	ALDB  databases.AuditLogDatabase
+	UDB   databases.UserDatabase
 }
 
 // FetchMostWantedHandler returns a paginated list of most wanted entries for a community
@@ -248,6 +250,19 @@ func (mw MostWanted) CreateMostWantedHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	actorID := req.AddedByUserID
+	if actorID == "" {
+		actorID = resolveActorFromRequest(r)
+	}
+	if cObjID, err := primitive.ObjectIDFromHex(req.CommunityID); err == nil {
+		name, _ := snapshot["name"].(string)
+		logAudit(mw.ALDB, cObjID, "most_wanted.created", "most_wanted", actorID, resolveActorName(mw.UDB, actorID), entry.ID.Hex(), name, map[string]interface{}{
+			"civilianID": req.CivilianID,
+			"stars":      stars,
+			"charges":    entry.Details.Charges,
+		})
+	}
+
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"message": "most wanted entry created successfully",
@@ -275,6 +290,10 @@ func (mw MostWanted) UpdateMostWantedHandler(w http.ResponseWriter, r *http.Requ
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	// Fetch the existing entry up front — used both to refresh the civilian
+	// snapshot and to give the audit log community/name/old-status context.
+	existing, existingErr := mw.DB.FindOne(ctx, bson.M{"_id": eID})
+
 	update := bson.M{}
 	for key, value := range updatedFields {
 		update["mostWanted."+key] = value
@@ -290,16 +309,13 @@ func (mw MostWanted) UpdateMostWantedHandler(w http.ResponseWriter, r *http.Requ
 				update["mostWanted.civilianSnapshot"] = buildCivilianSnapshot(civ)
 			}
 		}
-	} else {
+	} else if existingErr == nil && existing.Details.CivilianID != "" {
 		// Refresh snapshot from existing civilianID on the entry
-		existing, err := mw.DB.FindOne(ctx, bson.M{"_id": eID})
-		if err == nil && existing.Details.CivilianID != "" {
-			civID, err := primitive.ObjectIDFromHex(existing.Details.CivilianID)
+		civID, err := primitive.ObjectIDFromHex(existing.Details.CivilianID)
+		if err == nil {
+			civ, err := mw.CivDB.FindOne(ctx, bson.M{"_id": civID})
 			if err == nil {
-				civ, err := mw.CivDB.FindOne(ctx, bson.M{"_id": civID})
-				if err == nil {
-					update["mostWanted.civilianSnapshot"] = buildCivilianSnapshot(civ)
-				}
+				update["mostWanted.civilianSnapshot"] = buildCivilianSnapshot(civ)
 			}
 		}
 	}
@@ -309,6 +325,26 @@ func (mw MostWanted) UpdateMostWantedHandler(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		config.ErrorStatus("failed to update most wanted entry", http.StatusInternalServerError, w, err)
 		return
+	}
+
+	if existingErr == nil {
+		if cObjID, cerr := primitive.ObjectIDFromHex(existing.Details.CommunityID); cerr == nil {
+			actorID := resolveActorFromRequest(r)
+			changed := make([]string, 0, len(updatedFields))
+			for k := range updatedFields {
+				changed = append(changed, k)
+			}
+			action := "most_wanted.updated"
+			details := map[string]interface{}{"changedFields": changed}
+			// A status change (e.g. active -> captured/removed) is a distinct,
+			// audit-worthy event, so give it its own action string.
+			if newStatus, ok := updatedFields["status"].(string); ok && newStatus != existing.Details.Status {
+				action = "most_wanted.status_changed"
+				details["fromStatus"] = existing.Details.Status
+				details["toStatus"] = newStatus
+			}
+			logAudit(mw.ALDB, cObjID, action, "most_wanted", actorID, resolveActorName(mw.UDB, actorID), entryID, snapshotName(existing), details)
+		}
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -328,11 +364,23 @@ func (mw MostWanted) DeleteMostWantedHandler(w http.ResponseWriter, r *http.Requ
 	ctx, cancel := api.WithQueryTimeout(r.Context())
 	defer cancel()
 
+	// Fetch the entry before deleting so the audit log has community/name context.
+	existing, existingErr := mw.DB.FindOne(ctx, bson.M{"_id": eID})
+
 	filter := bson.M{"_id": eID}
 	err = mw.DB.DeleteOne(ctx, filter)
 	if err != nil {
 		config.ErrorStatus("failed to delete most wanted entry", http.StatusInternalServerError, w, err)
 		return
+	}
+
+	if existingErr == nil {
+		if cObjID, cerr := primitive.ObjectIDFromHex(existing.Details.CommunityID); cerr == nil {
+			actorID := resolveActorFromRequest(r)
+			logAudit(mw.ALDB, cObjID, "most_wanted.deleted", "most_wanted", actorID, resolveActorName(mw.UDB, actorID), entryID, snapshotName(existing), map[string]interface{}{
+				"civilianID": existing.Details.CivilianID,
+			})
+		}
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -381,8 +429,27 @@ func (mw MostWanted) ReorderMostWantedHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
+	if cObjID, err := primitive.ObjectIDFromHex(req.CommunityID); err == nil {
+		actorID := resolveActorFromRequest(r)
+		logAudit(mw.ALDB, cObjID, "most_wanted.reordered", "most_wanted", actorID, resolveActorName(mw.UDB, actorID), "", "", map[string]interface{}{
+			"count": len(req.Order),
+		})
+	}
+
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{"message": "most wanted list reordered successfully"})
+}
+
+// snapshotName returns the civilian's display name from a most wanted entry's
+// denormalized snapshot, or "" when unavailable. Used as the audit log target name.
+func snapshotName(entry *models.MostWantedEntry) string {
+	if entry == nil || entry.Details.CivilianSnapshot == nil {
+		return ""
+	}
+	if n, ok := entry.Details.CivilianSnapshot["name"].(string); ok {
+		return n
+	}
+	return ""
 }
 
 // buildCivilianSnapshot creates a map of civilian fields for denormalized storage


### PR DESCRIPTION
## Problem

Most Wanted list mutations (add / edit / delete, plus reorder) were not being written to the community audit log, unlike roles, events, members, settings, etc. There was no record of who added, edited, or removed a most-wanted entry.

## Changes

Wire `logAudit` into every write path in the `MostWanted` handlers, following the existing convention (`<category>.<verb>`, community ObjectID, actor ID + resolved name, target ID + name, details map):

| Action | When | Target name | Details |
|---|---|---|---|
| `most_wanted.created` | add entry | civilian name | civilianID, stars, charges |
| `most_wanted.updated` | edit entry | civilian name | changedFields |
| `most_wanted.status_changed` | edit that flips status (e.g. active → captured) | civilian name | fromStatus, toStatus |
| `most_wanted.deleted` | remove entry | civilian name | civilianID |
| `most_wanted.reordered` | reorder list | — | count |

- Adds `ALDB` + `UDB` fields to the `MostWanted` struct and wires them in `api.go` (the `alDB` handle already existed).
- `UpdateMostWantedHandler` and `DeleteMostWantedHandler` now fetch the existing entry up front so the log has the community ID, the civilian's display name, and (for edits) the prior status. The update handler reuses that fetch for the snapshot refresh it already did.
- All logging is best-effort — `logAudit` runs in a detached goroutine and can never block or fail the request.

## Actor resolution (cross-repo)

`create` records the actor from the request body's `addedByUserID`. `update`/`delete`/`reorder` carry the shared **static API token**, not a per-user bearer token, so the actor comes from the `?userId=` query param via `resolveActorFromRequest`. The web and mobile clients are updated in companion PRs to send it:
- police-cad: most-wanted.ejs PUT/DELETE/reorder now append `?userId=`
- police-cad-app: mostwanted service + screens pass `userId` through

Without those, these three actions still log correctly but with a blank actor.

## Verification

- `go build ./...` clean; `go vet` shows no new warnings in mostwanted.go (pre-existing unkeyed-struct warnings elsewhere are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)