### PR TITLE
feat(auth): unauthenticated forgot-password code flow

### DIFF
--- a/api/handlers/accountchange.go
+++ b/api/handlers/accountchange.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/linesmerrill/police-cad-api/api"
@@ -349,6 +350,171 @@ func (pv PendingVerification) ConfirmPasswordChangeHandler(w http.ResponseWriter
 			HTML:      templates.RenderPasswordChangedNotice(),
 		})
 	}
+
+	writeJSONOK(w, "Password updated successfully")
+}
+
+// ForgotPasswordRequestCodeHandler starts an UNAUTHENTICATED password reset. Given an email, if a
+// matching account exists it mails a 6-digit code (purpose=password_reset). It always returns 200
+// with a generic message — whether or not the account exists, and even when rate-limited — so the
+// endpoint can't be used to discover which emails are registered.
+func (pv PendingVerification) ForgotPasswordRequestCodeHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	email := strings.TrimSpace(strings.ToLower(body.Email))
+	if email == "" || !strings.Contains(email, "@") {
+		writeJSONError(w, http.StatusBadRequest, "A valid email is required")
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	// Generic success — returned in every non-error branch below so callers can't tell a
+	// registered email from an unregistered one.
+	genericOK := func() {
+		writeJSONOK(w, "If an account exists for that email, a reset code has been sent.")
+	}
+
+	user := models.User{}
+	if err := pv.UDB.FindOne(ctx, bson.M{"user.email": email}).Decode(&user); err != nil {
+		// No account — respond OK without sending, so the endpoint can't confirm registration.
+		if err != mongo.ErrNoDocuments {
+			zap.S().Warnf("forgot-password user lookup failed for %s: %v", email, err)
+		}
+		genericOK()
+		return
+	}
+
+	uID, err := primitive.ObjectIDFromHex(user.ID)
+	if err != nil {
+		// Legacy non-ObjectID _id we can't drive through the sensitive-code flow — respond OK
+		// without sending. (Those rare users still have the website token reset.)
+		genericOK()
+		return
+	}
+
+	// Silently skip the send when rate-limited so the generic response is preserved.
+	if err := checkSensitiveCodeRateLimit(ctx, pv.PVDB, uID, models.PurposePasswordReset); err != nil {
+		genericOK()
+		return
+	}
+
+	code, err := generateNumericCode()
+	if err != nil {
+		config.ErrorStatus("failed to generate reset code", http.StatusInternalServerError, w, err)
+		return
+	}
+	if err := upsertSensitiveCode(ctx, pv.PVDB, uID, models.PurposePasswordReset, email, "", code); err != nil {
+		config.ErrorStatus("failed to store reset code", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	sendSensitiveEmailAsync(sensitiveEmail{
+		To:        email,
+		Subject:   "Lines Police CAD: Password Reset Code",
+		PlainText: "Your password reset code is: " + code + ". This code expires in 15 minutes. If you did not request this, you can safely ignore this email.",
+		HTML:      templates.RenderPasswordChangeCode(code),
+	})
+
+	genericOK()
+}
+
+// ForgotPasswordResetHandler completes an UNAUTHENTICATED reset. Given email + 6-digit code +
+// newPassword, it verifies the code (purpose=password_reset) and sets the new password. Errors are
+// generic ("invalid or expired code") so they don't reveal whether the account exists.
+func (pv PendingVerification) ForgotPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Email       string `json:"email"`
+		Code        string `json:"code"`
+		NewPassword string `json:"newPassword"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	email := strings.TrimSpace(strings.ToLower(body.Email))
+	if email == "" || strings.TrimSpace(body.Code) == "" {
+		writeJSONError(w, http.StatusBadRequest, "Email and verification code are required")
+		return
+	}
+	if len(body.NewPassword) < minPasswordLength {
+		writeJSONError(w, http.StatusBadRequest, "New password must be at least 6 characters")
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	user := models.User{}
+	if err := pv.UDB.FindOne(ctx, bson.M{"user.email": email}).Decode(&user); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+		return
+	}
+
+	uID, err := primitive.ObjectIDFromHex(user.ID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+		return
+	}
+
+	pending, err := pv.PVDB.FindOne(ctx, bson.M{"userID": uID, "purpose": models.PurposePasswordReset})
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+			return
+		}
+		config.ErrorStatus("failed to find pending reset", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	if expired := timeFromBSON(pending.ExpiresAt); !expired.IsZero() && time.Now().After(expired) {
+		_ = pv.PVDB.DeleteOne(ctx, bson.M{"_id": pending.ID})
+		writeJSONError(w, http.StatusBadRequest, "Verification code expired. Request a new one.")
+		return
+	}
+
+	if pending.Attempts >= sensitiveMaxRetries {
+		_ = pv.PVDB.DeleteOne(ctx, bson.M{"_id": pending.ID})
+		writeJSONError(w, http.StatusBadRequest, "Too many attempts. Request a new code.")
+		return
+	}
+
+	if !codesEqualConstantTime(pending.Code, body.Code) {
+		_ = pv.PVDB.UpdateOne(ctx, bson.M{"_id": pending.ID}, bson.M{"$inc": bson.M{"attempts": 1}})
+		writeJSONError(w, http.StatusBadRequest, "Invalid verification code")
+		return
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(body.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		config.ErrorStatus("failed to hash new password", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	if _, err := pv.UDB.UpdateOne(ctx, bson.M{"_id": uID}, bson.M{
+		"$set": bson.M{
+			"user.password":  string(hashed),
+			"user.updatedAt": primitive.NewDateTimeFromTime(time.Now()),
+		},
+	}); err != nil {
+		config.ErrorStatus("failed to update password", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	_ = pv.PVDB.DeleteOne(ctx, bson.M{"_id": pending.ID})
+
+	sendSensitiveEmailAsync(sensitiveEmail{
+		To:        email,
+		Subject:   "Lines Police CAD: Your Password Was Changed",
+		PlainText: "The password on your Lines Police CAD account was just reset. If this wasn't you, contact support immediately at https://www.linespolice-cad.com/contact-us.",
+		HTML:      templates.RenderPasswordChangedNotice(),
+	})
 
 	writeJSONOK(w, "Password updated successfully")
 }

--- a/api/handlers/accountchange.go
+++ b/api/handlers/accountchange.go
@@ -519,6 +519,72 @@ func (pv PendingVerification) ForgotPasswordResetHandler(w http.ResponseWriter, 
 	writeJSONOK(w, "Password updated successfully")
 }
 
+// ForgotPasswordVerifyCodeHandler checks a reset code WITHOUT consuming it, so the app can advance
+// to the new-password step only once the code is known-good. The code is finally consumed by
+// ForgotPasswordResetHandler. A wrong code still increments attempts (brute force stays bounded).
+// Errors are generic so they don't reveal whether an account exists.
+func (pv PendingVerification) ForgotPasswordVerifyCodeHandler(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Email string `json:"email"`
+		Code  string `json:"code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		config.ErrorStatus("failed to decode request body", http.StatusBadRequest, w, err)
+		return
+	}
+	email := strings.TrimSpace(strings.ToLower(body.Email))
+	if email == "" || strings.TrimSpace(body.Code) == "" {
+		writeJSONError(w, http.StatusBadRequest, "Email and verification code are required")
+		return
+	}
+
+	ctx, cancel := api.WithQueryTimeout(r.Context())
+	defer cancel()
+
+	user := models.User{}
+	if err := pv.UDB.FindOne(ctx, bson.M{"user.email": email}).Decode(&user); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+		return
+	}
+
+	uID, err := primitive.ObjectIDFromHex(user.ID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+		return
+	}
+
+	pending, err := pv.PVDB.FindOne(ctx, bson.M{"userID": uID, "purpose": models.PurposePasswordReset})
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			writeJSONError(w, http.StatusBadRequest, "Invalid or expired verification code")
+			return
+		}
+		config.ErrorStatus("failed to find pending reset", http.StatusInternalServerError, w, err)
+		return
+	}
+
+	if expired := timeFromBSON(pending.ExpiresAt); !expired.IsZero() && time.Now().After(expired) {
+		_ = pv.PVDB.DeleteOne(ctx, bson.M{"_id": pending.ID})
+		writeJSONError(w, http.StatusBadRequest, "Verification code expired. Request a new one.")
+		return
+	}
+
+	if pending.Attempts >= sensitiveMaxRetries {
+		_ = pv.PVDB.DeleteOne(ctx, bson.M{"_id": pending.ID})
+		writeJSONError(w, http.StatusBadRequest, "Too many attempts. Request a new code.")
+		return
+	}
+
+	if !codesEqualConstantTime(pending.Code, body.Code) {
+		_ = pv.PVDB.UpdateOne(ctx, bson.M{"_id": pending.ID}, bson.M{"$inc": bson.M{"attempts": 1}})
+		writeJSONError(w, http.StatusBadRequest, "Invalid verification code")
+		return
+	}
+
+	// Valid — leave the row in place for ForgotPasswordResetHandler to consume.
+	writeJSONOK(w, "Code verified")
+}
+
 func writeJSONError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/api/handlers/accountchange_test.go
+++ b/api/handlers/accountchange_test.go
@@ -346,6 +346,58 @@ func TestConfirmPasswordChange_HappyPath_HashesAndUpdates(t *testing.T) {
 	mockPVDB.AssertCalled(t, "DeleteOne", mock.Anything, bson.M{"_id": rowID})
 }
 
+// TestForgotPasswordVerifyCode_ValidCode_Returns200_NoConsume: a correct code verifies but is NOT
+// consumed (no DeleteOne, no password UpdateOne) — the reset step consumes it later.
+func TestForgotPasswordVerifyCode_ValidCode_Returns200_NoConsume(t *testing.T) {
+	uID := primitive.NewObjectID()
+	rowID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	future := primitive.NewDateTimeFromTime(time.Now().Add(10 * time.Minute))
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return(&models.PendingVerification{
+			ID: rowID, UserID: uID, Purpose: models.PurposePasswordReset,
+			Code: "123456", Email: "user@example.com", Attempts: 0, ExpiresAt: future,
+		}, nil)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordVerifyCodeHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockPVDB.AssertNotCalled(t, "DeleteOne", mock.Anything, mock.Anything)
+	mockUDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestForgotPasswordVerifyCode_WrongCode_IncrementsAttempts(t *testing.T) {
+	uID := primitive.NewObjectID()
+	rowID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	future := primitive.NewDateTimeFromTime(time.Now().Add(10 * time.Minute))
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return(&models.PendingVerification{
+			ID: rowID, UserID: uID, Purpose: models.PurposePasswordReset,
+			Code: "999999", Email: "user@example.com", Attempts: 0, ExpiresAt: future,
+		}, nil)
+	mockPVDB.On("UpdateOne", mock.Anything, bson.M{"_id": rowID}, bson.M{"$inc": bson.M{"attempts": 1}}).Return(nil)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordVerifyCodeHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockPVDB.AssertCalled(t, "UpdateOne", mock.Anything, bson.M{"_id": rowID}, bson.M{"$inc": bson.M{"attempts": 1}})
+}
+
 // -----------------------------------------------------------------------------
 // ForgotPassword (unauthenticated reset) handlers
 // -----------------------------------------------------------------------------

--- a/api/handlers/accountchange_test.go
+++ b/api/handlers/accountchange_test.go
@@ -345,3 +345,158 @@ func TestConfirmPasswordChange_HappyPath_HashesAndUpdates(t *testing.T) {
 	mockUDB.AssertCalled(t, "UpdateOne", mock.Anything, bson.M{"_id": uID}, mock.Anything)
 	mockPVDB.AssertCalled(t, "DeleteOne", mock.Anything, bson.M{"_id": rowID})
 }
+
+// -----------------------------------------------------------------------------
+// ForgotPassword (unauthenticated reset) handlers
+// -----------------------------------------------------------------------------
+
+// stubUserFindByEmail wires UDB.FindOne({"user.email": email}) → user document (or a decode error).
+func stubUserFindByEmail(mockUserDB *mocks.UserDatabase, email string, user *models.User, decodeErr error) {
+	mr := &mocks.SingleResultHelper{}
+	if decodeErr != nil {
+		mr.On("Decode", mock.Anything).Return(decodeErr)
+	} else {
+		mr.On("Decode", mock.Anything).Run(func(args mock.Arguments) {
+			ptr := args.Get(0).(*models.User)
+			*ptr = *user
+		}).Return(nil)
+	}
+	mockUserDB.On("FindOne", mock.Anything, bson.M{"user.email": email}).Return(mr)
+}
+
+func TestForgotPasswordRequestCode_InvalidEmail_Returns400(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"not-an-email"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordRequestCodeHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockUDB.AssertNotCalled(t, "FindOne", mock.Anything, mock.Anything)
+}
+
+// An unknown email must still return 200 (generic) and never store a code — no enumeration.
+func TestForgotPasswordRequestCode_UnknownEmail_Returns200_NoStore(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	stubUserFindByEmail(mockUDB, "ghost@example.com", nil, mongo.ErrNoDocuments)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"ghost@example.com"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordRequestCodeHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockPVDB.AssertNotCalled(t, "InsertOne", mock.Anything, mock.Anything)
+	mockPVDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestForgotPasswordRequestCode_HappyPath_StoresCodeAndReturns200(t *testing.T) {
+	uID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	// Rate-limit FindOne and upsert FindOne (same filter) both find no prior row.
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return((*models.PendingVerification)(nil), mongo.ErrNoDocuments)
+	mockPVDB.On("InsertOne", mock.Anything, mock.AnythingOfType("models.PendingVerification")).
+		Return(&mocks.InsertOneResultHelper{}, nil)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordRequestCodeHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockPVDB.AssertCalled(t, "InsertOne", mock.Anything, mock.AnythingOfType("models.PendingVerification"))
+}
+
+func TestForgotPasswordReset_ShortPassword_Returns400(t *testing.T) {
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456","newPassword":"short"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordResetHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockUDB.AssertNotCalled(t, "FindOne", mock.Anything, mock.Anything)
+}
+
+func TestForgotPasswordReset_NoPendingRow_Returns400(t *testing.T) {
+	uID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return((*models.PendingVerification)(nil), mongo.ErrNoDocuments)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456","newPassword":"a-good-password"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordResetHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockUDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestForgotPasswordReset_WrongCode_IncrementsAttempts(t *testing.T) {
+	uID := primitive.NewObjectID()
+	rowID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	future := primitive.NewDateTimeFromTime(time.Now().Add(10 * time.Minute))
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return(&models.PendingVerification{
+			ID: rowID, UserID: uID, Purpose: models.PurposePasswordReset,
+			Code: "999999", Email: "user@example.com", Attempts: 0, ExpiresAt: future,
+		}, nil)
+	mockPVDB.On("UpdateOne", mock.Anything, bson.M{"_id": rowID}, bson.M{"$inc": bson.M{"attempts": 1}}).Return(nil)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456","newPassword":"a-good-password"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordResetHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	mockUDB.AssertNotCalled(t, "UpdateOne", mock.Anything, mock.Anything, mock.Anything)
+	mockPVDB.AssertCalled(t, "UpdateOne", mock.Anything, bson.M{"_id": rowID}, bson.M{"$inc": bson.M{"attempts": 1}})
+}
+
+func TestForgotPasswordReset_HappyPath_UpdatesPassword(t *testing.T) {
+	uID := primitive.NewObjectID()
+	rowID := primitive.NewObjectID()
+	mockUDB := &mocks.UserDatabase{}
+	mockPVDB := &mocks.PendingVerificationDatabase{}
+	future := primitive.NewDateTimeFromTime(time.Now().Add(10 * time.Minute))
+	stubUserFindByEmail(mockUDB, "user@example.com", &models.User{
+		ID: uID.Hex(), Details: models.UserDetails{Email: "user@example.com"},
+	}, nil)
+	mockPVDB.On("FindOne", mock.Anything, bson.M{"userID": uID, "purpose": models.PurposePasswordReset}).
+		Return(&models.PendingVerification{
+			ID: rowID, UserID: uID, Purpose: models.PurposePasswordReset,
+			Code: "123456", Email: "user@example.com", Attempts: 0, ExpiresAt: future,
+		}, nil)
+	mockUDB.On("UpdateOne", mock.Anything, bson.M{"_id": uID}, mock.Anything).
+		Return(&mongo.UpdateResult{MatchedCount: 1, ModifiedCount: 1}, nil)
+	mockPVDB.On("DeleteOne", mock.Anything, bson.M{"_id": rowID}).Return(nil)
+
+	pv := handlers.PendingVerification{PVDB: mockPVDB, UDB: mockUDB}
+	rr := httptest.NewRecorder()
+	req := newJSONRequest(t, "POST", `{"email":"user@example.com","code":"123456","newPassword":"a-good-password"}`, nil)
+	http.HandlerFunc(pv.ForgotPasswordResetHandler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	mockUDB.AssertCalled(t, "UpdateOne", mock.Anything, bson.M{"_id": uID}, mock.Anything)
+	mockPVDB.AssertCalled(t, "DeleteOne", mock.Anything, bson.M{"_id": rowID})
+}

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -309,6 +309,10 @@ func (a *App) New() *mux.Router {
 	apiCreate.Handle("/verify/verify-code", http.HandlerFunc(pv.VerifyCodeHandler)).Methods("POST")
 	apiCreate.Handle("/verify/resend-verification-code", http.HandlerFunc(pv.ResendVerificationCodeHandler)).Methods("POST")
 
+	// Unauthenticated forgot-password (6-digit code) flow.
+	apiCreate.Handle("/user/forgot-password/request-code", http.HandlerFunc(pv.ForgotPasswordRequestCodeHandler)).Methods("POST")
+	apiCreate.Handle("/user/forgot-password/reset", http.HandlerFunc(pv.ForgotPasswordResetHandler)).Methods("POST")
+
 	apiCreate.Handle("/community", api.Middleware(http.HandlerFunc(c.CreateCommunityHandler))).Methods("POST")
 	apiCreate.Handle("/community/subscribe", api.Middleware(http.HandlerFunc(c.SubscribeCommunityHandler))).Methods("POST")
 	apiCreate.Handle("/community/cancel-subscription", api.Middleware(http.HandlerFunc(c.CancelCommunitySubscriptionHandler))).Methods("POST")

--- a/api/handlers/api.go
+++ b/api/handlers/api.go
@@ -311,6 +311,7 @@ func (a *App) New() *mux.Router {
 
 	// Unauthenticated forgot-password (6-digit code) flow.
 	apiCreate.Handle("/user/forgot-password/request-code", http.HandlerFunc(pv.ForgotPasswordRequestCodeHandler)).Methods("POST")
+	apiCreate.Handle("/user/forgot-password/verify-code", http.HandlerFunc(pv.ForgotPasswordVerifyCodeHandler)).Methods("POST")
 	apiCreate.Handle("/user/forgot-password/reset", http.HandlerFunc(pv.ForgotPasswordResetHandler)).Methods("POST")
 
 	apiCreate.Handle("/community", api.Middleware(http.HandlerFunc(c.CreateCommunityHandler))).Methods("POST")

--- a/api/write_auth.go
+++ b/api/write_auth.go
@@ -33,6 +33,7 @@ var publicWritePaths = map[string]bool{
 	"/api/v1/verify/verify-code":                true,
 	"/api/v1/verify/resend-verification-code":   true,
 	"/api/v1/user/forgot-password/request-code": true, // forgot password: request 6-digit code
+	"/api/v1/user/forgot-password/verify-code":  true, // forgot password: check code before advancing
 	"/api/v1/user/forgot-password/reset":        true, // forgot password: submit code + new password
 }
 

--- a/api/write_auth.go
+++ b/api/write_auth.go
@@ -25,13 +25,15 @@ const (
 // present either a valid bearer token (browser + mobile) or the first-party
 // gateway secret (website backend, server-to-server).
 var publicWritePaths = map[string]bool{
-	"/api/v1/auth/token":                      true, // login (HTTP basic auth)
-	"/api/v1/auth/logout":                     true, // revoke (carries its own token)
-	"/api/v1/user/create-user":                true, // signup
-	"/api/v1/user/check-user":                 true, // email-exists check during signup
-	"/api/v1/verify/send-verification-code":   true,
-	"/api/v1/verify/verify-code":              true,
-	"/api/v1/verify/resend-verification-code": true,
+	"/api/v1/auth/token":                        true, // login (HTTP basic auth)
+	"/api/v1/auth/logout":                       true, // revoke (carries its own token)
+	"/api/v1/user/create-user":                  true, // signup
+	"/api/v1/user/check-user":                   true, // email-exists check during signup
+	"/api/v1/verify/send-verification-code":     true,
+	"/api/v1/verify/verify-code":                true,
+	"/api/v1/verify/resend-verification-code":   true,
+	"/api/v1/user/forgot-password/request-code": true, // forgot password: request 6-digit code
+	"/api/v1/user/forgot-password/reset":        true, // forgot password: submit code + new password
 }
 
 // writeAllowedOrigins are our own web origins. Browser-initiated writes from the

--- a/models/pendingVerification.go
+++ b/models/pendingVerification.go
@@ -8,6 +8,7 @@ const (
 	PurposeSignup         = "signup"
 	PurposeEmailChange    = "email_change"
 	PurposePasswordChange = "password_change"
+	PurposePasswordReset  = "password_reset"
 )
 
 // PendingVerification holds the structure for the pending verification collection in MongoDB


### PR DESCRIPTION
## What

Adds two **pre-auth** endpoints so the mobile app (and later the website) can do an in-app password reset with a **6-digit code**, instead of only the token/email-link website flow.

- `POST /api/v1/user/forgot-password/request-code` `{ email }` — emails a 6-digit code (`purpose=password_reset`). Always returns a generic `200` (even for unknown emails or when rate-limited) to avoid **account enumeration**.
- `POST /api/v1/user/forgot-password/reset` `{ email, code, newPassword }` — verifies the code (expiry / attempts / constant-time compare) and sets the new password. Generic errors so they don't reveal whether an account exists.

## How

Reuses the existing sensitive-code infrastructure (`upsertSensitiveCode`, rate-limit, SendGrid send, bcrypt) — the same machinery behind the authenticated change-password flow — just keyed by **email → ObjectID** instead of `userId + currentPassword`. Adds `PurposePasswordReset` and registers both paths in the `write_auth.go` public allowlist (they're unauthenticated by design).

## Tests

7 new handler tests (`accountchange_test.go`): invalid email → 400, unknown email → generic 200 with no code stored, happy-path request stores a code, short password → 400, no pending row → 400, wrong code increments attempts, happy-path reset updates the password + clears the row. Full `api/handlers` package passes.

## Notes

- Rare legacy users with a non-ObjectID `_id` fall through to a generic response and can still use the website token reset.
- Pairs with the police-cad-app 1.29.0 forgot-password screen (separate repo). Per the shared-host caveat, **the mobile flow only works once this is deployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)