### PR TITLE
fix(economy): clock-in 403 for approved members without a 10-code

### DIFF
--- a/api/handlers/economy.go
+++ b/api/handlers/economy.go
@@ -313,10 +313,13 @@ func (e Economy) ClockInHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rankID, found := findUserMembership(dept, userID)
-	// Public departments (approvalRequired=false) treat any community member
-	// as implicitly eligible — no explicit join required.
+	// Public departments (approvalRequired=false) treat any approved community
+	// member as implicitly eligible — no explicit join required. Use the
+	// authoritative membership source (community owner + user.Communities
+	// status=approved); the community.Members map is only populated after a
+	// user sets a 10-code, so relying on it 403s legitimate members.
 	if !found && !dept.ApprovalRequired {
-		if _, inCommunity := community.Details.Members[userID]; inCommunity {
+		if e.isApprovedCommunityMember(ctx, userID, req.CommunityID, community) {
 			found = true
 		}
 	}


### PR DESCRIPTION
## Problem

Website users are getting a **403 error when clocking in**. The client (`police-cad/public/js/dd-economy.js`) posts to `POST /api/v2/economy/clock-in` and surfaces any non-2xx (other than 409) as "Could not clock in".

## Root cause

In `ClockInHandler` (`api/handlers/economy.go`), public departments (`approvalRequired=false`) determined eligibility by looking the user up in `community.Details.Members[userID]`:

```go
if !found && !dept.ApprovalRequired {
    if _, inCommunity := community.Details.Members[userID]; inCommunity {
        found = true
    }
}
```

That map is **only populated after a user sets a 10-code** — it is not an authoritative membership source. A legitimately-approved member (or even the community owner) who never set a 10-code is absent from the map and gets `403 user is not a member of this department`. Introduced in `52602c5`.

## Fix

Swap the map lookup for the existing `isApprovedCommunityMember` helper already on the `Economy` struct — it checks `community.OwnerID` plus the user's `Communities[].Status == "approved"`, the same authoritative pattern the P2P transfer handler uses. No struct/constructor changes needed (`e.UDB` already wired).

- Public departments: now correctly admit any approved community member / owner.
- Private departments (`approvalRequired=true`): **unchanged** — still require an explicit `dept.Members` entry.

## Verification

- `go build ./...` passes.
- Behavior diff: an approved member without a 10-code previously 403'd on a public department; now clocks in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)