### PR TITLE
docs(triage): capture two unfiled DNYGUNZ asks + generator support

### DIFF
--- a/docs/feature-triage.md
+++ b/docs/feature-triage.md
@@ -1,6 +1,6 @@
 # Feature Request Triage — Living Doc
 
-_Auto-generated 2026-07-08 01:22 UTC from live feature-request data. Do not hand-edit — update `triage.json` and re-run `generate.py` (see [README](../scripts/feature-triage/README.md))._
+_Auto-generated 2026-07-12 04:03 UTC from live feature-request data. Do not hand-edit — update `triage.json` and re-run `generate.py` (see [README](../scripts/feature-triage/README.md))._
 
 **45** active requests · **216** total upvotes · **36** shipped. Statuses sync from the DB: an item marked released/beta on the site moves here automatically.
 
@@ -102,6 +102,15 @@ _Out of scope, infeasible, or cost far outweighs value._
 |   | [Login system](https://www.linespolice-cad.com/feature-requests/69f7d4433f57679bdb425d9c) | 1 | 2 | M | — | Sergant W. O'CONNOR | A per-department username/password login screen. Staff explained the existing 10-code online/offline (Signal 41/42) already handles department presence in real time. The clarified ask (a password gate per department) adds friction and a parallel auth model with little added value. _Risks/deps: Duplicates existing auth/presence; UX friction._ |
 |   | [Road names on map](https://www.linespolice-cad.com/feature-requests/6a182462c10fe9084bebc99a) | 4 | 0 | L | — | Grim | Road names on the map. Maps are static community-uploaded images (no vector/tile layer), so real road labeling would need either a vector-map refactor or manual per-map overlays. Simplest path is a community workaround: upload a map image that already includes street names. Low effort-to-value as a platform feature. _Risks/deps: Static-image map architecture; per-game-map street data unavailable._ |
 |   | [being able to have a radio to talk to other on that Department and to switch radio fincracy](https://www.linespolice-cad.com/feature-requests/6a4085ea449dcf2c86523949) | 2 | 0 | XL | — | Deadpool12 | In-app voice radio with channels 1–100 and a panic button. Same voice-infra reasoning staff used to decline the other radio requests. The panic sub-feature already exists via the panic button. _Risks/deps: Voice infra cost/reliability._ _Possible dup: Radio; Chat Radios_ |
+
+## 📥 Unfiled Asks (not yet feature requests)
+
+_Captured from Discord/DMs before a formal request exists — file them on the site to add upvotes, then move the entry into `triage`._
+
+| Ask | Source | Effort | Scope | Notes |
+|---|---|:--:|---|---|
+| Charge quantity / multiple counts (with drug unit weights) | DNYGUNZ (Discord); refines an earlier customer ask | M | ⚙️ 🌐 📱 api/website/mobile | When creating a penal code/violation, prompt whether it has a quantity and what unit: a plain COUNT (scam cards, 'two counts of murder') or a WEIGHT unit (oz/lb/kilo for drugs). When charging, the officer enters the quantity and the CAD multiplies fine and jail time per unit (penalty defined per-unit). Add the count to the report. Data path already exists (ArrestCharge + server-side ComputeArrestTotals); net-new is quantity+unit on the applied charge plus hasQuantity/unit on the penal-code definition. _Risks/deps: Multiply in ComputeArrestTotals (server = source of truth); quantity optional + backward-compatible; a 'Life' sentence stays Life regardless of count._ _Related: Extends the shipped Sentencing Calculator / Arrest Fine and Time Calculation_ |
+| Increase report narrative character limit (500 -> 1000) | DNYGUNZ (Discord) | S | ⚙️ 🌐 📱 api/website/mobile | The report narrative caps at 500 chars and most reports exceed it. Double to ~1000. Scope to the arrest/police report narrative field specifically (maxlength=500 is reused on ~15 textareas across calls/BOLOs/notes/911 - do NOT blanket-raise) and check for a server-side cap. _Risks/deps: Confirm the exact narrative field(s) and verify no server-side validation truncates at 500._ |
 
 ## ✅ Recently Shipped
 

--- a/scripts/feature-triage/generate.py
+++ b/scripts/feature-triage/generate.py
@@ -80,7 +80,12 @@ def pr_links(prs):
 
 def main():
     snap = json.loads(DATA_FILE.read_text())
-    triage = json.loads(TRIAGE_FILE.read_text()).get("triage", {})
+    triage_doc = json.loads(TRIAGE_FILE.read_text())
+    triage = triage_doc.get("triage", {})
+    # Unfiled asks: ideas captured (e.g. from Discord) that don't have a formal
+    # feature request yet, so they can't be keyed by id in `triage`. Held here
+    # until they're filed on the site (then move them into `triage`).
+    unfiled = triage_doc.get("unfiled", [])
     active = snap.get("requests", [])
     shipped = snap.get("shipped", [])
 
@@ -225,6 +230,27 @@ def main():
             author = esc((fr.get("author") or {}).get("username", "unknown"))
             w(f"| {fr_link(fr)} | {fr.get('upvoteCount',0)} | "
               f"{fr.get('commentCount',0)} | {author} |")
+        w("")
+
+    # ---- Unfiled asks -----------------------------------------------------
+    if unfiled:
+        w("## 📥 Unfiled Asks (not yet feature requests)")
+        w("")
+        w("_Captured from Discord/DMs before a formal request exists — file them "
+          "on the site to add upvotes, then move the entry into `triage`._")
+        w("")
+        w("| Ask | Source | Effort | Scope | Notes |")
+        w("|---|---|:--:|---|---|")
+        for u in unfiled:
+            notes = esc(u.get("rationale", ""))
+            risks = esc(u.get("risks_or_deps", ""))
+            rel = esc(u.get("possible_relation", ""))
+            if risks:
+                notes += f" _Risks/deps: {risks}_"
+            if rel:
+                notes += f" _Related: {rel}_"
+            w(f"| {esc(u.get('title','(untitled)'))} | {esc(u.get('source',''))} | "
+              f"{u.get('effort','?')} | {scope_str(u.get('scope'))} | {notes} |")
         w("")
 
     # ---- Shipped ----------------------------------------------------------

--- a/scripts/feature-triage/triage.json
+++ b/scripts/feature-triage/triage.json
@@ -478,5 +478,25 @@
       "risks_or_deps": "Currently in beta_testing — in flight.",
       "possible_duplicate": "Restrict who can suspend or revoke licenses"
     }
-  }
+  },
+  "unfiled": [
+    {
+      "title": "Charge quantity / multiple counts (with drug unit weights)",
+      "source": "DNYGUNZ (Discord); refines an earlier customer ask",
+      "scope": ["api", "website", "mobile"],
+      "effort": "M",
+      "rationale": "When creating a penal code/violation, prompt whether it has a quantity and what unit: a plain COUNT (scam cards, 'two counts of murder') or a WEIGHT unit (oz/lb/kilo for drugs). When charging, the officer enters the quantity and the CAD multiplies fine and jail time per unit (penalty defined per-unit). Add the count to the report. Data path already exists (ArrestCharge + server-side ComputeArrestTotals); net-new is quantity+unit on the applied charge plus hasQuantity/unit on the penal-code definition.",
+      "risks_or_deps": "Multiply in ComputeArrestTotals (server = source of truth); quantity optional + backward-compatible; a 'Life' sentence stays Life regardless of count.",
+      "possible_relation": "Extends the shipped Sentencing Calculator / Arrest Fine and Time Calculation"
+    },
+    {
+      "title": "Increase report narrative character limit (500 -> 1000)",
+      "source": "DNYGUNZ (Discord)",
+      "scope": ["api", "website", "mobile"],
+      "effort": "S",
+      "rationale": "The report narrative caps at 500 chars and most reports exceed it. Double to ~1000. Scope to the arrest/police report narrative field specifically (maxlength=500 is reused on ~15 textareas across calls/BOLOs/notes/911 - do NOT blanket-raise) and check for a server-side cap.",
+      "risks_or_deps": "Confirm the exact narrative field(s) and verify no server-side validation truncates at 500.",
+      "possible_relation": ""
+    }
+  ]
 }


### PR DESCRIPTION
Captures two asks that came in via Discord (DNYGUNZ) before they exist as formal feature requests, so they're tracked for later scoping.

## New capability
The triage system was keyed entirely by live feature-request id, so there was nowhere to record asks that aren't filed on the site yet. This adds an **`unfiled`** array to `triage.json` and a **📥 Unfiled Asks** section in `generate.py`. Once an ask is filed on the site, move its entry into `triage` (keyed by the new request id).

## Captured
- **Charge quantity / multiple counts (with drug unit weights)** — prompt for quantity + unit (count, or oz/lb/kilo) when creating a penal code; multiply fine + jail time per unit at charge time. Extends the shipped sentencing calculator.
- **Increase report narrative character limit (500 → 1000)** — scoped to the report narrative field specifically (the 500 cap is reused on ~15 textareas — not a blanket raise); check for a server-side cap too.

## Notes
- The doc's **live counts still show the last snapshot** (local `generate.py` uses the cached data file; only the weekly `feature-triage` workflow re-fetches via `fetch.py`). The next workflow run (or a manual `workflow_dispatch`) will refresh the live data and re-render with these unfiled entries intact.
- Diff is minimal: `triage.json` +21/−1, `generate.py` +28, doc +10/−1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)