### PR TITLE
fix(security): block banned users from panic/signal-100/tone broadcasts (+ anti-forgery)

### DIFF
--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -2318,6 +2318,25 @@ func userBannedFromCommunity(community *models.Community, userID string) bool {
 	return contains(community.Details.BanList, userID)
 }
 
+// rejectIfBanned writes a 403 and returns true if the acting user is banned from
+// the community. It checks BOTH the actor id supplied in the request body AND the
+// authenticated (bearer-token) user id from the request context. The authenticated
+// id is token-verified and cannot be forged, so checking it stops a banned user
+// from bypassing the ban by putting someone else's id in the request body. (When
+// no bearer token is present — e.g. the website's static API token — only the
+// body id is available; closing that residual gap is the broader auth-hardening
+// effort tracked separately.) Uses InfoStatus so a banned client retrying in a
+// loop doesn't flood the error logs with stacktraces.
+func rejectIfBanned(w http.ResponseWriter, r *http.Request, community *models.Community, bodyUserID, action string) bool {
+	authID := api.GetAuthenticatedUserIDFromContext(r.Context())
+	if userBannedFromCommunity(community, bodyUserID) ||
+		(authID != "" && userBannedFromCommunity(community, authID)) {
+		config.InfoStatus("banned user blocked from "+action, http.StatusForbidden, w, nil)
+		return true
+	}
+	return false
+}
+
 // sortDepartmentsByUserPreferences sorts departments based on user's custom order preference
 func (c Community) sortDepartmentsByUserPreferences(ctx context.Context, departments []models.Department, userID, communityID string) []models.Department {
 	// If no userID provided, return departments as-is
@@ -7152,8 +7171,7 @@ func (c Community) CreatePanicAlertHandler(w http.ResponseWriter, r *http.Reques
 		config.ErrorStatus("community not found", http.StatusNotFound, w, cErr)
 		return
 	}
-	if userBannedFromCommunity(comm, request.UserID) {
-		config.InfoStatus("banned user blocked from triggering a panic alert", http.StatusForbidden, w, nil)
+	if rejectIfBanned(w, r, comm, request.UserID, "triggering a panic alert") {
 		return
 	}
 
@@ -8354,8 +8372,7 @@ func (c Community) ActivateSignal100Handler(w http.ResponseWriter, r *http.Reque
 		config.ErrorStatus("community not found", http.StatusNotFound, w, fetchErr)
 		return
 	}
-	if userBannedFromCommunity(existing, request.UserID) {
-		config.InfoStatus("banned user blocked from activating signal 100", http.StatusForbidden, w, nil)
+	if rejectIfBanned(w, r, existing, request.UserID, "activating signal 100") {
 		return
 	}
 

--- a/api/handlers/community.go
+++ b/api/handlers/community.go
@@ -2306,6 +2306,18 @@ func contains(slice []string, item string) bool {
 	return false
 }
 
+// userBannedFromCommunity reports whether the given user is on the community's
+// ban list. The community-wide broadcast handlers (panic, signal-100, tones)
+// must consult this so a ban actually stops a user from triggering alerts —
+// otherwise a banned user's client keeps the community context and can keep
+// spamming these endpoints (the ban list was previously never checked here).
+func userBannedFromCommunity(community *models.Community, userID string) bool {
+	if community == nil || userID == "" {
+		return false
+	}
+	return contains(community.Details.BanList, userID)
+}
+
 // sortDepartmentsByUserPreferences sorts departments based on user's custom order preference
 func (c Community) sortDepartmentsByUserPreferences(ctx context.Context, departments []models.Department, userID, communityID string) []models.Department {
 	// If no userID provided, return departments as-is
@@ -7132,6 +7144,19 @@ func (c Community) CreatePanicAlertHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Reject banned users. Load the community once (also reused for the panic
+	// sound URL below) and block if the acting user is on the ban list — a
+	// banned user's client can otherwise keep spamming panic alerts.
+	comm, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID})
+	if cErr != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, cErr)
+		return
+	}
+	if userBannedFromCommunity(comm, request.UserID) {
+		config.InfoStatus("banned user blocked from triggering a panic alert", http.StatusForbidden, w, nil)
+		return
+	}
+
 	// Generate unique alert ID
 	alertID := primitive.NewObjectID().Hex()
 
@@ -7171,15 +7196,13 @@ func (c Community) CreatePanicAlertHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Resolve custom panic sound URL (if community has one configured)
+	// Resolve custom panic sound URL (community already loaded above)
 	var panicSoundUrl string
-	if comm, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID}); cErr == nil {
-		if key := comm.Details.DefaultPanicSound; key != "" {
-			for _, s := range comm.Details.CustomToneSounds {
-				if s.Key == key {
-					panicSoundUrl = s.URL
-					break
-				}
+	if key := comm.Details.DefaultPanicSound; key != "" {
+		for _, s := range comm.Details.CustomToneSounds {
+			if s.Key == key {
+				panicSoundUrl = s.URL
+				break
 			}
 		}
 	}
@@ -8323,13 +8346,23 @@ func (c Community) ActivateSignal100Handler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Load the community up front so we can (a) reject banned users and (b)
+	// dedupe. Without the ban check a banned user's client can keep activating
+	// Signal 100.
+	existing, fetchErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID})
+	if fetchErr != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, fetchErr)
+		return
+	}
+	if userBannedFromCommunity(existing, request.UserID) {
+		config.InfoStatus("banned user blocked from activating signal 100", http.StatusForbidden, w, nil)
+		return
+	}
+
 	// Check if signal 100 is already active to avoid duplicate push notifications.
 	// The website POSTs to this endpoint AND emits a socket event that also calls
 	// this endpoint, so we need to guard against sending notifications twice.
-	wasAlreadyActive := false
-	if existing, fetchErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID}); fetchErr == nil {
-		wasAlreadyActive = existing.Details.Signal100.Active || existing.Details.ActiveSignal100
-	}
+	wasAlreadyActive := existing.Details.Signal100.Active || existing.Details.ActiveSignal100
 
 	now := time.Now().UTC().Format(time.RFC3339)
 

--- a/api/handlers/panic_alerts_test.go
+++ b/api/handlers/panic_alerts_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/linesmerrill/police-cad-api/api"
 	"github.com/linesmerrill/police-cad-api/databases/mocks"
 	"github.com/linesmerrill/police-cad-api/models"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,7 @@ func TestCreatePanicAlertHandler(t *testing.T) {
 		name           string
 		communityID    string
 		requestBody    map[string]interface{}
+		authUserID     string // token-verified actor injected into context (optional)
 		expectedStatus int
 		expectedError  string
 		mockSetup      func(*mocks.CommunityDatabase)
@@ -98,6 +100,24 @@ func TestCreatePanicAlertHandler(t *testing.T) {
 				}, nil)
 			},
 		},
+		{
+			name:        "banned user cannot bypass with a forged body userId",
+			communityID: "507f1f77bcf86cd799439011",
+			requestBody: map[string]interface{}{
+				"userId":         "someoneelse", // forged — not on the ban list
+				"username":       "6A-404",
+				"callSign":       "6A-404",
+				"departmentType": "police",
+			},
+			authUserID:     "banneduser", // token-verified real identity, banned
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "banned",
+			mockSetup: func(mockDB *mocks.CommunityDatabase) {
+				mockDB.On("FindOne", mock.Anything, mock.Anything).Return(&models.Community{
+					Details: models.CommunityDetails{BanList: []string{"banneduser"}},
+				}, nil)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -121,6 +141,11 @@ func TestCreatePanicAlertHandler(t *testing.T) {
 
 			// Set up mux vars
 			req = mux.SetURLVars(req, map[string]string{"communityId": tt.communityID})
+
+			// Seed the token-verified actor the middleware would normally set.
+			if tt.authUserID != "" {
+				req = req.WithContext(api.WithAuthenticatedUserID(req.Context(), tt.authUserID))
+			}
 
 			// Call handler
 			handler.CreatePanicAlertHandler(w, req)

--- a/api/handlers/panic_alerts_test.go
+++ b/api/handlers/panic_alerts_test.go
@@ -73,7 +73,29 @@ func TestCreatePanicAlertHandler(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 			expectedError:  "failed to create panic alert",
 			mockSetup: func(mockDB *mocks.CommunityDatabase) {
+				// Ban-check load happens first; return a clean community so the
+				// user isn't banned, then fail the write.
+				mockDB.On("FindOne", mock.Anything, mock.Anything).Return(&models.Community{}, nil)
 				mockDB.On("UpdateOne", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("database error"))
+			},
+		},
+		{
+			name:        "banned user is blocked",
+			communityID: "507f1f77bcf86cd799439011",
+			requestBody: map[string]interface{}{
+				"userId":         "banneduser",
+				"username":       "6A-404",
+				"callSign":       "6A-404",
+				"departmentType": "police",
+			},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "banned",
+			mockSetup: func(mockDB *mocks.CommunityDatabase) {
+				// User is on the community ban list → panic must be rejected and
+				// no write should occur (no UpdateOne mock set).
+				mockDB.On("FindOne", mock.Anything, mock.Anything).Return(&models.Community{
+					Details: models.CommunityDetails{BanList: []string{"banneduser"}},
+				}, nil)
 			},
 		},
 	}

--- a/api/handlers/tone_board.go
+++ b/api/handlers/tone_board.go
@@ -49,6 +49,18 @@ func (c Community) SendToneHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject banned users so a ban stops them from broadcasting tones. Load the
+	// community once and reuse it for the sound-URL lookup below.
+	community, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID})
+	if cErr != nil {
+		config.ErrorStatus("community not found", http.StatusNotFound, w, cErr)
+		return
+	}
+	if userBannedFromCommunity(community, request.TriggeredByID) {
+		config.InfoStatus("banned user blocked from sending a tone", http.StatusForbidden, w, nil)
+		return
+	}
+
 	now := primitive.NewDateTimeFromTime(time.Now())
 
 	toneLog := models.ToneLog{
@@ -71,10 +83,9 @@ func (c Community) SendToneHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Resolve tone sound URL for custom tones
+	// Resolve tone sound URL for custom tones (community loaded above)
 	var toneSoundUrl string
-	community, cErr := c.DB.FindOne(context.Background(), bson.M{"_id": cID})
-	if cErr == nil {
+	{
 		// Build custom sound lookup
 		for _, s := range community.Details.CustomToneSounds {
 			if s.Key == request.ToneType {

--- a/api/handlers/tone_board.go
+++ b/api/handlers/tone_board.go
@@ -56,8 +56,7 @@ func (c Community) SendToneHandler(w http.ResponseWriter, r *http.Request) {
 		config.ErrorStatus("community not found", http.StatusNotFound, w, cErr)
 		return
 	}
-	if userBannedFromCommunity(community, request.TriggeredByID) {
-		config.InfoStatus("banned user blocked from sending a tone", http.StatusForbidden, w, nil)
+	if rejectIfBanned(w, r, community, request.TriggeredByID, "sending a tone") {
 		return
 	}
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -58,6 +58,13 @@ func withAuthenticatedUserID(ctx context.Context, userID string) context.Context
 	return context.WithValue(ctx, authenticatedUserIDContextKey{}, userID)
 }
 
+// WithAuthenticatedUserID returns a context carrying the authenticated user ID.
+// Exported so callers/tests can seed the token-verified actor the middleware
+// would normally set from a Bearer token.
+func WithAuthenticatedUserID(ctx context.Context, userID string) context.Context {
+	return withAuthenticatedUserID(ctx, userID)
+}
+
 // Middleware adds some basic header authentication around accessing the routes
 func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Report
A community owner banned a user (username `6A-404`) for spamming the **Panic** button and **Signal 100**, but after the ban they could **still trigger both** (67 panic notifications in a row). Affects website + mobile (same API).

## Root cause
The community-wide broadcast handlers trust the `userId` in the request body and broadcast unconditionally. The **ban list (`community.banList`) was never consulted** on these write paths — so a ban was inert for alerts (only enforced on re-join / display). The tone board had the same hole.

## Fix
Added `userBannedFromCommunity` + a `rejectIfBanned` helper and gated all three broadcast handlers on it:

| Handler | Change |
|---|---|
| `CreatePanicAlertHandler` | Load community up front (reused for the panic sound URL) → **403** if banned |
| `ActivateSignal100Handler` | Reuse the existing community load (now required) → **403** if banned |
| `SendToneHandler` | Load once (reused for the tone sound URL) → **403** if the triggering user is banned |

`rejectIfBanned` checks **both** identities:
1. **Body `userId`** — stops the reported real-world abuse (an honest client sending its own id).
2. **Token-verified actor** from the request context (`GetAuthenticatedUserIDFromContext`) — this is set by the middleware from a validated `Bearer` token and **cannot be forged**, so a banned user can't dodge the ban by putting someone else's id in the body.

Uses `config.InfoStatus` for the 403 so a banned client retrying in a loop **doesn't flood the error logs** with stacktraces.

## Residual gap (documented, not a regression)
Requests with **no Bearer token** — e.g. the website's static API token — still only have the forgeable body id to check. The **mobile app sends real Bearer tokens and is fully covered**; closing the website side is the broader auth-hardening effort (the website doesn't authenticate the individual user on these calls). Ban-list values and ids are all user `_id` hex, compared like-for-like.

## Verification
- `TestCreatePanicAlertHandler` gains two cases:
  - **`banned user is blocked`** → 403, no broadcast write.
  - **`banned user cannot bypass with a forged body userId`** → forged body id + token-verified banned id → 403.
- Exported `api.WithAuthenticatedUserID` so tests can seed the token-verified actor.
- `go build ./...`, `go vet ./api/...`, and the full `api/handlers` test package all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)